### PR TITLE
RQL Filter mess cleanup (GRV-1299)

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -81,6 +81,36 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * test if we can get list of apps, paged and with filters..
+     *
+     * @return void
+     */
+    public function testGetAppWithFilteringAndPaging()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app?perPage=1&q='.urlencode('eq(showInMenu,true)'));
+        $response = $client->getResponse();
+
+        $this->assertEquals(1, count($client->getResults()));
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29>; rel="self"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29&page=2&perPage=1>; rel="next"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29&page=2&perPage=1>; rel="last"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+    }
+
+    /**
      * check for empty collections when no fixtures are loaded
      *
      * @return void

--- a/src/Graviton/EntityBundle/Tests/Controller/CountryControllerTest.php
+++ b/src/Graviton/EntityBundle/Tests/Controller/CountryControllerTest.php
@@ -62,15 +62,15 @@ class CountryControllerTest extends RestTestCase
         $this->assertResponseContentType(self::COL_TYPE, $response);
 
         $this->assertContains(
-            '<http://localhost/entity/country?page='. $pageNumber .'&per_page=10>; rel="self"',
+            '<http://localhost/entity/country?page='. $pageNumber .'&perPage=10>; rel="self"',
             $linkHeader
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page='. ($pageNumber - 1) .'&per_page=10>; rel="prev"',
+            '<http://localhost/entity/country?page='. ($pageNumber - 1) .'&perPage=10>; rel="prev"',
             $linkHeader
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page='. ($pageNumber + 1) .'&per_page=10>; rel="next"',
+            '<http://localhost/entity/country?page='. ($pageNumber + 1) .'&perPage=10>; rel="next"',
             $linkHeader
         );
     }
@@ -105,15 +105,15 @@ class CountryControllerTest extends RestTestCase
         $this->assertResponseContentType(self::COL_TYPE, $response);
 
         $this->assertContains(
-            '<http://localhost/entity/country?page=26&per_page=10>; rel="last"',
+            '<http://localhost/entity/country?page=26&perPage=10>; rel="last"',
             $linkHeader
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=1&per_page=10>; rel="self"',
+            '<http://localhost/entity/country?page=1&perPage=10>; rel="self"',
             $linkHeader
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=2&per_page=10>; rel="next"',
+            '<http://localhost/entity/country?page=2&perPage=10>; rel="next"',
             $linkHeader
         );
     }
@@ -133,11 +133,11 @@ class CountryControllerTest extends RestTestCase
         $this->assertResponseContentType(self::COL_TYPE, $response);
 
         $this->assertContains(
-            '<http://localhost/entity/country?page=26&per_page=10>; rel="self"',
+            '<http://localhost/entity/country?page=26&perPage=10>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=1&per_page=10>; rel="first"',
+            '<http://localhost/entity/country?page=1&perPage=10>; rel="first"',
             explode(',', $response->headers->get('Link'))
         );
     }
@@ -158,28 +158,28 @@ class CountryControllerTest extends RestTestCase
         $this->assertResponseContentType(self::COL_TYPE, $response);
 
         $this->assertContains(
-            '<http://localhost/entity/country?page=1&per_page=10>; rel="self"',
+            '<http://localhost/entity/country?page=1&perPage=10>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=2&per_page=10>; rel="next"',
+            '<http://localhost/entity/country?page=2&perPage=10>; rel="next"',
             explode(',', $response->headers->get('Link'))
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=26&per_page=10>; rel="last"',
+            '<http://localhost/entity/country?page=26&perPage=10>; rel="last"',
             explode(',', $response->headers->get('Link'))
         );
     }
 
     /**
-     * check if per_page param works on collections
+     * check if perPage param works on collections
      *
      * @return void
      */
     public function testFindAllWithPerPageParam()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/entity/country?per_page=20');
+        $client->request('GET', '/entity/country?perPage=20');
 
         $response = $client->getResponse();
 
@@ -188,15 +188,36 @@ class CountryControllerTest extends RestTestCase
         $this->assertEquals(20, count($client->getResults()));
 
         $this->assertContains(
-            '<http://localhost/entity/country?page=1&per_page=20>; rel="self"',
+            '<http://localhost/entity/country?page=1&perPage=20>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=2&per_page=20>; rel="next"',
+            '<http://localhost/entity/country?page=2&perPage=20>; rel="next"',
             explode(',', $response->headers->get('Link'))
         );
         $this->assertContains(
-            '<http://localhost/entity/country?page=13&per_page=20>; rel="last"',
+            '<http://localhost/entity/country?page=13&perPage=20>; rel="last"',
+            explode(',', $response->headers->get('Link'))
+        );
+    }
+
+    /**
+     * check if data gets filtered and self header includes the filter
+     *
+     * @return void
+     */
+    public function testFindAllWithFiltering()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/entity/country?q='.urlencode('eq(capitalCity,Luanda)'));
+
+        $response = $client->getResponse();
+
+        $this->assertEquals(1, count($client->getResults()));
+        $this->assertResponseContentType(self::COL_TYPE, $response);
+
+        $this->assertContains(
+            '<http://localhost/entity/country?q=eq%28capitalCity%2CLuanda%29>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
     }

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -107,16 +107,15 @@ class SelfLinkResponseListener implements ContainerAwareInterface
             $parameters = array('id' => $request->get('id'));
         } elseif ($routeType != 'all') {
             $parameters = array('id' => $request->get('id'));
-        } elseif ($routeType == 'all') {
-            if ($request->attributes->get('paging')) {
-                $parameters = array('page' => $request->get('page', 1));
-                if ($request->attributes->get('perPage')) {
-                    $parameters['perPage'] = $request->attributes->get('perPage');
-                }
+        } elseif ($routeType == 'all' && $request->attributes->get('paging')) {
+            $parameters = array('page' => $request->get('page', 1));
+            if ($request->attributes->get('perPage')) {
+                $parameters['perPage'] = $request->attributes->get('perPage');
             }
-            if ($request->attributes->get('filtering')) {
-                $parameters = array('q' => $request->get('q', ''));
-            }
+        }
+
+        if ($routeType == 'all' && $request->attributes->get('filtering')) {
+            $parameters = array('q' => $request->get('q', ''));
         }
 
         return $parameters;

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -95,6 +95,8 @@ class SelfLinkResponseListener implements ContainerAwareInterface
      * @param Request $request   request object
      *
      * @return array
+     *
+     * @todo we need to refactor this as soon as we add another param, it already mixes paging and filtering too much
      */
     private function generateParameters($routeType, Request $request)
     {

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -101,15 +101,21 @@ class SelfLinkResponseListener implements ContainerAwareInterface
         // for now we assume that everything except collections has an id
         // this is also flawed since it does not handle search actions
         $parameters = array();
+
         if ($routeType == 'post') {
             // handle post request by rewriting self link to newly created resource
             $parameters = array('id' => $request->get('id'));
         } elseif ($routeType != 'all') {
             $parameters = array('id' => $request->get('id'));
-        } elseif ($request->attributes->get('paging')) {
-            $parameters = array('page' => $request->get('page', 1));
-            if ($request->attributes->get('perPage')) {
-                $parameters['per_page'] = $request->attributes->get('perPage');
+        } elseif ($routeType == 'all') {
+            if ($request->attributes->get('paging')) {
+                $parameters = array('page' => $request->get('page', 1));
+                if ($request->attributes->get('perPage')) {
+                    $parameters['perPage'] = $request->attributes->get('perPage');
+                }
+            }
+            if ($request->attributes->get('filtering')) {
+                $parameters = array('q' => $request->get('q', ''));
             }
         }
 

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -107,7 +107,9 @@ class SelfLinkResponseListener implements ContainerAwareInterface
             $parameters = array('id' => $request->get('id'));
         } elseif ($routeType != 'all') {
             $parameters = array('id' => $request->get('id'));
-        } elseif ($routeType == 'all' && $request->attributes->get('paging')) {
+        }
+
+        if ($routeType == 'all' && $request->attributes->get('paging')) {
             $parameters = array('page' => $request->get('page', 1));
             if ($request->attributes->get('perPage')) {
                 $parameters['perPage'] = $request->attributes->get('perPage');

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -75,10 +75,7 @@ class DocumentModel extends SchemaModel implements ModelInterface
     public function findAll(Request $request)
     {
         $pageNumber = $request->query->get('page', 1);
-        $numberPerPage = (int) $request->query->get(
-            'perPage',
-            $request->query->get('per_page', 10)
-        );
+        $numberPerPage = (int) $request->query->get('perPage', 10);
         $startAt = ($pageNumber - 1) * $numberPerPage;
 
         // *** do we have an RQL expression, do we need to filter data?

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -82,16 +82,14 @@ class DocumentModel extends SchemaModel implements ModelInterface
         $startAt = ($pageNumber - 1) * $numberPerPage;
 
         // *** do we have an RQL expression, do we need to filter data?
-        if (count($request->query->all()) > 0) {
+        if ($request->query->get('q') != null && strlen($request->query->get('q')) > 0) {
 
-            // prefer explicit filter param!
-            if ($request->query->get('q') != null && strlen($request->query->get('q')) > 0) {
-                $queryFilter = $request->query->get('q');
-            } else {
-                $queryFilter = $request->getQueryString();
-            }
+            $filter = $request->query->get('q');
 
-            $queryParser = new Query(urldecode($queryFilter));
+            // set filtering attributes on request
+            $request->attributes->set('filtering', true);
+
+            $queryParser = new Query(urldecode($filter));
             $queriable = new MongoOdm($this->repository, $numberPerPage, $startAt);
             $queriable = $queryParser->applyToQueriable($queriable);
             $records = $queriable->getDocuments();

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -79,9 +79,8 @@ class DocumentModel extends SchemaModel implements ModelInterface
         $startAt = ($pageNumber - 1) * $numberPerPage;
 
         // *** do we have an RQL expression, do we need to filter data?
-        if ($request->query->get('q') != null && strlen($request->query->get('q')) > 0) {
-
-            $filter = $request->query->get('q');
+        $filter = $request->query->get('q');
+        if (!empty($filter)) {
 
             // set filtering attributes on request
             $request->attributes->set('filtering', true);


### PR DESCRIPTION
This includes
* We now only accept RQL expressions per "q" GET param. We don't pass the whole query to the RQL Parser anymore..
* The "q" param gets included in the self and paging link headers (triggered via request attribute)
* Added some tests in the controllers that have usable data fixtures to test the new behavior.
* I also consolidated "per_page"/"perPage" mess. Now, we only use "perPage" everywhere, also corrected the test where this was asserted. I think it's clear that all params we accept should be camelCase when we use it everywhere else.