### PR TITLE
externalize getVersion()

### DIFF
--- a/src/Graviton/CoreBundle/Controller/MainController.php
+++ b/src/Graviton/CoreBundle/Controller/MainController.php
@@ -65,11 +65,7 @@ class MainController implements ContainerAwareInterface
         );
 
         $response->headers->set('Link', (string) $links);
-
-        # @todo don't find the composer file like so, use packagist to find and parse it if possible
-        $composerFile = __DIR__.'/../../../../composer.json';
-        $composer = json_decode(file_get_contents($composerFile), true);
-        $response->headers->set('X-Version', $composer['version']);
+        $response->headers->set('X-Version', $this->container->get('graviton.core.utils')->getVersion());
 
         $mainPage = new \stdClass;
         $mainPage->message = 'Please look at the Link headers of this response for further information.';

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -1,68 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-  <parameters>
-    <parameter key="graviton.core.controller.main.class">Graviton\CoreBundle\Controller\MainController</parameter>
-    <parameter key="graviton.core.controller.app.class">Graviton\CoreBundle\Controller\AppController</parameter>
-    <parameter key="graviton.core.repository.app.class">Graviton\CoreBundle\Repository\AppRepository</parameter>
-    <parameter key="graviton.core.model.app.class">Graviton\CoreBundle\Model\App</parameter>
-    <parameter key="graviton.core.document.app.class">Graviton\CoreBundle\Document\App</parameter>
-    <parameter key="graviton.core.controller.product.class">Graviton\CoreBundle\Controller\ProductController</parameter>
-    <parameter key="graviton.core.repository.product.class">Graviton\CoreBundle\Repository\ProductRepository</parameter>
-    <parameter key="graviton.core.model.product.class">Graviton\CoreBundle\Model\Product</parameter>
-    <parameter key="graviton.core.document.product.class">Graviton\CoreBundle\Document\Product</parameter>
-  </parameters>
-  <services>
-    <service id="graviton.core.controller.main"
-             class="%graviton.core.controller.main.class%">
-      <call method="setContainer">
-        <argument type="service" id="service_container"/>
-      </call>
-    </service>
-    <service id="graviton.core.controller.app"
-             class="%graviton.core.controller.app.class%"
-             parent="graviton.rest.controller" scope="request">
-      <call method="setModel">
-        <argument type="service" id="graviton.core.model.app"/>
-      </call>
-      <tag name="graviton.rest"/>
-    </service>
-    <service id="graviton.core.repository.app"
-             class="%graviton.core.repository.app.class%"
-             factory-service="doctrine_mongodb.odm.default_document_manager"
-             factory-method="getRepository">
-      <argument type="string">GravitonCoreBundle:App</argument>
-    </service>
-    <service id="graviton.core.model.app"
-             class="%graviton.core.model.app.class%"
-             parent="graviton.rest.model">
-      <call method="setRepository">
-        <argument type="service" id="graviton.core.repository.app"/>
-      </call>
-    </service>
-    <service id="graviton.core.document.app" class="%graviton.core.document.app.class%"/>
-    <service id="graviton.core.controller.product"
-             class="%graviton.core.controller.product.class%"
-             parent="graviton.rest.controller" scope="request">
-      <call method="setModel">
-        <argument type="service" id="graviton.core.model.product"/>
-      </call>
-      <tag name="graviton.rest" read-only="true"/>
-    </service>
-    <service id="graviton.core.repository.product"
-             class="%graviton.core.repository.product.class%"
-             factory-service="doctrine_mongodb.odm.default_document_manager"
-             factory-method="getRepository">
-      <argument type="string">GravitonCoreBundle:Product</argument>
-    </service>
-    <service id="graviton.core.model.product"
-             class="%graviton.core.model.product.class%"
-             parent="graviton.rest.model">
-      <call method="setRepository">
-        <argument type="service" id="graviton.core.repository.product"/>
-      </call>
-    </service>
-    <service id="graviton.core.document.product" class="%graviton.core.document.product.class%"/>
-  </services>
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="graviton.core.controller.main.class">Graviton\CoreBundle\Controller\MainController</parameter>
+        <parameter key="graviton.core.controller.app.class">Graviton\CoreBundle\Controller\AppController</parameter>
+        <parameter key="graviton.core.repository.app.class">Graviton\CoreBundle\Repository\AppRepository</parameter>
+        <parameter key="graviton.core.model.app.class">Graviton\CoreBundle\Model\App</parameter>
+        <parameter key="graviton.core.document.app.class">Graviton\CoreBundle\Document\App</parameter>
+        <parameter key="graviton.core.controller.product.class">Graviton\CoreBundle\Controller\ProductController</parameter>
+        <parameter key="graviton.core.repository.product.class">Graviton\CoreBundle\Repository\ProductRepository</parameter>
+        <parameter key="graviton.core.model.product.class">Graviton\CoreBundle\Model\Product</parameter>
+        <parameter key="graviton.core.document.product.class">Graviton\CoreBundle\Document\Product</parameter>
+        <parameter key="graviton.core.service.coreutils.class">Graviton\CoreBundle\Service\CoreUtils</parameter>
+    </parameters>
+    <services>
+        <service id="graviton.core.controller.main"
+                 class="%graviton.core.controller.main.class%">
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="graviton.core.controller.app"
+                 class="%graviton.core.controller.app.class%"
+                 parent="graviton.rest.controller" scope="request">
+            <call method="setModel">
+                <argument type="service" id="graviton.core.model.app"/>
+            </call>
+            <tag name="graviton.rest"/>
+        </service>
+        <service id="graviton.core.repository.app"
+                 class="%graviton.core.repository.app.class%"
+                 factory-service="doctrine_mongodb.odm.default_document_manager"
+                 factory-method="getRepository">
+            <argument type="string">GravitonCoreBundle:App</argument>
+        </service>
+        <service id="graviton.core.model.app"
+                 class="%graviton.core.model.app.class%"
+                 parent="graviton.rest.model">
+            <call method="setRepository">
+                <argument type="service" id="graviton.core.repository.app"/>
+            </call>
+        </service>
+        <service id="graviton.core.document.app" class="%graviton.core.document.app.class%"/>
+        <service id="graviton.core.controller.product"
+                 class="%graviton.core.controller.product.class%"
+                 parent="graviton.rest.controller" scope="request">
+            <call method="setModel">
+                <argument type="service" id="graviton.core.model.product"/>
+            </call>
+            <tag name="graviton.rest" read-only="true"/>
+        </service>
+        <service id="graviton.core.repository.product"
+                 class="%graviton.core.repository.product.class%"
+                 factory-service="doctrine_mongodb.odm.default_document_manager"
+                 factory-method="getRepository">
+            <argument type="string">GravitonCoreBundle:Product</argument>
+        </service>
+        <service id="graviton.core.model.product"
+                 class="%graviton.core.model.product.class%"
+                 parent="graviton.rest.model">
+            <call method="setRepository">
+                <argument type="service" id="graviton.core.repository.product"/>
+            </call>
+        </service>
+        <service id="graviton.core.document.product" class="%graviton.core.document.product.class%"/>
+        <service id="graviton.core.utils" class="%graviton.core.service.coreutils.class%">
+            <call method="setContainer">
+                <argument type="service" id="service_container"></argument>
+            </call>
+        </service>
+    </services>
 </container>

--- a/src/Graviton/CoreBundle/Service/CoreUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreUtils.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Graviton\CoreBundle\Service;
+
+/**
+ * A service providing some core util functions.
+ *
+ * @category GravitonCoreBundle
+ * @package  Graviton
+ * @author   Dario Nuevo <dario.nuevo@swisscom.com>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.com
+ */
+class CoreUtils
+{
+
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface service_container
+     */
+    private $container;
+
+    /**
+     * sets the container
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container service_container
+     *
+     * @return void
+     */
+    public function setContainer($container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Gets the current version we're running on..
+     *
+     * @return string version
+     */
+    public function getVersion()
+    {
+        /**
+         * @todo don't find the composer file like so, use packagist to find and parse it if possible
+         * @todo if we're in a wrapper context, use the version of the wrapper, not graviton
+         */
+        $composerFile = __DIR__.'/../../../../composer.json';
+        $composer = json_decode(file_get_contents($composerFile), true);
+        return $composer['version'];
+    }
+}


### PR DESCRIPTION
We had a version determination in the MainController. this is clearly the wrong place..

So this contains
* A new CoreUtils service containing a getVersion() method - yes, using the same code as before
* Let MainController use that service

This is preparation so swagger and others can display the same version to the user..