### PR TITLE
fix CORS headers on OPTIONS request with id

### DIFF
--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -21,7 +21,7 @@ class TranslatableControllerTest extends RestTestCase
      */
     const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/i18n/translatable/';
 
-   /**
+    /**
      * check for language schema
      *
      * @return void
@@ -34,7 +34,6 @@ class TranslatableControllerTest extends RestTestCase
 
         $results = $client->getResults();
         $response = $client->getResponse();
-        var_dump($results);
 
         $this->assertEquals('A Translatable string available for i18n purposes.', $results->items->description);
         $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -17,25 +17,15 @@ use Graviton\TestBundle\Test\RestTestCase;
 class TranslatableControllerTest extends RestTestCase
 {
     /**
-     * @const complete content type string expected on a resouce
-     */
-    const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/i18n/translatable/';
-
-    /**
      * check for language schema
      *
      * @return void
      */
-    public function testSchema()
+    public function testOptionsHasCors()
     {
         $client = static::createRestClient();
 
-        $client->request('OPTIONS', '/i18n/translatable', array(), array(), array('HTTP_ACCEPT_LANGUAGE' => 'en,de'));
-
-        $results = $client->getResults();
-        $response = $client->getResponse();
-
-        $this->assertEquals('A Translatable string available for i18n purposes.', $results->items->description);
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
+        $client->request('OPTIONS', '/i18n/translatable');
+        $this->assertEquals('*', $client->getResponse()->headers->get('Access-Control-Allow-Origin'));
     }
 }

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Basic functional test for /i18n/language.
+ */
+
+namespace Graviton\I18nBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+
+/**
+ * Basic functional test for /i18n/translatable
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class TranslatableControllerTest extends RestTestCase
+{
+    /**
+     * @const complete content type string expected on a resouce
+     */
+    const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/i18n/translatable/';
+
+   /**
+     * check for language schema
+     *
+     * @return void
+     */
+    public function testSchema()
+    {
+        $client = static::createRestClient();
+
+        $client->request('OPTIONS', '/i18n/translatable', array(), array(), array('HTTP_ACCEPT_LANGUAGE' => 'en,de'));
+
+        $results = $client->getResults();
+        $response = $client->getResponse();
+        var_dump($results);
+
+        $this->assertEquals('A Translatable string available for i18n purposes.', $results->items->description);
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
+    }
+}

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -17,7 +17,7 @@ use Graviton\TestBundle\Test\RestTestCase;
 class TranslatableControllerTest extends RestTestCase
 {
     /**
-     * check for language schema
+     * check that translatable record return correct CORS headers
      *
      * @return void
      */
@@ -25,7 +25,7 @@ class TranslatableControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
 
-        $client->request('OPTIONS', '/i18n/translatable');
-        $this->assertEquals('*', $client->getResponse()->headers->get('Access-Control-Allow-Origin'));
+        $client->request('OPTIONS', '/i18n/translatable/i18n-de-German');
+        $this->assertCorsHeaders('GET, POST, PUT, DELETE, OPTIONS', $client->getResponse());
     }
 }

--- a/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
+++ b/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
@@ -159,14 +159,18 @@ class ActionUtils
     /**
      * Get route for OPTIONS requests
      *
-     * @param string $service       service id
-     * @param array  $serviceConfig service configuration
-     * @param array  $parameters    service params
+     * @param string  $service       service id
+     * @param array   $serviceConfig service configuration
+     * @param array   $parameters    service params
+     * @param boolean $useIdPattern  geenrate route with id param
      *
      * @return Route
      */
-    public static function getRouteOptions($service, $serviceConfig, array $parameters = array())
+    public static function getRouteOptions($service, $serviceConfig, array $parameters = array(), $useIdPattern = false)
     {
+        if ($useIdPattern) {
+            $parameters['id'] = self::ID_PATTERN;
+        }
         return self::getRoute($service, 'OPTIONS', 'optionsAction', $serviceConfig, $parameters);
     }
 

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -165,7 +165,7 @@ class BasicLoader extends Loader implements ContainerAwareInterface
         $actionOptions = ActionUtils::getCanonicalSchemaRoute($service, $serviceConfig);
         $this->routes->add($resource . '.canonicalIdSchema', $actionOptions);
 
-        $actionOptions = ActionUtils::getRouteOptions($service, $serviceConfig, array('id' => '\w+'));
+        $actionOptions = ActionUtils::getRouteOptions($service, $serviceConfig, array(), true);
         $this->routes->add($resource . '.idOptions', $actionOptions);
     }
 


### PR DESCRIPTION
This is based on a case found by the frontend team. For some reasons GravitonRestBundle was not generating rules for OPTIONS requests with id. This lead to them not getting proper CORS headers in the responses.

I'm testing with a small test that is based on getting OPTIONS from ``/i18n/translatable/i18n-de-German`` since this is the module where the problems where first identified.