### PR TITLE
we still need to check for param existence to not trigger a warning output..

### DIFF
--- a/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
@@ -390,12 +390,14 @@ class GenerateDynamicBundleCommand extends ContainerAwareCommand
         $dbbGenerator = new DynamicBundleBundleGenerator();
 
         // add optional bundles if defined by parameter.
-        $additions = json_decode(
-            $this->getContainer()->getParameter('generator.bundlebundle.additions'),
-            true
-        );
-        if (is_array($additions)) {
-            $dbbGenerator->setAdditions($additions);
+        if ($this->getContainer()->hasParameter('generator.bundlebundle.additions')) {
+            $additions = json_decode(
+                $this->getContainer()->getParameter('generator.bundlebundle.additions'),
+                true
+            );
+            if (is_array($additions)) {
+                $dbbGenerator->setAdditions($additions);
+            }
         }
 
         $dbbGenerator->generate(


### PR DESCRIPTION
hopefully last thing needed there.. currently, a warning output is produced because the param is not really existing.. this should fix that, shouldn't have removed that in the first place..