### PR TITLE
CompilerPass to find services needed for generating routes

### DIFF
--- a/src/Graviton/RestBundle/DependencyInjection/Compiler/RestServicesCompilerPass.php
+++ b/src/Graviton/RestBundle/DependencyInjection/Compiler/RestServicesCompilerPass.php
@@ -8,6 +8,11 @@ namespace Graviton\RestBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
 class RestServicesCompilerPass implements CompilerPassInterface
 {
     /**

--- a/src/Graviton/RestBundle/DependencyInjection/Compiler/RestServicesCompilerPass.php
+++ b/src/Graviton/RestBundle/DependencyInjection/Compiler/RestServicesCompilerPass.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * find all services tagged as 'graviton.rest' and store them in 'graviton.rest.services'
+ */
+
+namespace Graviton\RestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RestServicesCompilerPass implements CompilerPassInterface
+{
+    /**
+     * load services
+     *
+     * @param ContainerBuilder $container container builder
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $container->setParameter(
+            'graviton.rest.services',
+            $container->findTaggedServiceIds('graviton.rest')
+        );
+    }
+}

--- a/src/Graviton/RestBundle/GravitonRestBundle.php
+++ b/src/Graviton/RestBundle/GravitonRestBundle.php
@@ -7,9 +7,11 @@ namespace Graviton\RestBundle;
 
 use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Graviton\BundleBundle\GravitonBundleInterface;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Misd\GuzzleBundle\MisdGuzzleBundle;
+use Graviton\RestBundle\DependencyInjection\Compiler\RestServicesCompilerPass;
 
 /**
  * GravitonRestBundle
@@ -34,5 +36,19 @@ class GravitonRestBundle extends Bundle implements GravitonBundleInterface
             new JMSSerializerBundle(),
             new KnpPaginatorBundle(),
         );
+    }
+
+    /**
+     * load compiler pass rest route loader
+     *
+     * @param ContainerBuilder $container container builder
+     *
+     * @return void
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RestServicesCompilerPass);
     }
 }

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
         <parameter key="graviton.rest.request.class">Symfony\Component\HttpFoundation\Request</parameter>
         <parameter key="graviton.rest.validation.jsoninput.class">Graviton\RestBundle\Validator\JsonInput</parameter>
         <parameter key="graviton.rest.listener.xversionresponselistener.class">Graviton\RestBundle\Listener\XVersionResponseListener</parameter>
+        <parameter key="graviton.rest.services" type="collection"/>
     </parameters>
     <services>
         <!-- Serializer / Serializer context -->
@@ -56,6 +57,7 @@
         <!-- Routing loader -->
         <service id="graviton.rest.routing.loader" class="%graviton.rest.routing.loader.class%">
             <argument type="service" id="graviton.rest.routing.collection"/>
+            <argument>%graviton.rest.services%</argument>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -39,7 +39,6 @@
             </call>
         </service>
 
-
         <service id="graviton.rest.doctrine" alias="doctrine"/>
         <service id="graviton.rest.validator" alias="validator"/>
         <service id="graviton.rest.router" alias="router"/>
@@ -58,9 +57,6 @@
         <service id="graviton.rest.routing.loader" class="%graviton.rest.routing.loader.class%">
             <argument type="service" id="graviton.rest.routing.collection"/>
             <argument>%graviton.rest.services%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
             <tag name="routing.loader"/>
         </service>
 

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -70,8 +70,7 @@ class BasicLoader extends Loader implements ContainerAwareInterface
             throw new \RuntimeException('Do not add the "graviton.rest.routing.loader" loader twice');
         }
 
-        foreach ($this->services AS $service => $serviceConfig)
-        {
+        foreach ($this->services as $service => $serviceConfig) {
             $this->loadService($service, $serviceConfig);
         }
 

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -5,7 +5,6 @@
 
 namespace Graviton\RestBundle\Routing\Loader;
 
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\RouteCollection;
 

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -38,15 +38,22 @@ class BasicLoader extends Loader implements ContainerAwareInterface
     private $routes;
 
     /**
+     * @var array
+     */
+    private $services;
+
+    /**
      * Constructor.
      *
-     * @param \Symfony\Component\Routing\RouteCollection $routes route collection
+     * @param \Symfony\Component\Routing\RouteCollection $routes   route collection
+     * @param array                                      $services configs for all services tagged as graviton.rest
      *
      * @return BasicLoader
      */
-    public function __construct($routes)
+    public function __construct($routes, $services)
     {
         $this->routes = $routes;
+        $this->services = $services;
     }
 
     /**
@@ -63,8 +70,8 @@ class BasicLoader extends Loader implements ContainerAwareInterface
             throw new \RuntimeException('Do not add the "graviton.rest.routing.loader" loader twice');
         }
 
-        $container = $this->getContainerBuilder();
-        foreach ($container->findTaggedServiceIds('graviton.rest') as $service => $serviceConfig) {
+        foreach ($this->services AS $service => $serviceConfig)
+        {
             $this->loadService($service, $serviceConfig);
         }
 

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -24,11 +24,6 @@ class BasicLoader extends Loader
     private $loaded = false;
 
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
-
-    /**
      * @var \Symfony\Component\Routing\RouteCollection
      */
     private $routes;

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -7,10 +7,6 @@ namespace Graviton\RestBundle\Routing\Loader;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\Loader;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -20,7 +16,7 @@ use Symfony\Component\Routing\RouteCollection;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class BasicLoader extends Loader implements ContainerAwareInterface
+class BasicLoader extends Loader
 {
     /**
      * @var boolean
@@ -77,53 +73,6 @@ class BasicLoader extends Loader implements ContainerAwareInterface
         $this->loaded = true;
 
         return $this->routes;
-    }
-
-    /**
-     * Loads the ContainerBuilder from the cache.
-     *
-     * @return ContainerBuilder
-     *
-     * @throws \LogicException
-     */
-    protected function getContainerBuilder()
-    {
-        if (!is_file(
-            $cachedFile = $this->getContainer()
-                               ->getParameter('debug.container.dump')
-        )
-        ) {
-            throw new \LogicException('Debug information about the container could not be found.');
-        }
-
-        $container = new ContainerBuilder();
-
-        $loader = new XmlFileLoader($container, new FileLocator());
-        $loader->load($cachedFile);
-
-        return $container;
-    }
-
-    /**
-     * get the container
-     *
-     * @return ContainerInterface
-     */
-    public function getContainer()
-    {
-        return $this->container;
-    }
-
-    /**
-     * set container
-     *
-     * @param ContainerInterface $container global container
-     *
-     * @return void
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 
     /**

--- a/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RestServicesCompilerPassTest.php
+++ b/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RestServicesCompilerPassTest.php
@@ -1,10 +1,20 @@
 <?php
+/**
+ * validate finding tagged services
+ *
+ * important because our autorouting hinges on it
+ */
 
 namespace Graviton\RestBundle\Tests\DependencyInjection\Compiler;
 
 use Graviton\RestBundle\DependencyInjection\Compiler\RestServicesCompilerPass;
 
-class WebServicesCompilerPassTest extends \PHPUnit_Framework_TestCase
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RestServicesCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * validate that process creates an array parameter

--- a/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/WebServicesCompilerPassTest.php
+++ b/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/WebServicesCompilerPassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Graviton\RestBundle\Tests\DependencyInjection\Compiler;
+
+use Graviton\RestBundle\DependencyInjection\Compiler\RestServicesCompilerPass;
+
+class WebServicesCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * validate that process creates an array parameter
+     *
+     * @dataProvider setsParamsProvider
+     *
+     * @param array $config service config
+     *
+     * @return void
+     */
+    public function testSetsParams($config)
+    {
+        $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with($this->equalTo('graviton.rest'))
+            ->will($this->returnValue($config));
+        $container
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with($this->equalTo('graviton.rest.services', 1), $this->equalTo($config));
+
+        $sut = new RestServicesCompilerPass();
+        $sut->process($container);
+    }
+
+    /**
+     * test cases for testSetsParams
+     *
+     * @return array
+     */
+    public function setsParamsProvider()
+    {
+        return array(
+            array(array()),
+            array(array('graviton.rest.test', array('read-only' => true))),
+        );
+    }
+}


### PR DESCRIPTION
Load routes tagged as ``graviton.rest`` during container compilation phase by using a compiler pass.

We'll still need to identify all the places where we need to clear the cache after this change. One area is certainly after generating bundles. I'm working on adding that to ``graviton:generate:`` on a branch as well.

For the time being we'll have to run ``app/console cache:clear`` after running the generators.

With this SYMFONY_ENVs aren't broken anymore. I was able to run graviton under the prod env.