### PR TITLE
clear cache after generating resource

### DIFF
--- a/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
@@ -10,6 +10,7 @@ use Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineEntityCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * generator command
@@ -20,6 +21,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateResourceCommand extends GenerateDoctrineEntityCommand
 {
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
     /**
      * {@inheritDoc}
      *
@@ -63,6 +69,17 @@ class GenerateResourceCommand extends GenerateDoctrineEntityCommand
             $input,
             $output
         );
+
+        $commandInput = new ArrayInput(array(
+            'command' => 'cache:clear',
+            '--no-warmup' => true
+        ));
+        $command = $this->getApplication()->find('cache:clear');
+        if ($command->run($commandInput, $output) == 0) {
+            $output->isVerbose() && $output->writeln(
+                'cache cleared'
+            );
+        }
 
         $output->writeln(
             'For the time being you need to fix titles and add descriptions in Resource/config/schema manually'

--- a/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
@@ -70,12 +70,12 @@ class GenerateResourceCommand extends GenerateDoctrineEntityCommand
             $output
         );
 
-        $commandInput = new ArrayInput(array(
+        $arguments = array(
             'command' => 'cache:clear',
             '--no-warmup' => true
-        ));
+        );
         $command = $this->getApplication()->find('cache:clear');
-        if ($command->run($commandInput, $output) == 0) {
+        if ($command->run(new ArrayInput($arguments), $output) == 0) {
             $output->isVerbose() && $output->writeln(
                 'cache cleared'
             );

--- a/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
@@ -76,9 +76,7 @@ class GenerateResourceCommand extends GenerateDoctrineEntityCommand
         );
         $command = $this->getApplication()->find('cache:clear');
         if ($command->run(new ArrayInput($arguments), $output) == 0) {
-            $output->isVerbose() && $output->writeln(
-                'cache cleared'
-            );
+            $output->isVerbose() && $output->writeln('cache cleared');
         }
 
         $output->writeln(


### PR DESCRIPTION
This might help with cache problems introduced by libgraviton/graviton#45.

We still need to find out of those really are an issue and if this is best put here. I'm also not sure if I should make this an option or not.

Feedback welcome ;)