### PR TITLE
throw at least some errors in graviton:generate:dynamicbundles

### DIFF
--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
@@ -60,6 +60,10 @@ class JsonDefinition
         }
 
         $this->doc = json_decode(file_get_contents($this->filename));
+
+        if (empty($this->doc)) {
+            throw new \RuntimeException(sprintf('Could not load %s', $filename));
+        }
     }
 
     /**
@@ -69,6 +73,9 @@ class JsonDefinition
      */
     public function getId()
     {
+        if (!property_exists($this->doc, 'id')) {
+            throw new \RuntimeException(sprintf("No id found for document %s", $this->filename));
+        }
         return $this->doc->id;
     }
 


### PR DESCRIPTION
These don't change the fact that we need to implement some kind of validation
and logging in these areas of our code.

If one happens to have a small error in a definition it should not take that much
debugging to figure it out :)

I think we already have a GRV on this, for now this is what happend due to a typo
of mine that i realized to late.