### PR TITLE
remove container dependency from listeners

### DIFF
--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -5,9 +5,8 @@
 
 namespace Graviton\RestBundle\Listener;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\RestBundle\Event\RestEvent;
@@ -19,12 +18,12 @@ use Graviton\RestBundle\Event\RestEvent;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class PagingLinkResponseListener implements ContainerAwareInterface
+class PagingLinkResponseListener
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface service_container
+     * @var Router
      */
-    private $container;
+    private $router;
 
     /**
      * @var \Graviton\RestBundle\HttpFoundation\LinkHeader
@@ -32,15 +31,13 @@ class PagingLinkResponseListener implements ContainerAwareInterface
     private $linkHeader;
 
     /**
-     * {@inheritDoc}
-     *
-     * @param ContainerInterface $container service_container
+     * @param Router $router router
      *
      * @return void
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setRouter($router)
     {
-        $this->container = $container;
+        $this->router = $router;
     }
 
     /**
@@ -123,12 +120,11 @@ class PagingLinkResponseListener implements ContainerAwareInterface
      */
     private function generateLink($routeName, $page, $perPage, $type, $additionalParams = array())
     {
-        $router = $this->container->get('router');
         $parameters = array_merge($additionalParams, array('page' => $page));
         if ($perPage) {
             $parameters['perPage'] = $perPage;
         }
-        $url = $router->generate($routeName, $parameters, true);
+        $url = $this->router->generate($routeName, $parameters, true);
         $this->linkHeader->add(new LinkHeaderItem($url, array('rel' => $type)));
     }
 }

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -32,10 +32,8 @@ class PagingLinkResponseListener
 
     /**
      * @param Router $router router
-     *
-     * @return void
      */
-    public function setRouter($router)
+    public function __construct(Router $router)
     {
         $this->router = $router;
     }

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -5,10 +5,9 @@
 
 namespace Graviton\RestBundle\Listener;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\RestBundle\Event\RestEvent;
@@ -20,23 +19,21 @@ use Graviton\RestBundle\Event\RestEvent;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class SelfLinkResponseListener implements ContainerAwareInterface
+class SelfLinkResponseListener
 {
     /**
-     * @private reference to service_container
+     * @var Router
      */
-    private $container;
+    private $router;
 
     /**
-     * {@inheritDoc}
-     *
-     * @param ContainerInterface $container service_container
+     * @param Router $router router
      *
      * @return void
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setRouter(Router $router)
     {
-        $this->container = $container;
+        $this->router = $router;;
     }
 
     /**
@@ -55,7 +52,6 @@ class SelfLinkResponseListener implements ContainerAwareInterface
 
         $response = $event->getResponse();
         $request = $event->getRequest();
-        $router = $this->container->get('router');
         $linkHeader = LinkHeader::fromResponse($response);
 
         // extract various info from route
@@ -77,7 +73,7 @@ class SelfLinkResponseListener implements ContainerAwareInterface
         $url = '';
 
         try {
-            $url = $router->generate($routeName, $this->generateParameters($routeType, $request), true);
+            $url = $this->router->generate($routeName, $this->generateParameters($routeType, $request), true);
         } catch (\Exception $e) {
             $addHeader = false;
         }

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -28,10 +28,8 @@ class SelfLinkResponseListener
 
     /**
      * @param Router $router router
-     *
-     * @return void
      */
-    public function setRouter(Router $router)
+    public function __construct(Router $router)
     {
         $this->router = $router;
     }

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -33,7 +33,7 @@ class SelfLinkResponseListener
      */
     public function setRouter(Router $router)
     {
-        $this->router = $router;;
+        $this->router = $router;
     }
 
     /**

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -107,18 +107,14 @@
         <!-- Paging listener -->
         <service id="graviton.rest.listener.paginglinkresponselistener"
                  class="%graviton.rest.listener.paginglinkresponselistener.class%">
-            <call method="setRouter">
-                <argument type="service" id="router"></argument>
-            </call>
+            <argument type="service" id="router"></argument>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 
         <!-- Self link response listener -->
         <service id="graviton.rest.listener.selflinkresponselistener"
                  class="%graviton.rest.listener.selflinkresponselistener.class%">
-            <call method="setRouter">
-                <argument type="service" id="router"></argument>
-            </call>
+            <argument type="service" id="router"></argument>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -107,8 +107,8 @@
         <!-- Paging listener -->
         <service id="graviton.rest.listener.paginglinkresponselistener"
                  class="%graviton.rest.listener.paginglinkresponselistener.class%">
-            <call method="setContainer">
-                <argument type="service" id="service_container"></argument>
+            <call method="setRouter">
+                <argument type="service" id="router"></argument>
             </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
@@ -116,8 +116,8 @@
         <!-- Self link response listener -->
         <service id="graviton.rest.listener.selflinkresponselistener"
                  class="%graviton.rest.listener.selflinkresponselistener.class%">
-            <call method="setContainer">
-                <argument type="service" id="service_container"></argument>
+            <call method="setRouter">
+                <argument type="service" id="router"></argument>
             </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>

--- a/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
@@ -27,10 +27,8 @@ class CanonicalSchemaLinkResponseListener
 
     /**
      * @param Router $router router
-     *
-     * @return void
      */
-    public function setRouter($router)
+    public function __construct(Router $router)
     {
         $this->router = $router;
     }

--- a/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
@@ -5,9 +5,8 @@
 
 namespace Graviton\SchemaBundle\Listener;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\SchemaBundle\SchemaUtils;
@@ -19,23 +18,21 @@ use Graviton\SchemaBundle\SchemaUtils;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class CanonicalSchemaLinkResponseListener implements ContainerAwareInterface
+class CanonicalSchemaLinkResponseListener
 {
     /**
-     * @private reference to service_container
+     * @var Router $router
      */
-    private $container;
+    private $router;
 
     /**
-     * {@inheritDoc}
-     *
-     * @param ContainerInterface $container service_container
+     * @param Router $router router
      *
      * @return void
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setRouter($router)
     {
-        $this->container = $container;
+        $this->router = $router;
     }
 
     /**
@@ -50,11 +47,10 @@ class CanonicalSchemaLinkResponseListener implements ContainerAwareInterface
         $request = $event->getRequest();
         if ($request->attributes->get('schemaRequest', false)) {
             $response = $event->getResponse();
-            $router = $this->container->get('router');
             $linkHeader = LinkHeader::fromResponse($response);
 
             $routeName = SchemaUtils::getSchemaRouteName($request->get('_route'));
-            $url = $router->generate($routeName, array(), true);
+            $url = $this->router->generate($routeName, array(), true);
 
             // append rel=canonical link to link headers
             $linkHeader->add(new LinkHeaderItem($url, array('rel' => 'canonical')));

--- a/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
@@ -6,9 +6,8 @@
 namespace Graviton\SchemaBundle\Listener;
 
 use Symfony\Component\Config\Definition\Exception\Exception;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\SchemaBundle\SchemaUtils;
 
 /**
@@ -18,23 +17,21 @@ use Graviton\SchemaBundle\SchemaUtils;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class SchemaContentTypeResponseListener implements ContainerAwareInterface
+class SchemaContentTypeResponseListener
 {
     /**
-     * @private ContainerInterface
+     * @uvar Router
      */
-    private $container;
+    private $router;
 
     /**
-     * inject a service_container
-     *
-     * @param ContainerInterface $container service_container
+     * @param router $router router
      *
      * @return void
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setRouter(Router $router)
     {
-        $this->container = $container;
+        $this->router = $router;
     }
 
     /**
@@ -51,14 +48,13 @@ class SchemaContentTypeResponseListener implements ContainerAwareInterface
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
-        $router = $this->container->get('router');
 
         // build content-type string
         $contentType = 'application/json; charset=UTF-8';
         if ($request->get('_route') != 'graviton.core.static.main.all') {
             try {
                 $schemaRoute = SchemaUtils::getSchemaRouteName($request->get('_route'));
-                $contentType .= sprintf('; profile=%s', $router->generate($schemaRoute, array(), true));
+                $contentType .= sprintf('; profile=%s', $this->router->generate($schemaRoute, array(), true));
             } catch (\Exception $e) {
                 return true;
             }

--- a/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
@@ -26,10 +26,8 @@ class SchemaContentTypeResponseListener
 
     /**
      * @param router $router router
-     *
-     * @return void
      */
-    public function setRouter(Router $router)
+    public function __construct(Router $router)
     {
         $this->router = $router;
     }

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -9,14 +9,14 @@
   </parameters>
   <services>
     <service id="graviton.schema.listener.schematyperesponse" class="%graviton.schema.listener.schematyperesponse.class%">
-      <call method="setContainer">
-        <argument type="service" id="service_container"></argument>
+      <call method="setRouter">
+        <argument type="service" id="router"></argument>
       </call>
       <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse"/>
     </service>
     <service id="graviton.schema.listener.canonicalschemaresponse" class="%graviton.schema.listener.canonicalschemaresponse.class%">
-      <call method="setContainer">
-        <argument type="service" id="service_container"></argument>
+      <call method="setRouter">
+        <argument type="service" id="router"></argument>
       </call>
       <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse"/>
     </service>

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -9,15 +9,11 @@
   </parameters>
   <services>
     <service id="graviton.schema.listener.schematyperesponse" class="%graviton.schema.listener.schematyperesponse.class%">
-      <call method="setRouter">
-        <argument type="service" id="router"></argument>
-      </call>
+      <argument type="service" id="router"></argument>
       <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse"/>
     </service>
     <service id="graviton.schema.listener.canonicalschemaresponse" class="%graviton.schema.listener.canonicalschemaresponse.class%">
-      <call method="setRouter">
-        <argument type="service" id="router"></argument>
-      </call>
+      <argument type="service" id="router"></argument>
       <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse"/>
     </service>
     <service id="graviton.schema.model.schemamodel" class="%graviton.schema.model.schemamodel.class%">


### PR DESCRIPTION
This should help a bit with our phpunit performance issues. Some of them seem to stem from the
fact the container builder does multiple passes on ContainerAware things. This gets rid of a small
part of them. It won't make phpunit fast, but it is a step in the right direction.

File this under cleaning up legacy code from the olden days when injecting the container was still
the rage.