### PR TITLE
swagger dist path

### DIFF
--- a/src/Graviton/SwaggerBundle/Command/SwaggerCopyCommand.php
+++ b/src/Graviton/SwaggerBundle/Command/SwaggerCopyCommand.php
@@ -85,7 +85,12 @@ class SwaggerCopyCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $srcDir = $this->rootDir.'/../vendor/libgraviton/swagger-ui/dist/';
+        if (strpos($this->rootDir, 'vendor') === false) {
+            $srcDir = $this->rootDir.'/../vendor/libgraviton/swagger-ui/dist/';
+        } else {
+            $srcDir = $this->rootDir.'/../../../libgraviton/swagger-ui/dist/';
+        }
+
         $destDir = $this->rootDir.'/../web/explorer/';
 
         $this->filesystem->mirror($srcDir, $destDir);


### PR DESCRIPTION
The path to the `vendor` dir differs in wrapper context, this fixes that..

AFAIK there is no programmatic way to know if we're the main package or a dependency, so this is a no-fuss way..