### PR TITLE
return cors header for swagger.json

### DIFF
--- a/.bp-config/nginx/server-locations.conf
+++ b/.bp-config/nginx/server-locations.conf
@@ -19,6 +19,10 @@ location / {
     try_files $uri $uri /app_dev.php?$args;
 }
 
+location /swagger.json {
+    add_header 'Access-Control-Allow-Origin' "*";
+}
+
 location ~* \.php$ {
     include         fastcgi_params;
     fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Now that we host it for itself we need to make it reachable from https://swagger.nova.scapp.io/.

This fixes that for cf and will need adding to all wrappers that target cf. We still need to solve it for wrappers that push elsewhere (ie. docker et al).