### PR TITLE
fix --no-dev composer install cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ php:
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-  - ./vendor/bin/phpcs --standard=PSR1 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
-  - ./vendor/bin/phpcs --standard=PSR2 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
-  - ./vendor/bin/phpcs --standard=ENTB --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
+  - composer check

--- a/app/Resources/doc/DEVELOPMENT.md
+++ b/app/Resources/doc/DEVELOPMENT.md
@@ -14,7 +14,7 @@ You can now start a development server.
 php app/console server:run
 ````
 
-Please run ``./vendor/bin/phpunit`` and ``sh dev-check.sh`` before
+Please run ``./vendor/bin/phpunit`` and ``composer check`` before
 commiting changes to ensure that travis will be ok with your changes.
 
 ## Code Generators

--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
-            "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson",
-            "if [ -f ./vendor/bin/phpcs ]; then ./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards; fi"
+            "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -68,8 +67,13 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
-            "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson",
-            "if [ -f ./vendor/bin/phpcs ]; then ./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards; fi"
+            "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson"
+        ],
+        "check": [
+            "./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards",
+            "./vendor/bin/phpcs --standard=PSR1 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/",
+            "./vendor/bin/phpcs --standard=PSR2 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/",
+            "./vendor/bin/phpcs --standard=ENTB  --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
             "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson",
-            "\"vendor/bin/phpcs\" --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards"
+            "if [ -f ./vendor/bin/phpcs ]; then ./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards; fi"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -69,7 +69,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
             "Graviton\\SwaggerBundle\\Composer\\ScriptHandler::generateSwaggerJson",
-            "\"vendor/bin/phpcs\" --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards"
+            "if [ -f ./vendor/bin/phpcs ]; then ./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards; fi"
         ]
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f983b3cc4b841fdc76c08446a5499c9b",
+    "hash": "7368d5e22c797b627fda179ec6509475",
     "packages": [
         {
             "name": "behat/transliterator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7368d5e22c797b627fda179ec6509475",
+    "hash": "54774f986d3b84c34663a834bd9bf2af",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2347,16 +2347,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae"
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c41c218e239b50446fd883acb1ecfd4b770caeae",
-                "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
                 "shasum": ""
             },
             "require": {
@@ -2416,7 +2416,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-03-05 01:12:12"
+            "time": "2015-03-09 09:58:04"
         },
         {
             "name": "php-jsonpatch/php-jsonpatch",

--- a/dev-check.sh
+++ b/dev-check.sh
@@ -1,4 +1,1 @@
-./vendor/bin/phpcs --standard=ENTB  --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
-./vendor/bin/phpcs --standard=PSR1 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
-./vendor/bin/phpcs --standard=PSR2 --ignore='src/GravitonDyn/*' --ignore='app/cache/*' --ignore='app/check.php' --ignore='app/SymfonyRequirements.php' --ignore='web/check.php' --ignore='web/config.php' --ignore='app/AppCache.php' --ignore='*.css' --ignore='*.js' src/ app/ web/
-
+composer check


### PR DESCRIPTION
Also fixes wrapper cases that don't themselves have phpcs installed.

I'm doing it like so since that was recommended on the composer issue
that talked about adding a "scripts-dev" node to composer.json. I can't
seem to find that again though.

This also fixes cloud pushes directly from the graviton repo and I use
those lots for dev.