### PR TITLE
added ability to provide a wrapper specific service whitelist

### DIFF
--- a/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
@@ -230,7 +230,7 @@ class GenerateDynamicBundleCommand extends Command
             );
 
             // controller?
-            if (!$jsonDef->hasController() || $this->isBlacklistedController($jsonDef->getRouterBase())) {
+            if (!$jsonDef->hasController() || $this->isNotWhitelistedController($jsonDef->getRouterBase())) {
                 $arguments['--no-controller'] = 'true';
             }
 
@@ -516,6 +516,7 @@ class GenerateDynamicBundleCommand extends Command
 
     /**
      * Checks an optional environment setting if this $routerBase is whitelisted there.
+     * If something is 'not whitelisted' (return true) means that the controller should not be generated.
      * This serves as a lowlevel possibility to disable the generation of certain controllers.
      * If we have no whitelist defined, we consider that all services should be generated (default).
      *
@@ -523,14 +524,14 @@ class GenerateDynamicBundleCommand extends Command
      *
      * @return bool true if yes, false if not
      */
-    private function isBlacklistedController($routerBase)
+    private function isNotWhitelistedController($routerBase)
     {
-        // if no whitelist is set, we're generating everything..
+        // if no whitelist is set, everything is whitelisted
         if (!$this->container->hasParameter('generator.dynamicbundles.service.whitelist')) {
             return false;
         }
 
-        // if param is there, default is 'yes' - everything is blacklisted..
+        // if param is there our default is 'yes' - everything is not whitelisted by default.
         $ret = true;
 
         $whitelist = json_decode(
@@ -538,7 +539,7 @@ class GenerateDynamicBundleCommand extends Command
             true
         );
 
-        // if in whitelist, it's not blacklisted ;-)
+        // whitelist it if in list..
         if (is_array($whitelist) && in_array($routerBase, $whitelist)) {
             $ret = false;
         }


### PR DESCRIPTION
Now, please consider my thoughts when looking into this.. it's a no-brainer actually ;-)

**What we need**
In specific Graviton wrappers we need to be able to exclude certain services from generating a controller.  In ml3k context, we do this by overriding the JSON file (inheritance there) and setting the `service.routerBase` to `null`. This here adds the same ability to Graviton, but obviously in a different fashion as we don't have JSON file inheritance here.

It's crucial we generate all `Documents` from *all* available JSON files - but *don't* generate a `Controller` to it as those `Document` classes are needed in logic controllers to do their work. See elaboration below.

**What solutions I considered**
Now, why is this an environmental setting influencing the Generator? I considered and discarded the following approaches
* Splitting JSON files in Bundles<br />Actually, I always thought we can solve this by re-arranging the JSON files in the bundle. So I would make a "parameter" bundle containing only parameter services (those that should not be generated on the external-facing wrapper) and one "logic" bundle containing services that should be generated on both wrappers.<br />This is actually not feasible as doing this would lead to the external facing wrapper *missing documents* (i.e. the documents having the configuration) and the wrapper would not be able to find it's required `Document` classes to implement his logic (i.e. `MortgageCost` service not being able to use `FinancingUseCase` documents) 
* Using ACL<br />This would be the wrong approach is the `Controller` endpoint would still exist, it would be listed in `MainController` (front listing all services) but then only on GET/POST it would be denied. This *would* work - I know - but it's more secure to not even generate `Controller`s to services we don't want to provide anyway in a certain wrapper.
