### PR TITLE
Remove serializer naming strategy from parameters.yml.dist

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -2,6 +2,9 @@ imports:
     - { resource: parameters.yml }
     - { resource: services.yml }
 
+parameters:
+    jms_serializer.camel_case_naming_strategy.class: JMS\Serializer\Naming\IdenticalPropertyNamingStrategy
+
 # Synfony Framework Configuation
 # see http://symfony.com/doc/current/reference/configuration/framework.html
 framework:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,8 +10,6 @@ parameters:
     # service info injected by cloudfoundry
     vcap.services: ~
 
-    jms_serializer.camel_case_naming_strategy.class: JMS\Serializer\Naming\IdenticalPropertyNamingStrategy
-
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
     mailer_user:       ~


### PR DESCRIPTION
This removes the naming strategy param from dist. I'm doing this since the user won't need to be able to configure this anyhow.