### PR TITLE
report malformed json

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -182,6 +182,28 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * test if we get a correct return if we post empty.
+     *
+     * @return void
+     */
+    public function testPostEmptyApp()
+    {
+        $client = static::createRestClient();
+
+        // send nothing really..
+        $client->post('/core/app', "", array(), array(), array(), false);
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            'No input data',
+            $response->getContent()
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
      * test if 500 error is reported when posting an malformed input
      *
      * @return void
@@ -209,7 +231,6 @@ class AppControllerTest extends RestTestCase
         );
 
         $this->assertEquals(500, $response->getStatusCode());
-
     }
 
     /**

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -226,7 +226,7 @@ class AppControllerTest extends RestTestCase
         $response = $client->getResponse();
 
         $this->assertContains(
-            'object property name separator &#039;:&#039; expected',
+            'Syntax error, malformed JSON',
             $response->getContent()
         );
 

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -182,6 +182,37 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * test if 500 error is reported when posting an malformed input
+     *
+     * @return void
+     */
+    public function testPostMalformedApp()
+    {
+        $testApp = new \stdClass;
+        $testApp->title = new \stdClass;
+        $testApp->title->en = 'new Test App';
+        $testApp->showInMenu = true;
+
+        // malform it ;-)
+        $input = str_replace(":", ";", json_encode($testApp));
+
+        $client = static::createRestClient();
+
+        // make sure this is sent as 'raw' input (not json_encoded again)
+        $client->post('/core/app', $input, array(), array(), array(), false);
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            'object property name separator &#039;:&#039; expected',
+            $response->getContent()
+        );
+
+        $this->assertEquals(500, $response->getStatusCode());
+
+    }
+
+    /**
      * test updating apps
      *
      * @return void

--- a/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
+++ b/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * MalformedInput exception class
+ */
+
+namespace Graviton\ExceptionBundle\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MalformedInput exception class
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+final class MalformedInputException extends RestException
+{
+    /**
+     * Constructor
+     *
+     * @param string     $message Error message
+     * @param \Exception $prev    Previous Exception
+     */
+    public function __construct($message = "Malformed input", $prev = null)
+    {
+        parent::__construct($message, Response::HTTP_INTERNAL_SERVER_ERROR, $prev);
+    }
+}

--- a/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
+++ b/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
@@ -16,6 +16,14 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class MalformedInputException extends RestException
 {
+    private $errorTypes = array(
+        JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
+        JSON_ERROR_STATE_MISMATCH => 'Underflow or modes mismatch',
+        JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
+        JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
+        JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
+    );
+
     /**
      * Constructor
      *
@@ -25,5 +33,19 @@ final class MalformedInputException extends RestException
     public function __construct($message = "Malformed input", $prev = null)
     {
         parent::__construct($message, Response::HTTP_INTERNAL_SERVER_ERROR, $prev);
+    }
+
+    /**
+     * Sets the specific json error type to make consistent error reporting (and thus testing) possible
+     *
+     * @param int $error Error constant from json_last_error
+     *
+     * @return void
+     */
+    public function setErrorType($error)
+    {
+        if (isset($this->errorTypes[$error])) {
+            $this->message = trim($this->errorTypes[$error].': '.$this->message);
+        }
     }
 }

--- a/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
@@ -65,6 +65,7 @@ class ValidationRequestListener
             // specially check for parse error ($input decodes to null) and report accordingly..
             if (is_null($input) && JSON_ERROR_NONE !== json_last_error()) {
                 $e = new MalformedInputException(json_last_error_msg());
+                $e->setErrorType(json_last_error());
                 $e->setResponse($event->getResponse());
                 throw $e;
             }

--- a/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\RestBundle\Listener;
 
+use Graviton\ExceptionBundle\Exception\MalformedInputException;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -57,6 +58,13 @@ class ValidationRequestListener
             // Decode the json from request
             if (!($input = json_decode($content, true)) && JSON_ERROR_NONE === json_last_error()) {
                 $e = new NoInputException();
+                $e->setResponse($event->getResponse());
+                throw $e;
+            }
+
+            // specially check for parse error ($input decodes to null) and report accordingly..
+            if (is_null($input) && JSON_ERROR_NONE !== json_last_error()) {
+                $e = new MalformedInputException(json_last_error_msg());
                 $e->setResponse($event->getResponse());
                 throw $e;
             }

--- a/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
@@ -64,7 +64,12 @@ class ValidationRequestListener
 
             // specially check for parse error ($input decodes to null) and report accordingly..
             if (is_null($input) && JSON_ERROR_NONE !== json_last_error()) {
-                $e = new MalformedInputException(json_last_error_msg());
+                $lastJsonError = '';
+                if (function_exists('json_last_error_msg')) { // for php54
+                    $lastJsonError = json_last_error_msg();
+                }
+
+                $e = new MalformedInputException($lastJsonError);
                 $e->setErrorType(json_last_error());
                 $e->setResponse($event->getResponse());
                 throw $e;

--- a/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/ValidationRequestListener.php
@@ -64,12 +64,7 @@ class ValidationRequestListener
 
             // specially check for parse error ($input decodes to null) and report accordingly..
             if (is_null($input) && JSON_ERROR_NONE !== json_last_error()) {
-                $lastJsonError = '';
-                if (function_exists('json_last_error_msg')) { // for php54
-                    $lastJsonError = json_last_error_msg();
-                }
-
-                $e = new MalformedInputException($lastJsonError);
+                $e = new MalformedInputException(json_last_error_msg());
                 $e->setErrorType(json_last_error());
                 $e->setResponse($event->getResponse());
                 throw $e;

--- a/src/Graviton/TestBundle/Client.php
+++ b/src/Graviton/TestBundle/Client.php
@@ -55,13 +55,18 @@ class Client extends FrameworkClient
         array $server = array(),
         $jsonEncode = true
     ) {
+
+        if ($jsonEncode) {
+            $content = json_encode($content);
+        }
+
         return $this->request(
             'POST',
             $uri,
             $parameters,
             $files,
             $server,
-            $jsonEncode ? json_encode($content) : $content
+            $content
         );
     }
 
@@ -87,13 +92,18 @@ class Client extends FrameworkClient
         array $server = array(),
         $jsonEncode = true
     ) {
+
+        if ($jsonEncode) {
+            $content = json_encode($content);
+        }
+
         return $this->request(
             'PUT',
             $uri,
             $parameters,
             $files,
             $server,
-            $jsonEncode ? json_encode($content) : $content
+            $content
         );
     }
 
@@ -119,13 +129,18 @@ class Client extends FrameworkClient
         array $server = array(),
         $jsonEncode = true
     ) {
+
+        if ($jsonEncode) {
+            $content = json_encode($content);
+        }
+
         return $this->request(
             'PATCH',
             $uri,
             $parameters,
             $files,
             $server,
-            $jsonEncode ? json_encode($content) : $content
+            $content
         );
     }
 

--- a/src/Graviton/TestBundle/Client.php
+++ b/src/Graviton/TestBundle/Client.php
@@ -36,55 +36,97 @@ class Client extends FrameworkClient
     /**
      * POSTs to an URI.
      *
-     * @param string $uri        The URI to fetch
-     * @param string $content    The raw body data
-     * @param array  $parameters The Request parameters
-     * @param array  $files      The files
-     * @param array  $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $uri        The URI to fetch
+     * @param string  $content    The raw body data
+     * @param array   $parameters The Request parameters
+     * @param array   $files      The files
+     * @param array   $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param boolean $jsonEncode If $content should be json encoded or not
      *
      * @return \Symfony\Component\DomCrawler\Crawler|null
      *
      * @api
      */
-    public function post($uri, $content, array $parameters = array(), array $files = array(), array $server = array())
-    {
-        return $this->request('POST', $uri, $parameters, $files, $server, json_encode($content));
+    public function post(
+        $uri,
+        $content,
+        array $parameters = array(),
+        array $files = array(),
+        array $server = array(),
+        $jsonEncode = true
+    ) {
+        return $this->request(
+            'POST',
+            $uri,
+            $parameters,
+            $files,
+            $server,
+            $jsonEncode ? json_encode($content) : $content
+        );
     }
 
     /**
      * PUTs to an URI.
      *
-     * @param string $uri        The URI to fetch
-     * @param string $content    The raw body data
-     * @param array  $parameters The Request parameters
-     * @param array  $files      The files
-     * @param array  $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $uri        The URI to fetch
+     * @param string  $content    The raw body data
+     * @param array   $parameters The Request parameters
+     * @param array   $files      The files
+     * @param array   $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param boolean $jsonEncode If $content should be json encoded or not
      *
      * @return \Symfony\Component\DomCrawler\Crawler|null
      *
      * @api
      */
-    public function put($uri, $content, array $parameters = array(), array $files = array(), array $server = array())
-    {
-        return $this->request('PUT', $uri, $parameters, $files, $server, json_encode($content));
+    public function put(
+        $uri,
+        $content,
+        array $parameters = array(),
+        array $files = array(),
+        array $server = array(),
+        $jsonEncode = true
+    ) {
+        return $this->request(
+            'PUT',
+            $uri,
+            $parameters,
+            $files,
+            $server,
+            $jsonEncode ? json_encode($content) : $content
+        );
     }
 
     /**
      * PATCH to an URI.
      *
-     * @param string $uri        The URI to fetch
-     * @param string $content    The raw body data
-     * @param array  $parameters The Request parameters
-     * @param array  $files      The files
-     * @param array  $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $uri        The URI to fetch
+     * @param string  $content    The raw body data
+     * @param array   $parameters The Request parameters
+     * @param array   $files      The files
+     * @param array   $server     The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param boolean $jsonEncode If $content should be json encoded or not
      *
      * @return \Symfony\Component\DomCrawler\Crawler|null
      *
      * @api
      */
-    public function patch($uri, $content, array $parameters = array(), array $files = array(), array $server = array())
-    {
-        return $this->request('PATCH', $uri, $parameters, $files, $server, json_encode($content));
+    public function patch(
+        $uri,
+        $content,
+        array $parameters = array(),
+        array $files = array(),
+        array $server = array(),
+        $jsonEncode = true
+    ) {
+        return $this->request(
+            'PATCH',
+            $uri,
+            $parameters,
+            $files,
+            $server,
+            $jsonEncode ? json_encode($content) : $content
+        );
     }
 
     /**


### PR DESCRIPTION
Currently, if a client posts malformed json to a service, he gets (sadly as HTML currently) the following:

```
Argument 1 passed to Graviton\RestBundle\Validator\JsonInput::checkDocument() must be of the type array, null given, called in /home/dn/git/graviton2/src/Graviton/RestBundle/Validator/JsonInput.php on line 79 and defined (500 Internal Server Error)
```

this is unspecific and doesn't help the consumer.. this PR addresses this and throws an explicit Exception containing the json decode error..

