### PR TITLE
Stop spamming hipchat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ notifications:
   hipchat:
     rooms:
       secure: F5pTVtwBACRIXMdkQ/oE6f5faK3eHvPqDmD7jmAv4vU7Nyog4RN1h1nqa8kJo6fRaRvdbIF5ovAwfdX5nuoMBQqio4FpfpT4jkfFNf5gGEFOlGW3UTQR/8JyoVCEvZ4Wau3OsIouv1U3du9uWvaqHoxIeI9HvnTVinSzu9P4EjE=
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This should only notify fails and when a build goes from fail to success, at least thats what I'm intending with it.

It i a cherry pick of the corresponding commit from #87. We still need to merge #87 and I'm absolutely not happy with #87 being help up over a ``composer update``. As promised, this contains just the hipchat change on its own.