### PR TITLE
fix translation load exception

### DIFF
--- a/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
+++ b/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
@@ -62,6 +62,8 @@ class PostPersistTranslatableListener implements EventSubscriber
                     $fs->remove($file->getRealPath());
                 }
             } catch (\InvalidArgumentException $e) {
+                // InvalidArgumentException gets thrown if the translation cache dir doesn't exist.
+                // we tolerate that is it's normal under some circumstances (no cache warmup yet)
             }
         }
     }

--- a/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
+++ b/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
@@ -62,9 +62,6 @@ class PostPersistTranslatableListener implements EventSubscriber
                     $fs->remove($file->getRealPath());
                 }
             } catch (\InvalidArgumentException $e) {
-                // InvalidArgumentException gets thrown if the translation cache dir doesn't exist.
-                // we tolerate that is it's normal under some circumstances (no cache warmup yet)
-                return true;
             }
         }
     }

--- a/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
+++ b/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
@@ -51,14 +51,20 @@ class PostPersistTranslatableListener implements EventSubscriber
                 $fs->touch($triggerFile);
             }
 
-            $finder = new Finder();
-            $finder
-                ->files()
-                ->in($cacheDirMask)
-                ->name('*.'.$locale.'.*');
+            try {
+                $finder = new Finder();
+                $finder
+                    ->files()
+                    ->in($cacheDirMask)
+                    ->name('*.' . $locale . '.*');
 
-            foreach ($finder as $file) {
-                $fs->remove($file->getRealPath());
+                foreach ($finder as $file) {
+                    $fs->remove($file->getRealPath());
+                }
+            } catch (\InvalidArgumentException $e) {
+                // InvalidArgumentException gets thrown if the translation cache dir doesn't exist.
+                // we tolerate that is it's normal under some circumstances (no cache warmup yet)
+                return true;
             }
         }
     }


### PR DESCRIPTION
I had the [InvalidArgumentException thrown by Symfony finder](http://api.symfony.com/2.6/Symfony/Component/Finder/Finder.html#method_in) if the directory it must search for files doesn't exist.. As this is thrown in app/console context, the Exception is unhandled and it leads to the stop of the fixture loading process. 

We can safely catch that exception and continue normal operation there..