### PR TITLE
ensure we don't create a new record when there is no ID on PUT request..

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -266,6 +266,58 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * Try to update an app with a non matching ID in GET and req body
+     *
+     * @return void
+     */
+    public function testNonMatchingIdPutApp()
+    {
+        $helloApp = new \stdClass();
+        $helloApp->id = "tablet";
+        $helloApp->title = new \stdClass();
+        $helloApp->title->en = "Tablet";
+        $helloApp->showInMenu = false;
+
+        $client = static::createRestClient();
+        $client->put('/core/app/someotherapp', $helloApp);
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            'Record ID in your payload must be the same',
+            $response->getContent()
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * We had an issue when PUTing without ID would create a new record.
+     * This test ensures that we don't do that, instead we should apply the ID from the GET req.
+     *
+     * @return void
+     */
+    public function testPutAppNoIdInPayload()
+    {
+        $helloApp = new \stdClass();
+        $helloApp->title = new \stdClass();
+        $helloApp->title->en = 'New tablet';
+        $helloApp->showInMenu = false;
+
+        $client = static::createRestClient();
+        $client->put('/core/app/tablet', $helloApp);
+
+        $response = $client->getResponse();
+        $results = $client->getResults();
+
+        $this->assertResponseContentType(self::CONTENT_TYPE, $response);
+
+        $this->assertEquals('tablet', $results->id);
+        $this->assertEquals('New tablet', $results->title->en);
+        $this->assertFalse($results->showInMenu);
+    }
+
+    /**
      * test updating an inexistant document
      *
      * @return void

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -6,6 +6,7 @@
 namespace Graviton\RestBundle\Controller;
 
 use Graviton\ExceptionBundle\Exception\DeserializationException;
+use Graviton\ExceptionBundle\Exception\MalformedInputException;
 use Graviton\ExceptionBundle\Exception\NotFoundException;
 use Graviton\ExceptionBundle\Exception\SerializationException;
 use Graviton\ExceptionBundle\Exception\ValidationException;
@@ -314,6 +315,8 @@ class RestController implements ContainerAwareInterface
      * @param Number  $id      ID of record
      * @param Request $request Current http request
      *
+     * @throws MalformedInputException
+     *
      * @return Response $response Result of action with data (if successful)
      */
     public function putAction($id, Request $request)
@@ -328,6 +331,17 @@ class RestController implements ContainerAwareInterface
             $request->getContent(),
             $this->getModel()->getEntityClass()
         );
+
+        // handle missing 'id' field in input to a PUT operation
+        // if it is settable on the document, let's set it and move on.. if not, inform the user..
+        if ($record->getId() != $id) {
+            // try to set it..
+            if (is_callable(array($record, 'setId'))) {
+                $record->setId($id);
+            } else {
+                throw new MalformedInputException('No ID was supplied in the request payload.');
+            }
+        }
 
         // And update the record, if everything is ok
         $this->getModel()->updateRecord($id, $record);


### PR DESCRIPTION
This bug was encountered during a issue testing from Kyrill..

For some reason, he made a PUT request with a payload without an "id" field (as said, in the payload) - but obviously specifying one in the URI he requested. 
Graviton in this case inserted a new record and returned this one (because of the way we insert it in `DocumentModel`).  It's wrong to insert a record on PUT.

This fixes that, ensuring that we take the ID from the URI request if it's not on the payload already. I also added tests that ensure that behavior. If the entity on question doesn't have a `setId()` function and there is no ID in the payload, we quit and tell the user.

Normally, a read/write entity would always have a `setId()` function, I just want to make it more reliable there as this is not *always* the case..