### PR TITLE
Require ID in /i18n/translatable schema

### DIFF
--- a/src/Graviton/I18nBundle/Resources/config/schema/Translatable.json
+++ b/src/Graviton/I18nBundle/Resources/config/schema/Translatable.json
@@ -27,6 +27,7 @@
     }
   },
   "required": [
+    "id",
     "domain",
     "locale",
     "original"

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -27,5 +27,8 @@ class TranslatableControllerTest extends RestTestCase
 
         $client->request('OPTIONS', '/i18n/translatable/i18n-de-German');
         $this->assertCorsHeaders('GET, POST, PUT, DELETE, OPTIONS', $client->getResponse());
+
+        $results = $client->getResults();
+        $this->assertContains('id', $results->required);
     }
 }


### PR DESCRIPTION
This one was simply too small to not just do.