### PR TITLE
Remove developer-local ignores after documenting ~/.gitignore_global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,14 +7,6 @@ web/bundles
 web/swagger.json
 src/Graviton/I18nBundle/Resources/translations/*.odm
 vendor/
-*.phar
-*.swp
-*.swo
-.*~
-.buildpath
-.settings/*
-.idea
-.project
 web/.htaccess
 web/explorer
 mongodata/


### PR DESCRIPTION
Just configure a global file and add something:

```
git config --global --add core.excludesfile ~/.gitignore_global
echo '.*.sw?' >> ~/.gitignore_global
```