### PR TITLE
Use global composer install

### DIFF
--- a/dev-cleanstart.sh
+++ b/dev-cleanstart.sh
@@ -1,4 +1,4 @@
 rm -Rf app/cache app/logs app/bootstrap.php.cache
-./composer.phar install
+composer install
 php app/console doctrine:mongodb:fixtures:load
 php app/console server:run


### PR DESCRIPTION
I just stared at a ``Composer\DependencyResolver\SolverProblemsException`` due to an issue that was long gone. Seriously, I'm adding that you should install composer globally to our guidelines ASAP.