### PR TITLE
Allow explicit parent service in services from jsondef

### DIFF
--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
@@ -275,6 +275,24 @@ class JsonDefinition
     }
 
     /**
+     * Returns the parent service to use when adding the service xml
+     *
+     * Defaults to graviton.rest.controller
+     *
+     * @return string base controller
+     */
+    public function getParentService()
+    {
+        $ret = 'graviton.rest.controller';
+
+        if (isset($this->doc->service->parent) && strlen($this->doc->service->parent) > 0) {
+            $ret = $this->doc->service->parent;
+        }
+
+        return $ret;
+    }
+
+    /**
      * Returns a specific field or null
      *
      * @param string $name Field name

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -163,6 +163,7 @@ class ResourceGenerator extends AbstractGenerator
                 // we leave it in the document though but we don't wanna output it..
                 $parameters['noIdField'] = true;
             }
+            $parameters['parent'] = $this->json->getParentService();
         }
 
         $this->generateDocument($parameters, $dir, $document, $withRepository);
@@ -771,7 +772,7 @@ class ResourceGenerator extends AbstractGenerator
         $this->addService(
             $services,
             $paramName,
-            'graviton.rest.controller',
+            $parameters['parent'],
             'request',
             array(
                 array(


### PR DESCRIPTION
Use it like this.

```js
{
  "id": "Foo",
  "description": "Foo service",
  "service": {
    "readOnly": false,
    "routerBase": "/acme/foo/",
    "parent": "graviton.acme.controller.foo",
    ]
  }
}
```

Wield it wisely and remember that we still need to put work into RestController to make this more sane.