### PR TITLE
Use phpunit-speedtrap to display slow tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "liip/functional-test-bundle": "~1.0",
         "squizlabs/php_codesniffer": "~2.2",
         "libgraviton/codesniffer": "~1.3",
-        "lapistano/proxy-object": "~2.1"
+        "lapistano/proxy-object": "~2.1",
+        "johnkary/phpunit-speedtrap": "^1.0@dev"
     },
     "suggests": {
         "graviton/s3-file-service-bundle": "to enable the /file/ endpoint that has a S3 backend",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4c5708548a1825266f0f3df27737536e",
+    "hash": "c5bc075eee17c5e8f100a156e4e95566",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -3577,6 +3577,56 @@
     ],
     "packages-dev": [
         {
+            "name": "johnkary/phpunit-speedtrap",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnkary/phpunit-speedtrap.git",
+                "reference": "ad70c60c6d77ddd51e6aca9fdf165538e43b0193"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/ad70c60c6d77ddd51e6aca9fdf165538e43b0193",
+                "reference": "ad70c60c6d77ddd51e6aca9fdf165538e43b0193",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JohnKary": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Kary",
+                    "email": "john@johnkary.net"
+                }
+            ],
+            "description": "Find slow tests in your PHPUnit test suite",
+            "homepage": "https://github.com/johnkary/phpunit-speedtrap",
+            "keywords": [
+                "phpunit",
+                "profile",
+                "slow"
+            ],
+            "time": "2015-03-21 19:00:39"
+        },
+        {
             "name": "lapistano/proxy-object",
             "version": "v2.1.1",
             "source": {
@@ -4641,7 +4691,8 @@
         "doctrine/mongodb-odm-bundle": 20,
         "php-jsonpointer/php-jsonpointer": 20,
         "php-jsonpatch/php-jsonpatch": 20,
-        "knplabs/knp-gaufrette-bundle": 20
+        "knplabs/knp-gaufrette-bundle": 20,
+        "johnkary/phpunit-speedtrap": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,9 +17,6 @@
       <directory>src/*/Bundle/*Bundle/Tests</directory>
     </testsuite>
   </testsuites>
-    <php>
-        <!--<server name="KERNEL_DIR" value="/home/graviton/graviton/app" />-->
-    </php>
   <filter>
     <whitelist>
       <directory>src</directory>
@@ -36,4 +33,7 @@
   <php>
     <ini name="error_reporting" value="E_ALL"/>
   </php>
+  <listeners>
+    <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+  </listeners>
 </phpunit>


### PR DESCRIPTION
Our suite is slow already. This displays the worst offenders and at least makes them visible. We still need real fixes here and also things like test parallelization but those will be left for other PRs.