### PR TITLE
Add and configure eo/airbreak-bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -72,6 +72,7 @@ class AppKernel extends Kernel
             new \Exercise\HTMLPurifierBundle\ExerciseHTMLPurifierBundle(),
             new \Graviton\RqlParserBundle\GravitonRqlParserBundle(),
             new \Knp\Bundle\GaufretteBundle\KnpGaufretteBundle(),
+            new \Eo\AirbrakeBundle\EoAirbrakeBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -141,3 +141,7 @@ knp_gaufrette:
     filesystems:
         file_service:
             adapter: %graviton.file.gaufrette.backend%
+
+eo_airbrake:
+        host: %graviton.errbit.host%
+        api_key: %graviton.errbit.api_key%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -29,3 +29,7 @@ parameters:
     graviton.file.s3.key: ~
     graviton.file.s3.secret: ~
     graviton.file.s3.bucket_name: graviton-dev-bucket
+
+    # errbit config
+    graviton.errbit.api_key: ~
+    graviton.errbit.host: ~

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "graviton/php-rql-parser": "~2.0@alpha",
         "graviton/rql-parser-bundle": "^0.1.0@alpha",
         "knplabs/knp-gaufrette-bundle": "dev-master",
-        "aws/aws-sdk-php": "~2.7@dev"
+        "aws/aws-sdk-php": "~2.7@dev",
+        "eo/airbrake-bundle": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6",
@@ -95,7 +96,11 @@
         "symfony-web-dir": "web",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml"
+            "file": "app/config/parameters.yml",
+            "env-map": {
+                "graviton.errbit.api_key": "ERRBIT_API_KEY",
+                "graviton.errbit.host": "ERRBIT_HOST"
+            }
         },
         "branch-alias": {
             "dev-master": "2.6-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,54 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3c4157c5268b77bb3ee0914ba1b453f0",
+    "hash": "20f90f1d0185263adb905250bf1cff51",
     "packages": [
+        {
+            "name": "airbrake/airbrake-php",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/airbrake/airbrake-php.git",
+                "reference": "b2a3f28a8113502d2426003b22c78a2efd333b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/airbrake/airbrake-php/zipball/b2a3f28a8113502d2426003b22c78a2efd333b3c",
+                "reference": "b2a3f28a8113502d2426003b22c78a2efd333b3c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php": ">=5.3.3",
+                "phpunit/phpunit": "*",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Airbrake\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Drew Butler",
+                    "email": "hi@dbtlr.com",
+                    "homepage": "http://dbtlr.com"
+                }
+            ],
+            "description": "A PHP 5.3 library for sending errors to the Airbrake.io service.",
+            "homepage": "https://github.com/dbtlr/php-airbrake",
+            "keywords": [
+                "airbrake",
+                "errors",
+                "exceptions",
+                "logging"
+            ],
+            "time": "2015-04-24 21:28:00"
+        },
         {
             "name": "aws/aws-sdk-php",
             "version": "2.8.3",
@@ -1291,6 +1337,54 @@
                 "validator"
             ],
             "time": "2015-04-26 15:49:00"
+        },
+        {
+            "name": "eo/airbrake-bundle",
+            "version": "dev-master",
+            "target-dir": "Eo/AirbrakeBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eymengunay/EoAirbrakeBundle.git",
+                "reference": "db41e7514b90b56715c82fa14004426bb29170d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eymengunay/EoAirbrakeBundle/zipball/db41e7514b90b56715c82fa14004426bb29170d3",
+                "reference": "db41e7514b90b56715c82fa14004426bb29170d3",
+                "shasum": ""
+            },
+            "require": {
+                "airbrake/airbrake-php": "dev-master",
+                "symfony/symfony": ">=2.1,<2.7-dev"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Eo\\AirbrakeBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eymen Gunay",
+                    "email": "eymen@egunay.com"
+                }
+            ],
+            "description": "Airbrake.io integration for Symfony2",
+            "keywords": [
+                "airbrake",
+                "errbit",
+                "exception"
+            ],
+            "time": "2014-07-21 16:05:47"
         },
         {
             "name": "exercise/htmlpurifier-bundle",


### PR DESCRIPTION
To enable errbit logging you need to set ``ERRBIT_API_KEY`` and ``ERRBIT_HOST``.

I already have errbit deployed to the cloud thru jenkins using a blue/green deploy and graviton-develop should also be setup properly for this to work on the next deploy. The code I used to deploy errbit is in a fork [over here](https://github.com/gravity-platform/errbit) and in jenkins' config.

We need to test that everything is running stable-ish before this makes sense but my first tests look very promising.

Contact me for access so you can review this using my cf instance of errbit. At the moment I have a prod and an unstable version available, I'll add develop if we need it (ie. on the next large upstream merge of errbit).