### PR TITLE
Implement AbstractCustomerController in PersonBundle

### DIFF
--- a/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
+++ b/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * abstract customer controller
+ *
+ * Implements async reading and writing for static data.
+ *
+ * We have heaps of 'unchangeable' data coming from complex enterprisy systems that have some data we need
+ * want to let our users change nevertheless. This controller implements a diff-layer to that data and
+ * allows us to store differences to the mainframe locally.
+ *
+ * We do this by adding an additional collection to mongodb containing an overlay of diff records. The idea
+ * is that there is also tooling that enables us to write back the contents of this diff layer into the
+ * enterprisy data container at a later stage following the varying complex scenarios needed to get that data
+ * back into the mainframe.
+ */
+
+namespace Graviton\PersonBundle\Controller;
+
+use Graviton\RestBundle\Controller\RestController;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+abstract class AbstractCustomerController extends RestController
+{
+}

--- a/src/Graviton/PersonBundle/Resources/config/services.xml
+++ b/src/Graviton/PersonBundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameter key="graviton.person.repository.personcontact.class">Graviton\PersonBundle\Repository\PersonContactRepository</parameter>
     <parameter key="graviton.person.model.personcontact.class">Graviton\PersonBundle\Model\PersonContact</parameter>
     <parameter key="graviton.person.document.personcontact.class">Graviton\PersonBundle\Document\PersonContact</parameter>
+    <parameter key="graviton.person.controller.abstractcustomer.class">Graviton\PersonBundle\Controller\AbstractCustomerController</parameter>
   </parameters>
   <services>
     <service id="graviton.person.repository.personcontact"
@@ -13,6 +14,8 @@
              factory-service="doctrine_mongodb.odm.default_document_manager"
              factory-method="getRepository">
       <argument type="string">GravitonPersonBundle:PersonContact</argument>
+    </service>
+    <service id="graviton.person.controller.abstractcustomer" abstract="true" parent="graviton.rest.controller" class="%graviton.person.controller.abstractcustomer.class%">
     </service>
     <service id="graviton.person.model.personcontact"
              class="%graviton.person.model.personcontact.class%"

--- a/src/Graviton/PersonBundle/Tests/Controller/AbstractCustomerControllerTest.php
+++ b/src/Graviton/PersonBundle/Tests/Controller/AbstractCustomerControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * validate AbstractCustomerController
+ */
+
+namespace Graviton\PersonBundle\Tests\Controller;
+
+use Graviton\PersonBundle\Controller\AbstractCustomerController;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class AbstractCustomerControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     */
+    public function testInstanciateController()
+    {
+        $stub = $this->getMockForAbstractClass('Graviton\PersonBundle\Controller\AbstractCustomerController');
+
+        $this->assertInstanceOf('Graviton\RestBundle\Controller\RestController', $stub);
+    }
+}


### PR DESCRIPTION
This is complete with docs and and an absolutely rudimentary testcase for the new ``Graviton\PersonBundle\Controller\AbstractCustomerController``.

It can be used in a JsonDefinition as follows.

```js
{
  // ...
  "service": {
    // ...
    "baseController": "\\Graviton\\PersonBundle\\Controller\\AbstractCustomerController",
    "parent": "graviton.person.controller.abstractcustomer",
    // ...
  },
  // ...
}
```

The corresponding internal pull request is incoming soon as well.

Both of them will enable me to put [GRV-1764](https://issue.swisscom.ch/browse/GRV-1764) into review.

I'm going to assigning this to @samsamann when the builds are through since he should be in the loop on this.