### PR TITLE
refactor resource generator field mapper

### DIFF
--- a/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
@@ -80,7 +80,8 @@ class GenerateResourceCommand extends GenerateDoctrineEntityCommand
             $this->input,
             $this->getContainer()->get('filesystem'),
             $this->getContainer()->get('doctrine'),
-            $this->getContainer()->get('kernel')
+            $this->getContainer()->get('kernel'),
+            $this->getContainer()->get('graviton_generator.resourcegenerator.field_mapper')
         );
     }
 }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Inflector\Inflector;
 use Graviton\GeneratorBundle\Definition\DefinitionElementInterface;
 use Graviton\GeneratorBundle\Definition\JsonDefinition;
+use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -55,6 +56,10 @@ class ResourceGenerator extends AbstractGenerator
     /** @var \DomDocument */
     private $serviceDOM;
 
+    /**
+     * @var FieldMapper
+     */
+    private $mapper;
 
     /**
      * Instantiates generator object
@@ -63,13 +68,15 @@ class ResourceGenerator extends AbstractGenerator
      * @param FileSystem     $filesystem fs abstraction layer
      * @param object         $doctrine   dbal
      * @param object         $kernel     app kernel
+     * @param FieldMapper    $mapper     field type mapper
      */
-    public function __construct(InputInterface $input, $filesystem, $doctrine, $kernel)
+    public function __construct(InputInterface $input, $filesystem, $doctrine, $kernel, FieldMapper $mapper)
     {
         $this->input = $input;
         $this->filesystem = $filesystem;
         $this->doctrine = $doctrine;
         $this->kernel = $kernel;
+        $this->mapper = $mapper;
         $this->xmlParameters = new ArrayCollection();
     }
 
@@ -97,20 +104,10 @@ class ResourceGenerator extends AbstractGenerator
         }
 
         // add more info to the fields array
+        $mapper = $this->mapper;
         $fields = array_map(
-            function ($field) {
-                // @todo all this mapping needs to go
-                $mapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
-                $mapper->addMapper(
-                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper
-                );
-                $mapper->addMapper(
-                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper
-                );
-                $mapper->addMapper(
-                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper
-                );
-                return $jsonMapper->map($field, $this->json);
+            function ($field) use ($mapper) {
+                return $mapper->map($field, $this->json);
             },
             $fields
         );

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -6,8 +6,6 @@
 namespace Graviton\GeneratorBundle\Generator;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Inflector\Inflector;
-use Graviton\GeneratorBundle\Definition\DefinitionElementInterface;
 use Graviton\GeneratorBundle\Definition\JsonDefinition;
 use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -101,20 +101,8 @@ class ResourceGenerator extends AbstractGenerator
             function ($field) {
 
                 // @todo all this mapping needs to go
-                // derive types for serializer from document types
-                $field['serializerType'] = $field['type'];
-                if (substr($field['type'], -2) == '[]') {
-                    $field['serializerType'] = sprintf('array<%s>', substr($field['type'], 0, -2));
-                }
-
-                // @todo this assumtion is a hack and needs fixing
-                if ($field['type'] === 'array') {
-                    $field['serializerType'] = 'array<string>';
-                }
-
-                if ($field['type'] === 'object') {
-                    $field['serializerType'] = 'array';
-                }
+                $typeMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
+                $field = $typeMapper->map($field);
 
                 // add singular form
                 $field['singularName'] = Inflector::singularize($field['fieldName']);

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -107,21 +107,8 @@ class ResourceGenerator extends AbstractGenerator
                 $nameMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper;
                 $field = $nameMapper->map($field);
 
-                // add information from our json file (if provided)..
-                if ($this->json instanceof JsonDefinition &&
-                    $this->json->getField($field['fieldName']) instanceof DefinitionElementInterface
-                ) {
-                    $fieldInformation = $this->json->getField($field['fieldName'])
-                        ->getDefAsArray();
-
-                    // in this context, the default type is the doctrine type..
-                    if (isset($fieldInformation['doctrineType'])) {
-                        $fieldInformation['type'] = $fieldInformation['doctrineType'];
-                    }
-
-                    $field = array_merge($field, $fieldInformation);
-                }
-
+                $jsonMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper;
+                $field = $jsonMapper->map($field, $this->json);
                 return $field;
             },
             $fields

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -104,8 +104,8 @@ class ResourceGenerator extends AbstractGenerator
                 $typeMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
                 $field = $typeMapper->map($field);
 
-                // add singular form
-                $field['singularName'] = Inflector::singularize($field['fieldName']);
+                $nameMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper;
+                $field = $nameMapper->map($field);
 
                 // add information from our json file (if provided)..
                 if ($this->json instanceof JsonDefinition &&

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -99,17 +99,18 @@ class ResourceGenerator extends AbstractGenerator
         // add more info to the fields array
         $fields = array_map(
             function ($field) {
-
                 // @todo all this mapping needs to go
-                $typeMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
-                $field = $typeMapper->map($field);
-
-                $nameMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper;
-                $field = $nameMapper->map($field);
-
-                $jsonMapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper;
-                $field = $jsonMapper->map($field, $this->json);
-                return $field;
+                $mapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
+                $mapper->addMapper(
+                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper
+                );
+                $mapper->addMapper(
+                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper
+                );
+                $mapper->addMapper(
+                    new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper
+                );
+                return $jsonMapper->map($field, $this->json);
             },
             $fields
         );

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -100,7 +100,7 @@ class ResourceGenerator extends AbstractGenerator
         $fields = array_map(
             function ($field) {
                 // @todo all this mapping needs to go
-                $mapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
+                $mapper = new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
                 $mapper->addMapper(
                     new \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper
                 );

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldJsonMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldJsonMapper.php
@@ -13,7 +13,7 @@ use Graviton\GeneratorBundle\Definition\DefinitionElementInterface;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class FieldJsonMapper
+class FieldJsonMapper implements FieldMapperInterface
 {
     /**
      * @param array $field   mappable field with type attribute
@@ -21,7 +21,7 @@ class FieldJsonMapper
      *
      * @return array
      */
-    public function map($field, $context)
+    public function map($field, $context = null)
     {
         if ($context instanceof JsonDefinition &&
             $context->getField($field['fieldName']) instanceof DefinitionElementInterface

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldJsonMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldJsonMapper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * add singular names to fields
+ */
+
+namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
+
+use Graviton\GeneratorBundle\Definition\JsonDefinition;
+use Graviton\GeneratorBundle\Definition\DefinitionElementInterface;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldJsonMapper
+{
+    /**
+     * @param array $field   mappable field with type attribute
+     * @param mixed $context context for mapper to check
+     *
+     * @return array
+     */
+    public function map($field, $context)
+    {
+        if ($context instanceof JsonDefinition &&
+            $context->getField($field['fieldName']) instanceof DefinitionElementInterface
+        ) {
+            $fieldInformation = $context->getField($field['fieldName'])
+                ->getDefAsArray();
+
+            // in this context, the default type is the doctrine type..
+            if (isset($fieldInformation['doctrineType'])) {
+                $fieldInformation['type'] = $fieldInformation['doctrineType'];
+            }
+
+            $field = array_merge($field, $fieldInformation);
+        }
+
+        return $field;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * map fields using multiple mappers
+ */
+
+namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
+
+use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapperInterface;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldMapper implements FieldMapperInterface
+{
+    /**
+     * @var FieldMapperInterface
+     */
+    private $mappers = [];
+
+    /**
+     * @param FieldMapperInterface $mapper mapper to add
+     *
+     * @return void
+     */
+    public function addMapper(FieldMapperInterface $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    /**
+     * @param array $field   mappable field with type attribute
+     * @param mixed $context context for mapper to check
+     *
+     * @return array
+     */
+    public function map($field, $context = null)
+    {
+        foreach ($this->mappers as $mapper) {
+            $field = $mapper->map($field, $context);
+        }
+        return $field;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapper.php
@@ -15,7 +15,7 @@ use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapperInterface;
 class FieldMapper implements FieldMapperInterface
 {
     /**
-     * @var FieldMapperInterface
+     * @var FieldMapperInterface[]
      */
     private $mappers = [];
 

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapperInterface.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldMapperInterface.php
@@ -1,18 +1,16 @@
 <?php
 /**
- * add singular names to fields
+ * ResourceGenerator field mapper interface
  */
 
 namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
-
-use Doctrine\Common\Inflector\Inflector;
 
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class FieldNameMapper implements FieldMapperInterface
+interface FieldMapperInterface
 {
     /**
      * @param array $field   mappable field with type attribute
@@ -20,9 +18,5 @@ class FieldNameMapper implements FieldMapperInterface
      *
      * @return array
      */
-    public function map($field, $context = null)
-    {
-        $field['singularName'] = Inflector::singularize($field['fieldName']);
-        return $field;
-    }
+    public function map($field, $context = null);
 }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldNameMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldNameMapper.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * add singular names to fields
+ */
+
+namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
+
+use Doctrine\Common\Inflector\Inflector;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldNameMapper
+{
+    /**
+     * @param array $field mappable field with type attribute
+     *
+     * @return array
+     */
+    public function map($field)
+    {
+        $field['singularName'] = Inflector::singularize($field['fieldName']);
+        return $field;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * map fields for ResourceGenerator
+ *
+ * Use to generate corresponding serializerTypes from json-def fields.
+ */
+
+namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
+
+use Doctrine\Common\Inflector\Inflector;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldTypeMapper
+{
+    /**
+     * @param array $field
+     *
+     * @return array
+     */
+    public function map($field)
+    {
+        $field['serializerType'] = $field['type'];
+        if (substr($field['type'], -2) == '[]') {
+            $field['serializerType'] = sprintf('array<%s>', substr($field['type'], 0, -2));
+        }
+
+        // @todo this assumtion is a hack and needs fixing
+        if ($field['type'] === 'array') {
+            $field['serializerType'] = 'array<string>';
+        }
+
+        if ($field['type'] === 'object') {
+            $field['serializerType'] = 'array';
+        }
+
+        return $field;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Inflector\Inflector;
 class FieldTypeMapper
 {
     /**
-     * @param array $field
+     * @param array $field mappable field with type attribute
      *
      * @return array
      */

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * map fields for ResourceGenerator
+ * map field types for ResourceGenerator
  *
  * Use to generate corresponding serializerTypes from json-def fields.
  */

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
@@ -12,14 +12,15 @@ namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class FieldTypeMapper
+class FieldTypeMapper implements FieldMapperInterface
 {
     /**
-     * @param array $field mappable field with type attribute
+     * @param array $field   mappable field with type attribute
+     * @param mixed $context context for mapper to check
      *
      * @return array
      */
-    public function map($field)
+    public function map($field, $context = null)
     {
         $field['serializerType'] = $field['type'];
         if (substr($field['type'], -2) == '[]') {

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/FieldTypeMapper.php
@@ -7,8 +7,6 @@
 
 namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
 
-use Doctrine\Common\Inflector\Inflector;
-
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License

--- a/src/Graviton/GeneratorBundle/Resources/config/services.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/services.xml
@@ -8,9 +8,28 @@
         <parameter key="graviton_generator.definition.loader.strategy.file.class">Graviton\GeneratorBundle\Definition\Loader\Strategy\FileStrategy</parameter>
         <parameter key="graviton_generator.definition.loader.strategy.dir.class">Graviton\GeneratorBundle\Definition\Loader\Strategy\DirStrategy</parameter>
         <parameter key="graviton_generator.definition.loader.strategy.scan.class">Graviton\GeneratorBundle\Definition\Loader\Strategy\ScanStrategy</parameter>
+        <parameter key="graviton_generator.resourcegenerator.field_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper</parameter>
+        <parameter key="graviton_generator.resourcegenerator.field_type_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper</parameter>
+        <parameter key="graviton_generator.resourcegenerator.field_name_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper</parameter>
+        <parameter key="graviton_generator.resourcegenerator.field_json_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper</parameter>
     </parameters>
 
     <services>
+        <service id="graviton_generator.resourcegenerator.field_mapper" class="%graviton_generator.resourcegenerator.field_mapper.class%">
+            <call method="addMapper">
+                <argument type="service" id="graviton_generator.resourcegenerator.field_type_mapper"/>
+            </call>
+            <call method="addMapper">
+                <argument type="service" id="graviton_generator.resourcegenerator.field_name_mapper"/>
+            </call>
+            <call method="addMapper">
+                <argument type="service" id="graviton_generator.resourcegenerator.field_json_mapper"/>
+            </call>
+        </service>
+        <service id="graviton_generator.resourcegenerator.field_type_mapper" class="%graviton_generator.resourcegenerator.field_type_mapper.class%"/>
+        <service id="graviton_generator.resourcegenerator.field_name_mapper" class="%graviton_generator.resourcegenerator.field_name_mapper.class%"/>
+        <service id="graviton_generator.resourcegenerator.field_json_mapper" class="%graviton_generator.resourcegenerator.field_json_mapper.class%"/>
+        
         <service id="graviton_generator.definition.loader" class="%graviton_generator.definition.loader.class%">
             <call method="addStrategy">
                 <argument type="service" id="graviton_generator.definition.loader.strategy.file"/>

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldJsonMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldJsonMapperTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * validate overriding of mapping from json-defs
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Generator\ResourceGenerator;
+
+use \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldJsonMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider mapData
+     *
+     * @param array $field    field to map
+     * @param array $def      field def ala JsonDef
+     * @param array $expected expected result
+     *
+     * @return void
+     */
+    public function testMap($field, $json, $expected)
+    {
+        $sut = new FieldJsonMapper;
+
+        $jsonDouble = $this->getMockBuilder('\Graviton\GeneratorBundle\Definition\JsonDefinition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $fieldDouble = $this->getMockBuilder('\Graviton\GeneratorBundle\Definition\JsonDefinitionField')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $jsonDouble->expects($this->any())
+            ->method('getField')
+            ->with($field['fieldName'])
+            ->willReturn($fieldDouble);
+
+        $fieldDouble->expects($this->once())
+            ->method('getDefAsArray')
+            ->willReturn($json);
+
+        $this->assertEquals($expected, $sut->map($field, $jsonDouble));
+    }
+
+    /**
+     * @return array
+     */
+    public function mapData()
+    {
+        return [
+            'empty jsondef' => [
+                ['fieldName' => 'test'],
+                [],
+                ['fieldName' => 'test'],
+            ],
+            'string field' => [
+                ['fieldName' => 'foo'],
+                ['doctrineType' => 'string'],
+                ['fieldName' => 'foo', 'doctrineType' => 'string', 'type' => 'string'],
+            ],
+        ];
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldJsonMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldJsonMapperTest.php
@@ -23,7 +23,7 @@ class FieldJsonMapperTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testMap($field, $json, $expected)
+    public function testMap($field, $def, $expected)
     {
         $sut = new FieldJsonMapper;
 
@@ -41,7 +41,7 @@ class FieldJsonMapperTest extends \PHPUnit_Framework_TestCase
 
         $fieldDouble->expects($this->once())
             ->method('getDefAsArray')
-            ->willReturn($json);
+            ->willReturn($def);
 
         $this->assertEquals($expected, $sut->map($field, $jsonDouble));
     }

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
@@ -32,6 +32,6 @@ class FieldMapperTest extends \PHPUnit_Framework_TestCase
         $sut->addMapper($mapperDouble);
         $sut->addMapper($mapperDouble);
 
-        $this->assertEquals($sut->map([], $context), []);
+        $this->assertEquals([], $sut->map([], $context));
     }
 }

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * validate field mapper
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Generator\ResourceGenerator;
+
+use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     */
+    public function testWillCallMapperr()
+    {
+        $sut = new FieldMapper;
+
+        $context = new \StdClass;
+
+        $mapperDouble = $this->getMock('\Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapperInterface');
+        $mapperDouble->expects($this->exactly(2))
+            ->method('map')
+            ->with([], $context)
+            ->willReturn([]);
+
+        $sut->addMapper($mapperDouble);
+        $sut->addMapper($mapperDouble);
+
+        $this->assertEquals($sut->map([], $context), []);
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldNameMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldNameMapperTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * validate mapping of names to singular
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Generator\ResourceGenerator;
+
+use \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldNameMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider mapData
+     *
+     * @param string $plural   plural form of string
+     * @param string $singular singular form of string
+     *
+     * @return void
+     */
+    public function testMap($plural, $singular)
+    {
+        $sut = new FieldNameMapper;
+
+        $field = [
+            'fieldName' => $plural
+        ];
+        $expected = [
+            'fieldName' => $plural,
+            'singularName' => $singular
+        ];
+        $this->assertEquals($sut->map($field), $expected);
+    }
+
+    /**
+     * @return array
+     */
+    public function mapData()
+    {
+        return [
+            ['patches', 'patch'],
+            ['names', 'name'],
+            ['fields', 'field'],
+            ['buses', 'bus'],
+        ];
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldNameMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldNameMapperTest.php
@@ -33,7 +33,7 @@ class FieldNameMapperTest extends \PHPUnit_Framework_TestCase
             'fieldName' => $plural,
             'singularName' => $singular
         ];
-        $this->assertEquals($sut->map($field), $expected);
+        $this->assertEquals($expected, $sut->map($field));
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
@@ -26,7 +26,7 @@ class FieldTypeMapperTest extends \PHPUnit_Framework_TestCase
     {
         $sut = new FieldTypeMapper;
 
-        $this->assertEquals($sut->map($field), $expected);
+        $this->assertEquals($expected, $sut->map($field));
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * validate field type mapper
+ */
+
+namespace Graviton\GeneratorBundle\Tests\ResourceGenerator;
+
+use \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldTypeMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider mapData
+     *
+     * @param array $field    field to be mapped
+     * @param array $expected mapped field
+     *
+     * @return void
+     */
+    public function testMap($field, $expected)
+    {
+        $sut = new FieldTypeMapper;
+
+        $this->assertEquals($sut->map($field), $expected);
+    }
+
+    /**
+     * @return array
+     */
+    public function mapData()
+    {
+        return [
+            'simple string' => [
+                ['type' => 'string'],
+                ['type' => 'string', 'serializerType' => 'string'],
+            ],
+            'basic array' => [
+                ['type' => 'array'],
+                ['type' => 'array', 'serializerType' => 'array<string>'],
+            ],
+            'basic class' => [
+                ['type' => 'StdClass[]'],
+                ['type' => 'StdClass[]', 'serializerType' => 'array<StdClass>']
+            ],
+            'generic object' => [
+                ['type' => 'object'],
+                ['type' => 'object', 'serializerType' => 'array']
+            ]
+        ];
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldTypeMapperTest.php
@@ -3,7 +3,7 @@
  * validate field type mapper
  */
 
-namespace Graviton\GeneratorBundle\Tests\ResourceGenerator;
+namespace Graviton\GeneratorBundle\Tests\Generator\ResourceGenerator;
 
 use \Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper;
 


### PR DESCRIPTION
This replaced my much older PR #34 and finally refactors a rather complex lambda function in ``Graviton\GeneratorBundle\Generator\ResourceGenerator``.

I should probably avoid using such lambda function since it never takes long until someone else comes along and adds much more complexity to a short function without doing the refactor that would be needed in that moment.

This cleans up one such occurrence and replaces it with heaps of tested code.

This is still not perfect (ie. it still uses ``array_map`` and the command is still not configured through the di) so it's not as complete as #34 was. Nevertheless I feel like this already is worthy to merge since it makes the reason I started #34 sane again (aka field-mapping is now tested and thus documented).