### PR TITLE
parameter builder for resource generator

### DIFF
--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Graviton\GeneratorBundle\Definition\JsonDefinition;
 use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
 use Graviton\GeneratorBundle\Generator\ResourceGenerator\ParameterBuilder;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -162,7 +162,7 @@ class ResourceGenerator extends AbstractGenerator
             ->setParameter('format', $format)
             ->setParameter('json', $this->json)
             ->setParameter('fields', $fields)
-            ->setParameter('ibasename', $basename)
+            ->setParameter('basename', $basename)
             ->getParameters();
 
         $this->generateDocument($parameters, $dir, $document, $withRepository);

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -80,10 +80,11 @@ class ResourceGenerator extends AbstractGenerator
     /**
      * Instantiates generator object
      *
-     * @param Filesystem          $filesystem fs abstraction layer
-     * @param DoctrineRegistry    $doctrine   odm registry
-     * @param HttpKernelInterface $kernel     app kernel
-     * @param FieldMapper         $mapper     field type mapper
+     * @param Filesystem          $filesystem       fs abstraction layer
+     * @param DoctrineRegistry    $doctrine         odm registry
+     * @param HttpKernelInterface $kernel           app kernel
+     * @param FieldMapper         $mapper           field type mapper
+     * @param ParameterBuilder    $parameterBuilder param builder
      */
     public function __construct(
         Filesystem $filesystem,

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
@@ -42,6 +42,7 @@ class ParameterBuilder
                 // we leave it in the document though but we don't wanna output it..
                 $this->parameters['noIdField'] = true;
             }
+            $this->parameters['parent'] = $value->getParentService();
         } else {
             $this->parameters[$name] = $value;
         }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * generate params array for various calls
+ */
+
+namespace Graviton\GeneratorBundle\Generator\ResourceGenerator;
+
+use Graviton\GeneratorBundle\Definition\JsonDefinition;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ParameterBuilder
+{
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @param string $name  parameter name
+     * @param mixed  $value parameter to set
+     */
+    public function setParameter($name, $value)
+    {
+        if ($name === 'basename') {
+            $this->parameters['bundle_basename'] = $value;
+            $this->parameters['extension_alias'] = Container::underscore($value);
+        } elseif ($name === 'json') {
+            $this->parameters['json'] = $value;
+            // if we have data for id field, pass it along
+            $idField = $value->getField('id');
+            if (!is_null($idField)) {
+                $this->parameters['idField'] = $idField->getDefAsArray();
+            } else {
+                // if there is a json file and no id defined - so we don't do one here..
+                // we leave it in the document though but we don't wanna output it..
+                $this->parameters['noIdField'] = true;
+            }
+        } else {
+            $this->parameters[$name] = $value;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator/ParameterBuilder.php
@@ -23,6 +23,8 @@ class ParameterBuilder
     /**
      * @param string $name  parameter name
      * @param mixed  $value parameter to set
+     *
+     * @return self
      */
     public function setParameter($name, $value)
     {
@@ -43,6 +45,7 @@ class ParameterBuilder
         } else {
             $this->parameters[$name] = $value;
         }
+        return $this;
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Resources/config/services.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/services.xml
@@ -12,6 +12,7 @@
         <parameter key="graviton_generator.resourcegenerator.field_type_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldTypeMapper</parameter>
         <parameter key="graviton_generator.resourcegenerator.field_name_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldNameMapper</parameter>
         <parameter key="graviton_generator.resourcegenerator.field_json_mapper.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldJsonMapper</parameter>
+        <parameter key="graviton_generator.resourcegenerator.parameter_builder.class">Graviton\GeneratorBundle\Generator\ResourceGenerator\ParameterBuilder</parameter>
         <parameter key="graviton_generator.generator.resourcegenerator.class">Graviton\GeneratorBundle\Generator\ResourceGenerator</parameter>
         <parameter key="graviton_generator.command.generateresource.class">Graviton\GeneratorBundle\Command\GenerateResourceCommand</parameter>
     </parameters>
@@ -51,11 +52,14 @@
             </call>
         </service>
 
+        <service id="graviton_generator.resourcegenerator.parameter_builder" class="%graviton_generator.resourcegenerator.parameter_builder.class%"/>
+
         <service id="graviton_generator.generator.resourcegenerator" class="%graviton_generator.generator.resourcegenerator.class%">
             <argument type="service" id="filesystem"/>
             <argument type="service" id="doctrine"/>
             <argument type="service" id="kernel"/>
             <argument type="service" id="graviton_generator.resourcegenerator.field_mapper"/>
+            <argument type="service" id="graviton_generator.resourcegenerator.parameter_builder"/>
         </service>
 
         <!-- commands -->

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * validate resource-generators param builder
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Generator\ResourceGenerator;
+
+use Graviton\GeneratorBundle\Generator\ResourceGenerator\ParameterBuilder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider buildBasicParamData
+     *
+     * @param string $document document name
+     * @param string $index    param index
+     *
+     * @return void
+     */
+    public function testBuildDocumentParam($document, $index)
+    {
+        $sut = new ParameterBuilder();
+
+        $sut->setParameter($index, $document);
+        $parameters = $sut->getParameters();
+        $this->assertEquals($document, $parameters[$index]);
+    }
+
+    /**
+     * @return array
+     */
+    public function buildBasicParamData()
+    {
+        return [
+            ['document', 'document'],
+            ['My\Longer\Document\Name', 'document'],
+            ['someBaseBundleNamespace', 'base'],
+            ['BundleName', 'bundle'],
+        ];
+    }
+
+    /**
+     * @dataProvider buildBasenameParams
+     *
+     * @param string $basename   basename
+     * @param string $underscored underscored form of basename
+     *
+     * @return void
+     */
+    public function testBuildBasenameParams($basename, $underscored)
+    {
+        $sut = new ParameterBuilder();
+
+        $sut->setParameter('basename', $basename);
+        $parameters = $sut->getParameters();
+        $this->assertEquals($basename, $parameters['bundle_basename']);
+        $this->assertEquals($underscored, $parameters['extension_alias']);
+    }
+
+    /**
+     * @returns void
+     */
+    public function buildBasenameParams()
+    {
+        return [
+            ['Name', 'name'],
+            ['BaseName', 'base_name'],
+        ];
+    }
+
+    /**
+     * @dataProvider buildJsonParamsIdFieldDefData
+     *
+     * @return void
+     */
+    public function testBuildJsonParamsIdFieldDef($idFieldDef)
+    {
+        $sut = new ParameterBuilder;
+
+        $jsonDefDouble = $this->getMockBuilder('Graviton\GeneratorBundle\Definition\JsonDefinition')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fieldDouble = null;
+        if (!is_null($idFieldDef)) {
+            $fieldDouble = $this->getMockBuilder('Graviton\GeneratorBundle\Definition\JsonDefinitionField')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        $jsonDefDouble->expects($this->once())
+            ->method('getField')
+            ->willReturn($fieldDouble);
+
+        if (!is_null($idFieldDef)) {
+            $fieldDouble->expects($this->once())
+                ->method('getDefAsArray')
+                ->willReturn($idFieldDef);
+        }
+
+        $sut->setParameter('json', $jsonDefDouble);
+
+        $parameters = $sut->getParameters();
+
+        if (is_null($idFieldDef)) {
+            $idFieldDef = [];
+        }
+        $expected = ['json' => $jsonDefDouble];
+        if ($idFieldDef === []) {
+            $expected['noIdField'] = true;
+        } else {
+            $expected['idField'] = $idFieldDef;
+        }
+        $this->assertEquals($expected, $parameters);
+    }
+
+    /**
+     * @return array
+     */
+    public function buildJsonParamsIdFieldDefData()
+    {
+        return [
+            [null],
+            [['type' => 'string']]
+        ];
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
@@ -26,7 +26,7 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $sut = new ParameterBuilder();
 
-        $sut->setParameter($index, $document);
+        $this->assertEquals($sut, $sut->setParameter($index, $document));
         $parameters = $sut->getParameters();
         $this->assertEquals($document, $parameters[$index]);
     }
@@ -56,7 +56,8 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $sut = new ParameterBuilder();
 
-        $sut->setParameter('basename', $basename);
+        $this->assertEquals($sut, $sut->setParameter('basename', $basename));
+
         $parameters = $sut->getParameters();
         $this->assertEquals($basename, $parameters['bundle_basename']);
         $this->assertEquals($underscored, $parameters['extension_alias']);
@@ -103,7 +104,7 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
                 ->willReturn($idFieldDef);
         }
 
-        $sut->setParameter('json', $jsonDefDouble);
+        $this->assertEquals($sut, $sut->setParameter('json', $jsonDefDouble));
 
         $parameters = $sut->getParameters();
 

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/ParameterBuilderTest.php
@@ -47,7 +47,7 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider buildBasenameParams
      *
-     * @param string $basename   basename
+     * @param string $basename    basename
      * @param string $underscored underscored form of basename
      *
      * @return void
@@ -64,7 +64,7 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @returns void
+     * @return array
      */
     public function buildBasenameParams()
     {
@@ -77,9 +77,12 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider buildJsonParamsIdFieldDefData
      *
+     * @param array|null $idFieldDef field definition or null if not a json def
+     * @param string     $parent     parent service name
+     *
      * @return void
      */
-    public function testBuildJsonParamsIdFieldDef($idFieldDef)
+    public function testBuildJsonParamsIdFieldDef($idFieldDef, $parent = null)
     {
         $sut = new ParameterBuilder;
 
@@ -104,6 +107,13 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
                 ->willReturn($idFieldDef);
         }
 
+        if (!is_null($parent)) {
+            $jsonDefDouble
+                ->expects($this->once())
+                ->method('getParentService')
+                ->willReturn($parent);
+        }
+
         $this->assertEquals($sut, $sut->setParameter('json', $jsonDefDouble));
 
         $parameters = $sut->getParameters();
@@ -111,7 +121,7 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
         if (is_null($idFieldDef)) {
             $idFieldDef = [];
         }
-        $expected = ['json' => $jsonDefDouble];
+        $expected = ['json' => $jsonDefDouble, 'parent' => $parent];
         if ($idFieldDef === []) {
             $expected['noIdField'] = true;
         } else {
@@ -127,7 +137,8 @@ class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [null],
-            [['type' => 'string']]
+            [['type' => 'string']],
+            [['type' => 'int'], 'parent.service'],
         ];
     }
 }


### PR DESCRIPTION
Splits out the ``$parameters`` building part of ``ResourceGenerator::generate()`` into its own class.

While the new ``ParameterBuilder`` class could be cleaner and more decoupled, this is nevertheless better than what we had before.

I'm not going any further on this due to the fact that ~~``ResourceGenerator``~~``ResourceGenerator::generate()`` isn't our worst smell anymore and also because the remaining refactor is rather small and straightforward.

If anyone wants to pick up the torch and carry on from here, you're welcome to refactor ``ParameterBuilder::setParameter()`` into something less complex.