### PR TITLE
Remove container dependency in MainController

### DIFF
--- a/src/Graviton/CoreBundle/Controller/MainController.php
+++ b/src/Graviton/CoreBundle/Controller/MainController.php
@@ -89,7 +89,7 @@ class MainController
     /**
      * Determines what service endpoints are available.
      *
-     * @param array  $optionRoutes List of routing options.
+     * @param array $optionRoutes List of routing options.
      *
      * @return array
      */

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -17,9 +17,10 @@
     <services>
         <service id="graviton.core.controller.main"
                  class="%graviton.core.controller.main.class%">
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+             <argument type="service" id="router"/>
+             <argument type="service" id="graviton.rest.response" strict="false"/>
+             <argument type="service" id="graviton.rest.restutils"/>
+             <argument type="service" id="templating"/>
         </service>
         <service id="graviton.core.controller.app"
                  class="%graviton.core.controller.app.class%"

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -119,13 +119,18 @@ class MainControllerTest extends RestTestCase
             )
             ->will($this->returnValue("http://localhost/core/app"));
 
+        $responseDouble = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $restUtilsDouble = $this->getMock('Graviton\RestBundle\Service\RestUtils');
+        $templateDouble = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+
         $controller = $this->getProxyBuilder('\Graviton\CoreBundle\Controller\MainController')
+            ->setConstructorArgs([$routerDouble, $responseDouble, $restUtilsDouble, $templateDouble])
             ->setMethods(array('prepareLinkHeader'))
             ->getProxy();
 
         $this->assertEquals(
             '<http://localhost/core/app>; rel="apps"; type="application/json"',
-            $controller->prepareLinkHeader($routerDouble)
+            $controller->prepareLinkHeader()
         );
     }
 
@@ -168,6 +173,9 @@ class MainControllerTest extends RestTestCase
                 )
             );
 
+        $responseDouble = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $restUtilsDouble = $this->getMock('Graviton\RestBundle\Service\RestUtils');
+        $templateDouble = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
 
         $optionRoutes = [
             "graviton.core.rest.app.options"     => $routerDouble,
@@ -175,6 +183,7 @@ class MainControllerTest extends RestTestCase
         ];
 
         $controller = $this->getProxyBuilder('\Graviton\CoreBundle\Controller\MainController')
+            ->setConstructorArgs([$routerDouble, $responseDouble, $restUtilsDouble, $templateDouble])
             ->setMethods(array('determineServices'))
             ->getProxy();
 
@@ -189,7 +198,7 @@ class MainControllerTest extends RestTestCase
                     'profile' => 'http://localhost/schema/core/product/collection'
                 ],
             ],
-            $controller->determineServices($routerDouble, $optionRoutes)
+            $controller->determineServices($optionRoutes)
         );
     }
 }


### PR DESCRIPTION
I would have also marked the Controller as final if it the final keyword hadn't been broken by proxy-object based testing (which I believe to be silly in itself, IMHO things should either be public and directly tested or in the need of refactoring as they are not properly exposed, but that discussion is for another time).

Also, if you're interested, this is the ``.git/hooks/pre-commit`` I wrote after 4ae30f9 failed on travis:

```bash
exec /usr/local/bin/composer check
```