### PR TITLE
Switch to constructor injection, add final keyword and don't use container in most cases

### DIFF
--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -97,9 +97,10 @@
 
         <!-- restUtils service - a service providing some helpers dealing with services -->
         <service id="graviton.rest.restutils" class="Graviton\RestBundle\Service\RestUtils">
-            <call method="setContainer">
-                <argument type="service" id="service_container"></argument>
-            </call>
+            <argument type="service" id="service_container"></argument>
+            <argument type="service" id="router"/>
+            <argument type="service" id="graviton.rest.serializer"/>
+            <argument type="service" id="graviton.rest.serializer.serializercontext"/>
         </service>
 
         <!-- Graviton rest event stuff -->

--- a/src/Graviton/RestBundle/Service/RestUtils.php
+++ b/src/Graviton/RestBundle/Service/RestUtils.php
@@ -5,8 +5,12 @@
 
 namespace Graviton\RestBundle\Service;
 
-use Graviton\RestBundle\Controller\RestController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Router;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializationContext;
+use Graviton\RestBundle\Controller\RestController;
 
 /**
  * A service (meaning symfony service) providing some convenience stuff when dealing with our RestController
@@ -16,24 +20,44 @@ use Symfony\Component\Routing\Route;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class RestUtils
+final class RestUtils
 {
-
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface service_container
+     * @var ContainerInterface
      */
     private $container;
 
     /**
-     * sets the container
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container service_container
-     *
-     * @return void
+     * @var Serializer
      */
-    public function setContainer($container = null)
-    {
+    private $serializer;
+
+    /**
+     * @var SerializationContext
+     */
+    private $serializerContext;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * @param ContainerInterface   $container         container
+     * @param Router               $router            router
+     * @param Serializer           $serializer        serializer
+     * @param SerializationContext $serializerContext context for serializer
+     */
+    public function __construct(
+        ContainerInterface $container,
+        Router $router,
+        Serializer $serializer,
+        SerializationContext $serializerContext = null
+    ) {
         $this->container = $container;
+        $this->serializer = $serializer;
+        $this->serializerContext = $serializerContext;
+        $this->router = $router;
     }
 
     /**
@@ -110,11 +134,11 @@ class RestUtils
     /**
      * Get the serializer
      *
-     * @return \JMS\Serializer\Serializer
+     * @return Serializer
      */
     public function getSerializer()
     {
-        return $this->container->get('graviton.rest.serializer');
+        return $this->serializer;
     }
 
     /**
@@ -124,7 +148,7 @@ class RestUtils
      */
     public function getSerializerContext()
     {
-        return clone $this->container->get('graviton.rest.serializer.serializercontext');
+        return clone $this->serializerContext;
     }
 
     /**
@@ -135,7 +159,7 @@ class RestUtils
      */
     public function getOptionRoutes()
     {
-        $router = $this->container->get('router');
+        $router = $this->router;
         $ret = array_filter(
             $router->getRouteCollection()
                    ->all(),
@@ -163,9 +187,9 @@ class RestUtils
     public function getRoutesByBasename($baseName)
     {
         $ret = array();
-        foreach ($this->container->get('router')
-                                 ->getRouteCollection()
-                                 ->all() as $routeName => $route) {
+        foreach ($this->router
+                      ->getRouteCollection()
+                      ->all() as $routeName => $route) {
             if (preg_match('/^' . $baseName . '/', $routeName)) {
                 $ret[$routeName] = $route;
             }


### PR DESCRIPTION
We still need to get rid of container use in ``getControllerFromRoute``. I might do a factory on that but have not really decided how to proceed yet.

I'm pretty sure this is also done in a similar fashion elsewhere so that adding such a factory will probably have other implications elsewhere as well.

At this stage the most valuable part of this PR is probably adding the ``final`` keyword. While the rest doesn't fully achieve the target of getting rid of the container-dep it still seems worthy.