### PR TITLE
Fix camel case services in extref

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "~2.1",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "^0.2"
+        "graviton/test-services-bundle": "^0.3"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2f3f24310e4b9a8f96a4caea78e069b6",
+    "hash": "2d61c48eeadc0dc825e356be8c9a8e94",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -2299,7 +2299,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/f1734151aecb55b95ed9d6dcfb47b61eb4c753fd",
+                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/9d52413665284f9c96e0cef399fc14e68ac0aa5a",
                 "reference": "f1734151aecb55b95ed9d6dcfb47b61eb4c753fd",
                 "shasum": ""
             },
@@ -3793,16 +3793,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.2.0",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "281a8d3e522a8b35cf466484bcc1326ec1b9042c"
+                "reference": "79e2faa69c63c787abc5dd91914d82671fa8911e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/281a8d3e522a8b35cf466484bcc1326ec1b9042c",
-                "reference": "281a8d3e522a8b35cf466484bcc1326ec1b9042c",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/79e2faa69c63c787abc5dd91914d82671fa8911e",
+                "reference": "79e2faa69c63c787abc5dd91914d82671fa8911e",
                 "shasum": ""
             },
             "type": "library",
@@ -3817,10 +3817,10 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/0.2.0",
+                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.3.0",
                 "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
             },
-            "time": "2015-05-22 05:14:10"
+            "time": "2015-05-28 09:51:08"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/src/Graviton/DocumentBundle/Tests/Types/ExtReferenceTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Types/ExtReferenceTest.php
@@ -72,6 +72,17 @@ class ExtReferenceTest extends \PHPUnit_Framework_TestCase
                     'id' => '[a-zA-Z0-9\-_\/]+',
                 ]
             ),
+            new Route(
+                '/hans/showcase/{id}',
+                [
+                    '_controller' => 'gravitondyn.showcase.controller.showcase:getAction',
+                    '_format' => '~'
+                ],
+                [
+                    '_method' => 'GET',
+                    'id' => '[a-zA-Z0-9\-_\/]+',
+                ]
+            ),
         ];
     }
 
@@ -115,6 +126,7 @@ class ExtReferenceTest extends \PHPUnit_Framework_TestCase
             [
                 'App' => 'graviton.core.rest.app.get',
                 'Language' => 'graviton.i18n.rest.language.get',
+                'ShowCase' => 'gravitondyn.showcase.rest.showcase.get',
             ]
         );
 
@@ -131,6 +143,7 @@ class ExtReferenceTest extends \PHPUnit_Framework_TestCase
         return [
             ['http://localhost/core/app/test', ['$ref' => 'App', '$id' => 'test']],
             ['/core/app/test', ['$ref' => 'App', '$id' => 'test']],
+            ['http://localhost/hans/showcase/blah', ['$ref' => 'ShowCase', '$id' => 'blah']],
         ];
     }
 

--- a/src/Graviton/DocumentBundle/Tests/Types/ExtReferenceTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Types/ExtReferenceTest.php
@@ -132,7 +132,7 @@ class ExtReferenceTest extends \PHPUnit_Framework_TestCase
 
         $result = $sut->convertToDatabaseValue($url);
 
-        $this->assertEquals($result, $expected);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/src/Graviton/DocumentBundle/Types/ExtReference.php
+++ b/src/Graviton/DocumentBundle/Types/ExtReference.php
@@ -162,7 +162,7 @@ class ExtReference extends Type
 
             list($routeService) = explode(':', $route->getDefault('_controller'));
             list($core, $bundle,,$name) = explode('.', $routeService);
-            $serviceName = implode('.' ,[$core, $bundle, 'rest', $name, 'get']);
+            $serviceName = implode('.', [$core, $bundle, 'rest', $name, 'get']);
             $collection = array_search($serviceName, $this->mapping);
         }
 

--- a/src/Graviton/DocumentBundle/Types/ExtReference.php
+++ b/src/Graviton/DocumentBundle/Types/ExtReference.php
@@ -102,10 +102,10 @@ class ExtReference extends Type
         $path = $this->getPathFromUrl($value);
 
         foreach ($this->router->getRouteCollection()->all() as $route) {
+            list($collection, $id) = $this->getDataFromRoute($route, $path);
             if (!empty($collection) && !empty($id)) {
                 return \MongoDBRef::create($collection, $id);
             }
-            list($collection, $id) = $this->getDataFromRoute($route, $path);
         }
 
         if (empty($collection) || empty($id)) {
@@ -161,8 +161,9 @@ class ExtReference extends Type
             $id = $matches['id'];
 
             list($routeService) = explode(':', $route->getDefault('_controller'));
-            list(,,,$name) = explode('.', $routeService);
-            $collection = ucfirst($name);
+            list($core, $bundle,,$name) = explode('.', $routeService);
+            $serviceName = implode('.' ,[$core, $bundle, 'rest', $name, 'get']);
+            $collection = array_search($serviceName, $this->mapping);
         }
 
         return [$collection, $id];


### PR DESCRIPTION
With these changes using $ref references that point to a service that has a camel-cased collection name in MongoDB should work.

* [x] get rid of ``ucfirst()`` in ``DocumentBundle/Types/ExtReference.php``
* [ ] get rid of ``ucfirst()`` in ``DocumentBundle/DependencyInjection/Compiler/ExtRefMappingCompilerPass.php``