### PR TITLE
Add colon (:) support in rql strings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1610,16 +1610,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "v2.0.0-alpha5",
+            "version": "v2.0.0-alpha6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "41867c0d862707e83da42976aa882d1d57bd28ae"
+                "reference": "221fe6bc0ca3ad42be4f53bf36f90ca46a72b881"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/41867c0d862707e83da42976aa882d1d57bd28ae",
-                "reference": "41867c0d862707e83da42976aa882d1d57bd28ae",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/221fe6bc0ca3ad42be4f53bf36f90ca46a72b881",
+                "reference": "221fe6bc0ca3ad42be4f53bf36f90ca46a72b881",
                 "shasum": ""
             },
             "require": {
@@ -1662,7 +1662,7 @@
                 "rest",
                 "rql"
             ],
-            "time": "2015-05-18 10:56:59"
+            "time": "2015-05-28 13:23:09"
         },
         {
             "name": "graviton/rql-parser-bundle",
@@ -2299,7 +2299,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/f1734151aecb55b95ed9d6dcfb47b61eb4c753fd",
+                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/9d52413665284f9c96e0cef399fc14e68ac0aa5a",
                 "reference": "f1734151aecb55b95ed9d6dcfb47b61eb4c753fd",
                 "shasum": ""
             },


### PR DESCRIPTION
Makes [GRV-1786](https://issue.swisscom.ch/browse/GRV-1786) ready for review. I'll still have to deploy it though.