### PR TITLE
fix camel case services in extref

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/AbstractExtRefCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/AbstractExtRefCompilerPass.php
@@ -24,15 +24,10 @@ abstract class AbstractExtRefCompilerPass implements CompilerPassInterface
      */
     final public function process(ContainerBuilder $container)
     {
-        $gravitonServices = array_filter(
-            $container->getServiceIds(),
-            function ($id) {
-                return substr(strtolower($id), 0, 8) == 'graviton' &&
-                    strpos(strtolower($id), 'controller') !== false &&
-                    strtolower($id) !== 'graviton.rest.controller';
-            }
+        $gravitonServices = $container->findTaggedServiceIds(
+            'graviton.rest'
         );
-        $this->processServices($container, $gravitonServices);
+        $this->processServices($container, array_keys($gravitonServices));
     }
 
     /**

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefMappingCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefMappingCompilerPass.php
@@ -31,7 +31,15 @@ class ExtRefMappingCompilerPass extends AbstractExtRefCompilerPass
         $map = [];
         foreach ($services as $id) {
             list($ns, $bundle,, $doc) = explode('.', $id);
-            $map[ucfirst($doc)] = implode('.', [$ns, $bundle, 'rest', $doc, 'get']);
+
+            $tag = $container->getDefinition($id)->getTag('graviton.rest');
+            if (!empty($tag[0]) && array_key_exists('collection', $tag[0])) {
+                $collection = $tag[0]['collection'];
+            } else {
+                $collection = ucfirst($doc);
+            }
+
+            $map[$collection] = implode('.', [$ns, $bundle, 'rest', $doc, 'get']);
         }
         $container->setParameter('graviton.document.type.extref.mapping', $map);
     }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -559,6 +559,9 @@ class ResourceGenerator extends AbstractGenerator
 
                 // get stuff from json definition
                 if ($this->json instanceof JsonDefinition) {
+                    // id is also name of collection in mongodb
+                    $this->addAttributeToNode('collection', $this->json->getId(), $dom, $tagNode);
+
                     // is this read only?
                     if ($this->json->isReadOnlyService()) {
                         $this->addAttributeToNode('read-only', 'true', $dom, $tagNode);


### PR DESCRIPTION
This continues where I left off with #126. Building the map of extref value now takes into account that the name of a collection might have to be modeled after the id from a json definition.