### PR TITLE
use symfony/finder in ExtRefFieldsCompilerPass

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -41,7 +41,7 @@ class ExtRefFieldsCompilerPass extends AbstractExtRefCompilerPass
             $tag = $container->getDefinition($id)->getTag('graviton.rest');
             if (!empty($tag[0]['collection'])) {
                 $doc = $tag[0]['collection'];
-                $bundle = $tag[0]['collection'];
+                $bundle = ucfirst($tag[0]['collection']);
             }
             $this->loadFields($map, $ns, $bundle, $doc);
         }

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -79,7 +79,7 @@ class ExtRefFieldsCompilerPass extends AbstractExtRefCompilerPass
                         '..',
                         '..',
                         ucfirst($ns),
-                        $bundle.'Bundle',
+                        ucfirst($bundle).'Bundle',
                         'Resources',
                         'config',
                         'doctrine'

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -86,7 +86,7 @@ class ExtRefFieldsCompilerPass extends AbstractExtRefCompilerPass
                     ]
                 )
             )->name(
-                $doc.'.mongodb.xml'
+                ucfirst($doc).'.mongodb.xml'
             );
 
         if ($files->count() != 1) {


### PR DESCRIPTION
This fixes the compiler pass so it also works for generated bundles that have mixed-case document names.

This is not a perfect solution to the problem, I'll have to refactor this when I finish adding forms support since I need it there anyway...