### PR TITLE
Use proper HttpException as base

### DIFF
--- a/src/Graviton/ExceptionBundle/Exception/DeserializationException.php
+++ b/src/Graviton/ExceptionBundle/Exception/DeserializationException.php
@@ -24,6 +24,6 @@ final class DeserializationException extends RestException
      */
     public function __construct($message = "Deserialization Error", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_INTERNAL_SERVER_ERROR, $prev);
+        parent::__construct(Response::HTTP_INTERNAL_SERVER_ERROR, $message, $prev);
     }
 }

--- a/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
+++ b/src/Graviton/ExceptionBundle/Exception/MalformedInputException.php
@@ -32,7 +32,7 @@ final class MalformedInputException extends RestException
      */
     public function __construct($message = "Malformed input", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_INTERNAL_SERVER_ERROR, $prev);
+        parent::__construct(Response::HTTP_INTERNAL_SERVER_ERROR, $message, $prev);
     }
 
     /**

--- a/src/Graviton/ExceptionBundle/Exception/NoInputException.php
+++ b/src/Graviton/ExceptionBundle/Exception/NoInputException.php
@@ -24,6 +24,6 @@ final class NoInputException extends RestException
      */
     public function __construct($message = "No Content", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_BAD_REQUEST, $prev);
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message, $prev);
     }
 }

--- a/src/Graviton/ExceptionBundle/Exception/NotFoundException.php
+++ b/src/Graviton/ExceptionBundle/Exception/NotFoundException.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\ExceptionBundle\Exception;
 
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -14,8 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-final class NotFoundException extends RestException
+final class NotFoundException extends NotFoundHttpException implements RestExceptionInterface
 {
+    use RestExceptionTrait;
+
     /**
      * Constructor
      *
@@ -24,6 +27,6 @@ final class NotFoundException extends RestException
      */
     public function __construct($message = "Not Found", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_NOT_FOUND, $prev);
+        parent::__construct($message, $prev);
     }
 }

--- a/src/Graviton/ExceptionBundle/Exception/RestException.php
+++ b/src/Graviton/ExceptionBundle/Exception/RestException.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\ExceptionBundle\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -14,36 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-abstract class RestException extends \Exception
+abstract class RestException extends HttpException implements RestExceptionInterface
 {
-    /**
-     * Response object
-     *
-     * @var Response
-     */
-    private $response = false;
-
-    /**
-     * Set the response object (optional)
-     *
-     * @param Response $response Response object
-     *
-     * @return RestException $this This
-     */
-    public function setResponse(Response $response)
-    {
-        $this->response = $response;
-
-        return $this;
-    }
-
-    /**
-     * Get the response object
-     *
-     * @return Response $response Response object
-     */
-    public function getResponse()
-    {
-        return $this->response;
-    }
+    use RestExceptionTrait;
 }

--- a/src/Graviton/ExceptionBundle/Exception/RestException.php
+++ b/src/Graviton/ExceptionBundle/Exception/RestException.php
@@ -6,7 +6,6 @@
 namespace Graviton\ExceptionBundle\Exception;
 
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Base rest exception class

--- a/src/Graviton/ExceptionBundle/Exception/RestExceptionInterface.php
+++ b/src/Graviton/ExceptionBundle/Exception/RestExceptionInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * common rest exception interface
+ */
+
+namespace Graviton\ExceptionBundle\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+interface RestExceptionInterface
+{
+    /**
+     * Set the response object (optional)
+     *
+     * @param Response $response Response object
+     *
+     * @return RestException $this This
+     */
+    public function setResponse(Response $response);
+
+    /**
+     * Get the response object
+     *
+     * @return Response $response Response object
+     */
+    public function getResponse();
+}

--- a/src/Graviton/ExceptionBundle/Exception/RestExceptionTrait.php
+++ b/src/Graviton/ExceptionBundle/Exception/RestExceptionTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Base rest exception class
+ */
+
+namespace Graviton\ExceptionBundle\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Base rest exception class
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+trait RestExceptionTrait
+{
+    /**
+     * Response object
+     *
+     * @var Response
+     */
+    private $response = false;
+
+    /**
+     * Set the response object (optional)
+     *
+     * @param Response $response Response object
+     *
+     * @return RestException $this This
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+
+    /**
+     * Get the response object
+     *
+     * @return Response $response Response object
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Graviton/ExceptionBundle/Exception/SerializationException.php
+++ b/src/Graviton/ExceptionBundle/Exception/SerializationException.php
@@ -24,6 +24,6 @@ final class SerializationException extends RestException
      */
     public function __construct($message = "Serialization Error", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_INTERNAL_SERVER_ERROR, $prev);
+        parent::__construct(Response::HTTP_INTERNAL_SERVER_ERROR, $message, $prev);
     }
 }

--- a/src/Graviton/ExceptionBundle/Exception/ValidationException.php
+++ b/src/Graviton/ExceptionBundle/Exception/ValidationException.php
@@ -33,7 +33,7 @@ final class ValidationException extends RestException
      */
     public function __construct($message = "Validation Failed", $prev = null)
     {
-        parent::__construct($message, Response::HTTP_BAD_REQUEST, $prev);
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message, $prev);
     }
 
     /**


### PR DESCRIPTION
This makes our home-baked exceptions use symfonys HttpException as base.

In itself this does not change much, it's part of the larger picture of us refactoring parts to use more framework and less home-made stuff.