### PR TITLE
Allow If-None-Match in CORS headers

### DIFF
--- a/src/Graviton/RestBundle/Listener/CorsResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/CorsResponseListener.php
@@ -25,7 +25,7 @@ class CorsResponseListener
     /**
      * @var string[]
      */
-    private $allowHeaders = array('Content-Type', 'Content-Language');
+    private $allowHeaders = array('Content-Type', 'Content-Language', 'If-None-Match');
 
     /**
      * add an allowed header


### PR DESCRIPTION
This should fix ETag/If-None-Match based caching in cross-origin requests.