### PR TITLE
honor date.timezone setting if it's around

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -33,7 +33,10 @@ class AppKernel extends Kernel
      */
     public function __construct($environment, $debug)
     {
-        date_default_timezone_set('UTC');
+        $configuredTimeZone = ini_get('date.timezone');
+        if (empty($configuredTimeZone)) {
+            date_default_timezone_set('UTC');
+        }
         parent::__construct($environment, $debug);
     }
 


### PR DESCRIPTION
graviton should honor the `date.timezone` php setting and not fix itself to UTC just like that. we still fix to UTC if there's no timezone set.

I didn't use `date_default_timezone_get()` as it takes into account too much, like the `TZ` env variable of the webserver user and so on - we just want to honour `date.timezone` IMHO..