### PR TITLE
Retry MongoDB operations

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,6 +64,8 @@ doctrine_mongodb:
             options: { connect: true }
     document_managers:
         default:
+            retry_connect: 3
+            retry_query: 1
             mappings:
                 GravitonCoreBundle: ~
             filters:


### PR DESCRIPTION
This helps us fail over in cases like replica set fail overs.

See http://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/config.html#retrying-connections-and-queries for more info.

Should allow us to resolve https://errbit.nova.scapp.io/apps/5559a49731386c002b170000/problems/555dc00731386d002a7d0000.