### PR TITLE
Work on php 7 and hhvm on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
 - 5.6
 - 5.5
 - 5.4
+- 7.0
 matrix:
   allow_failures:
   - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: php
 services: mongodb
 sudo: false
 before_script:
-- echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-- composer install --no-interaction
+- if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "7.0" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+- if [ $(phpenv version-name) = "hhvm" ] || [ $(phpenv version-name) = "7.0" ]; then composer require mongofill/mongofill --ignore-platform-reqs; fi
+- composer install --no-interaction  --ignore-platform-reqs
 - touch src/Graviton/I18nBundle/Resources/translations/i18n.de.odm
 - touch src/Graviton/I18nBundle/Resources/translations/i18n.es.odm
 - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   allow_failures:
   - php: hhvm
   - php: 5.4
+  - php: 7.0
 script:
 - "./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover"
 - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "~5.4",
+        "php": ">=5.4",
         "symfony/symfony": "~2.6.5",
         "doctrine/orm": "~2.4",
         "twig/extensions": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ff2275fd569d9efb2c38031e4660deaf",
+    "hash": "f18209223c4017c68ac8d7110a3b6159",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -5015,7 +5015,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~5.4"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Both are allowed to fail (and even do so for various reasons) and both get a bit further along than before.

This should help us keep track of when mongodb/doctrine stops blocking both platforms.