### PR TITLE
Return defaultLocale if no locale requested

### DIFF
--- a/src/Graviton/I18nBundle/Listener/AcceptLanguageRequestListener.php
+++ b/src/Graviton/I18nBundle/Listener/AcceptLanguageRequestListener.php
@@ -24,15 +24,20 @@ class AcceptLanguageRequestListener
     private $repository;
 
     /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
      * set language repository used for getting available languages
      *
-     * @param LanguageRepository $repository repo
-     *
-     * @return void
+     * @param LanguageRepository $repository    repo
+     * @param string             $defaultLocale default locale to return if no language given in request
      */
-    public function setRepository(LanguageRepository $repository)
+    public function __construct(LanguageRepository $repository, $defaultLocale)
     {
         $this->repository = $repository;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -61,6 +66,9 @@ class AcceptLanguageRequestListener
                 $this->repository->findAll()
             )
         );
+        if (empty($languages)) {
+            $languages[$this->defaultLocale] = $this->defaultLocale;
+        }
 
         $request->attributes->set('languages', $languages);
 

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -89,9 +89,8 @@
       <tag name="kernel.event_listener" event="kernel.response" method="onkernelresponse"/>
     </service>
     <service id="graviton.i18n.listener.acceptlanguagerequest" class="%graviton.i18n.listener.acceptlanguagerequest.class%">
-      <call method="setRepository">
-        <argument type="service" id="graviton.i18n.repository.language"/>
-      </call>
+      <argument type="service" id="graviton.i18n.repository.language"/>
+      <argument type="string">%graviton.translator.default.locale%</argument>
       <tag name="kernel.event_listener" event="kernel.request" method="onkernelrequest"/>
     </service>
     <service id="graviton.i18n.loader.doctrineodm" class="%graviton.i18n.loader.doctrineodm.class%">


### PR DESCRIPTION
This makes using curl make a bit more sense and stops us from returning invalid content.

ie.

```
{ "name": [] }
```

becomes

```
{ "name": { "en": "Name" } }
```