### PR TITLE
make swagger json valid & more complete

### DIFF
--- a/src/Graviton/CoreBundle/Document/App.php
+++ b/src/Graviton/CoreBundle/Document/App.php
@@ -47,6 +47,16 @@ class App implements TranslatableDocumentInterface
     }
 
     /**
+     * return pretranslated fields
+     *
+     * @return string[]
+     */
+    public function getPreTranslatedFields()
+    {
+        return array();
+    }
+
+    /**
      * Set id
      *
      * @param string $id id for new document

--- a/src/Graviton/CoreBundle/Document/Product.php
+++ b/src/Graviton/CoreBundle/Document/Product.php
@@ -4,6 +4,7 @@
  */
 
 namespace Graviton\CoreBundle\Document;
+use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
 
 /**
  * Product
@@ -12,7 +13,7 @@ namespace Graviton\CoreBundle\Document;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class Product
+class Product implements TranslatableDocumentInterface
 {
     /**
      * @var string app id
@@ -23,6 +24,26 @@ class Product
      * @var string[] app title in multiple languages
      */
     protected $name;
+
+    /**
+     * make title translatable
+     *
+     * @return string[]
+     */
+    public function getTranslatableFields()
+    {
+        return array();
+    }
+
+    /**
+     * return pretranslated fields
+     *
+     * @return string[]
+     */
+    public function getPreTranslatedFields()
+    {
+        return array('name');
+    }
 
     /**
      * Get id

--- a/src/Graviton/CoreBundle/Document/Product.php
+++ b/src/Graviton/CoreBundle/Document/Product.php
@@ -4,6 +4,7 @@
  */
 
 namespace Graviton\CoreBundle\Document;
+
 use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
 
 /**

--- a/src/Graviton/CoreBundle/Resources/config/schema/Product.json
+++ b/src/Graviton/CoreBundle/Resources/config/schema/Product.json
@@ -13,8 +13,5 @@
   "required": [
     "id",
     "name"
-  ],
-  "pretranslated": [
-    "name"
   ]
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -499,6 +499,7 @@ class AppControllerTest extends RestTestCase
         $this->assertContains('id', $schema->required);
 
         $this->assertEquals('object', $schema->properties->title->type);
+        $this->assertEquals('translatable', $schema->properties->title->format);
         $this->assertEquals('Title', $schema->properties->title->title);
         $this->assertEquals('Display name for an app.', $schema->properties->title->description);
         $this->assertEquals('string', $schema->properties->title->properties->en->type);

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -272,4 +272,26 @@ class ModuleControllerTest extends RestTestCase
         $client->request('GET', '/core/module/'.$moduleId);
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }
+
+    /**
+     * test getting collection schema.
+     * i avoid retesting everything (covered in /core/app), this test only
+     * asserts translatable & extref representation
+     *
+     * @return void
+     */
+    public function testGetModuleCollectionSchemaInformationFormat()
+    {
+        $client = static::createRestClient();
+
+        $client->request('OPTIONS', '/core/module');
+        $results = $client->getResults();
+
+        $this->assertEquals('object', $results->items->properties->name->type);
+        $this->assertEquals('translatable', $results->items->properties->name->format);
+
+        $this->assertEquals('object', $results->items->properties->app->type);
+        $this->assertEquals('string', $results->items->properties->app->properties->ref->type);
+        $this->assertEquals('extref', $results->items->properties->app->properties->ref->format);
+    }
 }

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -6,9 +6,7 @@
 namespace Graviton\FileBundle\Controller;
 
 use Graviton\RestBundle\Controller\RestController;
-use Graviton\RestBundle\Service\RestUtils;
 use Graviton\RestBundle\Service\RestUtilsInterface;
-use Graviton\I18nBundle\Repository\LanguageRepository;
 use Graviton\SchemaBundle\SchemaUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,7 +37,6 @@ class FileController extends RestController
      * @param Response           $response    Response
      * @param RestUtilsInterface $restUtils   Rest utils
      * @param Router             $router      Router
-     * @param LanguageRepository $language    Language
      * @param ValidatorInterface $validator   Validator
      * @param EngineInterface    $templating  Templating
      * @param FormFactory        $formFactory form factory
@@ -52,7 +49,6 @@ class FileController extends RestController
         Response $response,
         RestUtilsInterface $restUtils,
         Router $router,
-        LanguageRepository $language,
         ValidatorInterface $validator,
         EngineInterface $templating,
         FormFactory $formFactory,
@@ -65,7 +61,6 @@ class FileController extends RestController
             $response,
             $restUtils,
             $router,
-            $language,
             $validator,
             $templating,
             $formFactory,

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -6,8 +6,10 @@
 namespace Graviton\FileBundle\Controller;
 
 use Graviton\RestBundle\Controller\RestController;
+use Graviton\RestBundle\Service\RestUtils;
 use Graviton\RestBundle\Service\RestUtilsInterface;
 use Graviton\I18nBundle\Repository\LanguageRepository;
+use Graviton\SchemaBundle\SchemaUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -43,6 +45,7 @@ class FileController extends RestController
      * @param FormFactory        $formFactory form factory
      * @param DocumentType       $formType    generic form
      * @param ContainerInterface $container   Container
+     * @param SchemaUtils        $schemaUtils schema utils
      * @param FileSystem         $gaufrette   file system abstraction layer for s3 and more
      */
     public function __construct(
@@ -55,6 +58,7 @@ class FileController extends RestController
         FormFactory $formFactory,
         DocumentType $formType,
         ContainerInterface $container,
+        SchemaUtils $schemaUtils,
         Filesystem $gaufrette
     ) {
         parent::__construct(
@@ -66,7 +70,8 @@ class FileController extends RestController
             $templating,
             $formFactory,
             $formType,
-            $container
+            $container,
+            $schemaUtils
         );
         $this->gaufrette = $gaufrette;
     }

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
@@ -8,6 +8,7 @@ use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\DeserializationContext;
 
 {% set translatableFields = [] %}
+{% set preTranslatedFields = [] %}
 
 /**
  * {{ base }}Document\{{ document }}
@@ -87,6 +88,10 @@ class {{ document }} implements TranslatableDocumentInterface
 
     {% if field.translatable is defined and field.translatable == true %}
         {% set translatableFields = translatableFields|merge([field.fieldName]) %}
+    {% endif %}
+
+    {% if field.pretranslated is defined and field.pretranslated == true %}
+        {% set preTranslatedFields = preTranslatedFields|merge([field.fieldName]) %}
     {% endif %}
 
     /**
@@ -190,6 +195,16 @@ class {{ document }} implements TranslatableDocumentInterface
     public function getTranslatableFields()
     {
         return array('{{ translatableFields|join('\',\'') }}');
+    }
+
+    /**
+     * return pretranslated field names
+     *
+     * @return string[]
+     */
+    public function getPreTranslatedFields()
+    {
+        return array('{{ preTranslatedFields|join('\',\'') }}');
     }
 
 }

--- a/src/Graviton/I18nBundle/Document/Language.php
+++ b/src/Graviton/I18nBundle/Document/Language.php
@@ -25,6 +25,16 @@ class Language implements TranslatableDocumentInterface
     }
 
     /**
+     * return pretranslated fields
+     *
+     * @return string[]
+     */
+    public function getPreTranslatedFields()
+    {
+        return array();
+    }
+
+    /**
      * @var string $id
      */
     protected $id;

--- a/src/Graviton/I18nBundle/Document/TranslatableDocumentInterface.php
+++ b/src/Graviton/I18nBundle/Document/TranslatableDocumentInterface.php
@@ -18,4 +18,11 @@ interface TranslatableDocumentInterface
      * @return string[]
      */
     public function getTranslatableFields();
+
+    /**
+     * return all pretranslated fields
+     *
+     * @return string[]
+     */
+    public function getPreTranslatedFields();
 }

--- a/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
+++ b/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
@@ -19,7 +19,6 @@ namespace Graviton\PersonBundle\Controller;
 use Graviton\RestBundle\Controller\RestController;
 use Graviton\PersonBundle\Repository\CustomerDiffRepository;
 use Graviton\RestBundle\Service\RestUtilsInterface;
-use Graviton\I18nBundle\Repository\LanguageRepository;
 use Graviton\SchemaBundle\SchemaUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -45,7 +44,6 @@ abstract class AbstractCustomerController extends RestController
      * @param Response               $response    Response
      * @param RestUtilsInterface     $restUtils   Rest utils
      * @param Router                 $router      Router
-     * @param LanguageRepository     $language    Language
      * @param ValidatorInterface     $validator   Validator
      * @param EngineInterface        $templating  Templating
      * @param FormFactory            $formFactory form factory
@@ -58,7 +56,6 @@ abstract class AbstractCustomerController extends RestController
         Response $response,
         RestUtilsInterface $restUtils,
         Router $router,
-        LanguageRepository $language,
         ValidatorInterface $validator,
         EngineInterface $templating,
         FormFactory $formFactory,
@@ -71,7 +68,6 @@ abstract class AbstractCustomerController extends RestController
             $response,
             $restUtils,
             $router,
-            $language,
             $validator,
             $templating,
             $formFactory,

--- a/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
+++ b/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
@@ -20,6 +20,7 @@ use Graviton\RestBundle\Controller\RestController;
 use Graviton\PersonBundle\Repository\CustomerDiffRepository;
 use Graviton\RestBundle\Service\RestUtilsInterface;
 use Graviton\I18nBundle\Repository\LanguageRepository;
+use Graviton\SchemaBundle\SchemaUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -51,6 +52,7 @@ abstract class AbstractCustomerController extends RestController
      * @param DocumentType           $formType    generic form
      * @param ContainerInterface     $container   Container
      * @param CustomerDiffRepository $diffRepo    repo containing customer diffs
+     * @param SchemaUtils            $schemaUtils Schema utils
      */
     public function __construct(
         Response $response,
@@ -62,6 +64,7 @@ abstract class AbstractCustomerController extends RestController
         FormFactory $formFactory,
         DocumentType $formType,
         ContainerInterface $container,
+        SchemaUtils $schemaUtils,
         CustomerDiffRepository $diffRepo
     ) {
         parent::__construct(
@@ -73,7 +76,8 @@ abstract class AbstractCustomerController extends RestController
             $templating,
             $formFactory,
             $formType,
-            $container
+            $container,
+            $schemaUtils
         );
         $this->diffRepo = $diffRepo;
     }

--- a/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
+++ b/src/Graviton/PersonBundle/Controller/AbstractCustomerController.php
@@ -51,8 +51,8 @@ abstract class AbstractCustomerController extends RestController
      * @param FormFactory            $formFactory form factory
      * @param DocumentType           $formType    generic form
      * @param ContainerInterface     $container   Container
-     * @param CustomerDiffRepository $diffRepo    repo containing customer diffs
      * @param SchemaUtils            $schemaUtils Schema utils
+     * @param CustomerDiffRepository $diffRepo    repo containing customer diffs
      */
     public function __construct(
         Response $response,

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -464,10 +464,6 @@ class RestController
         $model = $this->container->get(implode('.', array($app, $module, 'model', $modelName)));
         $document = $this->container->get(implode('.', array($app, $module, 'document', $modelName)));
 
-        $translatableFields = array();
-        if ($document instanceof TranslatableDocumentInterface) {
-            $translatableFields = $document->getTranslatableFields();
-        }
         $languages = array_map(
             function ($language) {
                 return $language->getId();
@@ -483,7 +479,7 @@ class RestController
         if (!$id && $schemaType != 'canonicalIdSchema') {
             $schemaMethod = 'getCollectionSchema';
         }
-        $schema = SchemaUtils::$schemaMethod($modelName, $model, $translatableFields, $languages);
+        $schema = SchemaUtils::$schemaMethod($modelName, $model, array(), $languages);
 
         // enabled methods for CorsListener
         $corsMethods = 'GET, POST, PUT, DELETE, OPTIONS';

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -17,7 +17,6 @@ use Graviton\RestBundle\Model\PaginatorAwareInterface;
 use Graviton\SchemaBundle\SchemaUtils;
 use Graviton\DocumentBundle\Form\Type\DocumentType;
 use Graviton\RestBundle\Service\RestUtilsInterface;
-use Graviton\I18nBundle\Repository\LanguageRepository;
 use Knp\Component\Pager\Paginator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,12 +48,12 @@ class RestController
      * @var ContainerInterface service_container
      */
     private $container;
-    
+
     /**
      * @var Response
      */
     private $response;
-    
+
     /**
      * @var FormFactory
      */
@@ -74,32 +73,26 @@ class RestController
      * @var SchemaUtils
      */
     private $schemaUtils;
-    
+
     /**
      * @var Router
      */
     private $router;
-    
-    /**
-     * @var LanguageRepository
-     */
-    private $language;
-    
+
     /**
      * @var ValidatorInterface
      */
     private $validator;
-    
+
     /**
      * @var EngineInterface
      */
     private $templating;
-    
+
     /**
      * @param Response           $response    Response
      * @param RestUtilsInterface $restUtils   Rest utils
      * @param Router             $router      Router
-     * @param LanguageRepository $language    Language
      * @param ValidatorInterface $validator   Validator
      * @param EngineInterface    $templating  Templating
      * @param FormFactory        $formFactory form factory
@@ -111,7 +104,6 @@ class RestController
         Response $response,
         RestUtilsInterface $restUtils,
         Router $router,
-        LanguageRepository $language,
         ValidatorInterface $validator,
         EngineInterface $templating,
         FormFactory $formFactory,
@@ -122,7 +114,6 @@ class RestController
         $this->response = $response;
         $this->restUtils = $restUtils;
         $this->router = $router;
-        $this->language = $language;
         $this->validator = $validator;
         $this->templating = $templating;
         $this->formFactory = $formFactory;
@@ -469,7 +460,6 @@ class RestController
 
         list($app, $module, , $modelName, $schemaType) = explode('.', $request->attributes->get('_route'));
         $model = $this->container->get(implode('.', array($app, $module, 'model', $modelName)));
-        $document = $this->container->get(implode('.', array($app, $module, 'document', $modelName)));
 
         $response = $this->response;
         $response->setStatusCode(Response::HTTP_OK);

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -62,7 +62,6 @@
             <argument type="service" id="graviton.rest.response" strict="false"/>
             <argument type="service" id="graviton.rest.restutils"/>
             <argument type="service" id="graviton.rest.router"/>
-            <argument type="service" id="graviton.i18n.repository.language"/>
             <argument type="service" id="graviton.rest.validator"/>
             <argument type="service" id="templating"/>
             <argument type="service" id="form.factory"/>

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -68,6 +68,7 @@
             <argument type="service" id="form.factory"/>
             <argument type="service" id="graviton.document.form.type.document"/>
             <argument type="service" id="service_container"/>
+            <argument type="service" id="graviton.schema.utils"/>
         </service>
 
         <!-- Model -->

--- a/src/Graviton/SchemaBundle/Document/Schema.php
+++ b/src/Graviton/SchemaBundle/Document/Schema.php
@@ -299,7 +299,7 @@ class Schema
      */
     public function setTranslatable($translatable)
     {
-        if ($translatable == true) {
+        if ($translatable === true) {
             $this->setType('translatable');
         } else {
             $this->setType('string');

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -150,18 +150,4 @@ class SchemaModel implements ContainerAwareInterface
         return $this->schema->required;
     }
 
-    /**
-     * get pretranslated fields for this object
-     *
-     * @return string[]
-     */
-    public function getPreTranslatedFields()
-    {
-        $return = array();
-        if (isset($this->schema->pretranslated)) {
-            $return = $this->schema->pretranslated;
-        }
-
-        return $return;
-    }
 }

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -149,5 +149,4 @@ class SchemaModel implements ContainerAwareInterface
     {
         return $this->schema->required;
     }
-
 }

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -30,7 +30,7 @@
       "items": "object",
       "description": "Array of required field names"
     },
-    "translatable": {
+    "x-translatable": {
       "title": "Translatable",
       "type": "boolean",
       "description": "If property is translatable or not"

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -16,24 +16,28 @@
     "type": {
       "title": "Type",
       "type": "string",
-      "description": "Data type of the property"
+      "description": "Primitive data type of the property"
+    },
+    "format": {
+      "title": "Format",
+      "type": "string",
+      "description": "Data format of this property"
     },
     "properties": {
       "title": "Properties",
       "type": "array",
-      "items": "object",
+      "items": {
+        "type": "object"
+      },
       "description": "Array of properties"
     },
     "required": {
       "title": "Required",
       "type": "array",
-      "items": "object",
+      "items": {
+        "type": "string"
+      },
       "description": "Array of required field names"
-    },
-    "x-translatable": {
-      "title": "Translatable",
-      "type": "boolean",
-      "description": "If property is translatable or not"
     }
   },
   "required": ["title", "description", "type"]

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -11,6 +11,6 @@
     <property name="required" accessor-getter="getRequired" accessor-setter="setRequired" expose="true">
       <type><![CDATA[array<string>]]></type>
     </property>
-    <property name="translatable" accessor-getter="isTranslatable" accessor-setter="setTranslatable" expose="true"/>
+    <property name="translatable" accessor-getter="isTranslatable" accessor-setter="setTranslatable" expose="true" serialized-name="x-translatable"/>
   </class>
 </serializer>

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -4,6 +4,7 @@
     <property name="title" type="string" accessor-getter="getTitle" accessor-setter="setTitle" expose="true"/>
     <property name="description" type="string" accessor-getter="getDescription" accessor-setter="setDescription" expose="true"/>
     <property name="type" type="string" accessor-getter="getType" accessor-setter="setType" expose="true"/>
+    <property name="format" type="string" accessor-getter="getFormat" accessor-setter="setFormat" expose="true"/>
     <property name="items" type="Graviton\SchemaBundle\Document\Schema" accessor-getter="getItems" accessor-setter="setItems" expose="true"/>
     <property name="properties" accessor-getter="getProperties" expose="true">
       <type><![CDATA[array<string, Graviton\SchemaBundle\Document\Schema>]]></type>
@@ -11,6 +12,5 @@
     <property name="required" accessor-getter="getRequired" accessor-setter="setRequired" expose="true">
       <type><![CDATA[array<string>]]></type>
     </property>
-    <property name="translatable" accessor-getter="isTranslatable" accessor-setter="setTranslatable" expose="true" serialized-name="x-translatable"/>
   </class>
 </serializer>

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameter key="graviton.schema.listener.schematyperesponse.class">Graviton\SchemaBundle\Listener\SchemaContentTypeResponseListener</parameter>
     <parameter key="graviton.schema.listener.canonicalschemaresponse.class">Graviton\SchemaBundle\Listener\CanonicalSchemaLinkResponseListener</parameter>
     <parameter key="graviton.schema.model.schemamodel.class">Graviton\SchemaBundle\Model\SchemaModel</parameter>
+    <parameter key="graviton.schema.service.schemautils.class">Graviton\SchemaBundle\SchemaUtils</parameter>
   </parameters>
   <services>
     <service id="graviton.schema.listener.schematyperesponse" class="%graviton.schema.listener.schematyperesponse.class%">
@@ -19,6 +20,11 @@
     <service id="graviton.schema.model.schemamodel" class="%graviton.schema.model.schemamodel.class%">
       <call method="setContainer">
         <argument type="service" id="service_container"></argument>
+      </call>
+    </service>
+    <service id="graviton.schema.utils" class="%graviton.schema.service.schemautils.class%">
+      <call method="setLanguageRepository">
+        <argument type="service" id="graviton.i18n.repository.language"></argument>
       </call>
     </service>
   </services>

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -23,9 +23,7 @@
       </call>
     </service>
     <service id="graviton.schema.utils" class="%graviton.schema.service.schemautils.class%">
-      <call method="setLanguageRepository">
-        <argument type="service" id="graviton.i18n.repository.language"></argument>
-      </call>
+      <argument type="service" id="graviton.i18n.repository.language"/>
     </service>
   </services>
 </container>

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -54,25 +54,16 @@ class SchemaUtils
         $schema->setDescription($model->getDescription());
         $schema->setType('object');
 
+
+
         // add pre translated fields
-        $translatableFields = array_merge($translatableFields, $model->getPreTranslatedFields());
+        $translatableFields = array_merge($translatableFields, array());
 
         // grab schema info from model
         $repo = $model->getRepository();
         $meta = $repo->getClassMetadata();
 
         foreach ($meta->getFieldNames() as $field) {
-            /**
-             * [nue] here there was a dirty workaround rename uri to $ref..
-             * this is wrong and led to an error on an entity that actually had a field named 'uri'
-             * if somebody wants to expose a field 'uri' as $ref, please use the serializer for that.
-             * that's for what he's there..
-             */
-            /*
-            if ($field == 'uri') {
-                $field = '$ref';
-            }
-            */
 
             // don't describe deletedDate in schema..
             if ($field == 'deletedDate') {

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -43,17 +43,15 @@ class SchemaUtils
      *
      * @param string   $modelName          name of model
      * @param object   $model              model
-     * @param string[] $translatableFields fields that get translated on the fly
-     * @param string[] $languages          languages
      *
      * @return Schema
      */
-    public function getCollectionSchema($modelName, $model, $translatableFields, $languages)
+    public function getCollectionSchema($modelName, $model)
     {
         $collectionSchema = new Schema;
         $collectionSchema->setTitle(sprintf('Array of %s objects', $modelName));
         $collectionSchema->setType('array');
-        $collectionSchema->setItems(self::getModelSchema($modelName, $model, $translatableFields, $languages));
+        $collectionSchema->setItems(self::getModelSchema($modelName, $model));
 
         return $collectionSchema;
     }

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -30,8 +30,6 @@ class SchemaUtils
      * Constructor
      *
      * @param LanguageRepository $languageRepository repository
-     *
-     * @return SchemaUtils
      */
     public function __construct(LanguageRepository $languageRepository)
     {
@@ -110,13 +108,13 @@ class SchemaUtils
 
             if ($meta->getTypeOfField($field) === 'many') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));
-                $property->setItems(self::getModelSchema($field, $propertyModel, $translatableFields, $languages));
+                $property->setItems(self::getModelSchema($field, $propertyModel));
                 $property->setType('array');
             }
 
             if ($meta->getTypeOfField($field) === 'one') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));
-                $property = self::getModelSchema($field, $propertyModel, $translatableFields, $languages);
+                $property = self::getModelSchema($field, $propertyModel);
             }
 
             if (in_array($field, $translatableFields)) {

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -6,6 +6,7 @@
 namespace Graviton\SchemaBundle;
 
 use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
+use Graviton\I18nBundle\Repository\LanguageRepository;
 use Graviton\SchemaBundle\Document\Schema;
 
 /**
@@ -17,6 +18,26 @@ use Graviton\SchemaBundle\Document\Schema;
  */
 class SchemaUtils
 {
+
+    /**
+     * language repository
+     *
+     * @var LanguageRepository repository
+     */
+    private $languageRepository;
+
+    /**
+     * sets the language repository
+     *
+     * @param LanguageRepository $languageRepository
+     *
+     * @return void
+     */
+    public function setLanguageRepository($languageRepository)
+    {
+        $this->languageRepository = $languageRepository;
+    }
+
     /**
      * get schema for an array of models
      *
@@ -27,7 +48,7 @@ class SchemaUtils
      *
      * @return Schema
      */
-    public static function getCollectionSchema($modelName, $model, $translatableFields, $languages)
+    public function getCollectionSchema($modelName, $model, $translatableFields, $languages)
     {
         $collectionSchema = new Schema;
         $collectionSchema->setTitle(sprintf('Array of %s objects', $modelName));
@@ -40,14 +61,12 @@ class SchemaUtils
     /**
      * return the schema for a given route
      *
-     * @param string   $modelName          name of mode to generate schema for
-     * @param object   $model              model to generate schema for
-     * @param string[] $translatableFields fields that get translated on the fly
-     * @param string[] $languages          languages
+     * @param string $modelName name of mode to generate schema for
+     * @param object $model     model to generate schema for
      *
      * @return Schema
      */
-    public static function getModelSchema($modelName, $model, $translatableFields, $languages)
+    public function getModelSchema($modelName, $model)
     {
         // build up schema data
         $schema = new Schema;
@@ -68,6 +87,13 @@ class SchemaUtils
                 $translatableFields = $documentClass->getTranslatableFields();
             }
         }
+
+        $languages = array_map(
+            function ($language) {
+                return $language->getId();
+            },
+            $this->languageRepository->findAll()
+        );
 
         foreach ($meta->getFieldNames() as $field) {
 
@@ -113,7 +139,7 @@ class SchemaUtils
      *
      * @return Schema
      */
-    public static function makeTranslatable(Schema $property, $languages)
+    public function makeTranslatable(Schema $property, $languages)
     {
         $property->setType('object');
         $property->setTranslatable(true);
@@ -139,7 +165,7 @@ class SchemaUtils
      *
      * @return string schema route name
      */
-    public static function getSchemaRouteName($routeName)
+    static public function getSchemaRouteName($routeName)
     {
         $routeParts = explode('.', $routeName);
 

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -29,7 +29,7 @@ class SchemaUtils
     /**
      * sets the language repository
      *
-     * @param LanguageRepository $languageRepository
+     * @param LanguageRepository $languageRepository repository
      *
      * @return void
      */
@@ -41,8 +41,8 @@ class SchemaUtils
     /**
      * get schema for an array of models
      *
-     * @param string   $modelName          name of model
-     * @param object   $model              model
+     * @param string $modelName name of model
+     * @param object $model     model
      *
      * @return Schema
      */
@@ -97,7 +97,6 @@ class SchemaUtils
         );
 
         foreach ($meta->getFieldNames() as $field) {
-
             // don't describe deletedDate in schema..
             if ($field == 'deletedDate') {
                 continue;
@@ -166,7 +165,7 @@ class SchemaUtils
      *
      * @return string schema route name
      */
-    static public function getSchemaRouteName($routeName)
+    public static function getSchemaRouteName($routeName)
     {
         $routeParts = explode('.', $routeName);
 

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\SchemaBundle;
 
+use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
 use Graviton\SchemaBundle\Document\Schema;
 
 /**
@@ -54,14 +55,19 @@ class SchemaUtils
         $schema->setDescription($model->getDescription());
         $schema->setType('object');
 
-
-
-        // add pre translated fields
-        $translatableFields = array_merge($translatableFields, array());
-
         // grab schema info from model
         $repo = $model->getRepository();
         $meta = $repo->getClassMetadata();
+
+        // look for translatables in document class
+        $entityName = $repo->getClassName();
+        $translatableFields = array();
+        if (class_exists($entityName)) {
+            $documentClass = new $entityName();
+            if ($documentClass instanceof TranslatableDocumentInterface) {
+                $translatableFields = $documentClass->getTranslatableFields();
+            }
+        }
 
         foreach ($meta->getFieldNames() as $field) {
 

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -82,7 +82,10 @@ class SchemaUtils
         if (class_exists($entityName)) {
             $documentClass = new $entityName();
             if ($documentClass instanceof TranslatableDocumentInterface) {
-                $translatableFields = $documentClass->getTranslatableFields();
+                $translatableFields = array_merge(
+                    $documentClass->getTranslatableFields(),
+                    $documentClass->getPreTranslatedFields()
+                );
             }
         }
 

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -27,13 +27,13 @@ class SchemaUtils
     private $languageRepository;
 
     /**
-     * sets the language repository
+     * Constructor
      *
      * @param LanguageRepository $languageRepository repository
      *
-     * @return void
+     * @return SchemaUtils
      */
-    public function setLanguageRepository($languageRepository)
+    public function __construct(LanguageRepository $languageRepository)
     {
         $this->languageRepository = $languageRepository;
     }

--- a/src/Graviton/SwaggerBundle/Command/SwaggerGenerateCommand.php
+++ b/src/Graviton/SwaggerBundle/Command/SwaggerGenerateCommand.php
@@ -7,11 +7,8 @@ namespace Graviton\SwaggerBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Process\Process;
 
 /**
  * Generates swagger.json

--- a/src/Graviton/SwaggerBundle/Resources/config/services.xml
+++ b/src/Graviton/SwaggerBundle/Resources/config/services.xml
@@ -20,6 +20,9 @@
             <call method="setSchemaModel">
                 <argument type="service" id="graviton.schema.model.schemamodel"></argument>
             </call>
+            <call method="setSchemaUtils">
+                <argument type="service" id="graviton.schema.utils"></argument>
+            </call>
         </service>
 
         <service id="graviton.swagger.command.swaggercopy.filesystem"

--- a/src/Graviton/SwaggerBundle/Resources/config/services.xml
+++ b/src/Graviton/SwaggerBundle/Resources/config/services.xml
@@ -11,18 +11,9 @@
 
         <!-- swagger service - a service that generates swagger spec -->
         <service id="graviton.rest.apidoc" class="Graviton\SwaggerBundle\Service\Swagger">
-            <call method="setContainer">
-                <argument type="service" id="service_container"></argument>
-            </call>
-            <call method="setRestUtils">
-                <argument type="service" id="graviton.rest.restutils"></argument>
-            </call>
-            <call method="setSchemaModel">
-                <argument type="service" id="graviton.schema.model.schemamodel"></argument>
-            </call>
-            <call method="setSchemaUtils">
-                <argument type="service" id="graviton.schema.utils"></argument>
-            </call>
+            <argument type="service" id="graviton.rest.restutils"></argument>
+            <argument type="service" id="graviton.schema.model.schemamodel"></argument>
+            <argument type="service" id="graviton.schema.utils"></argument>
         </service>
 
         <service id="graviton.swagger.command.swaggercopy.filesystem"

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -5,9 +5,11 @@
 
 namespace Graviton\SwaggerBundle\Service;
 
+use Graviton\ExceptionBundle\Exception\MalformedInputException;
 use Graviton\RestBundle\Service\RestUtils;
 use Graviton\SchemaBundle\Model\SchemaModel;
 use Graviton\SchemaBundle\SchemaUtils;
+use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -41,8 +43,6 @@ class Swagger
      * @param RestUtils   $restUtils   rest utils
      * @param SchemaModel $schemaModel schema model instance
      * @param SchemaUtils $schemaUtils schema utils
-     *
-     * @return Swagger
      */
     public function __construct(
         RestUtils $restUtils,
@@ -77,6 +77,15 @@ class Swagger
                 }
 
                 $thisModel = $this->restUtils->getModelFromRoute($route);
+                if ($thisModel === false) {
+                    throw new \LogicException(
+                        sprintf(
+                            'Could not resolve route "%s" to model',
+                            $routeName
+                        )
+                    );
+                }
+
                 $entityClassName = str_replace('\\', '', get_class($thisModel));
 
                 $schema = $this->schemaUtils->getModelSchema($entityClassName, $thisModel);

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -34,6 +34,11 @@ class Swagger
     private $schemaModel;
 
     /**
+     * @var SchemaUtils
+     */
+    private $schemaUtils;
+
+    /**
      * sets the container
      *
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container service_container
@@ -62,11 +67,23 @@ class Swagger
      *
      * @param SchemaModel $schemaModel schema model instance
      *
-     * @return SchemaModel
+     * @return void
      */
     public function setSchemaModel($schemaModel)
     {
         $this->schemaModel = $schemaModel;
+    }
+
+    /**
+     * set SchemaUtils
+     *
+     * @param SchemaUtils $schemaUtils
+     *
+     * @return void
+     */
+    public function setSchemaUtils($schemaUtils)
+    {
+        $this->schemaUtils = $schemaUtils;
     }
 
     /**
@@ -94,7 +111,7 @@ class Swagger
                 $thisModel = $this->restUtils->getModelFromRoute($route);
                 $entityClassName = str_replace('\\', '', get_class($thisModel));
 
-                $schema = SchemaUtils::getModelSchema($entityClassName, $thisModel, array(), array());
+                $schema = $this->schemaUtils->getModelSchema($entityClassName, $thisModel);
 
                 $ret['definitions'][$entityClassName] = json_decode(
                     $this->restUtils->serializeContent($schema),

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -77,7 +77,7 @@ class Swagger
     /**
      * set SchemaUtils
      *
-     * @param SchemaUtils $schemaUtils
+     * @param SchemaUtils $schemaUtils schema utils
      *
      * @return void
      */

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\SwaggerBundle\Service;
 
+use Graviton\RestBundle\Service\RestUtils;
 use Graviton\SchemaBundle\Model\SchemaModel;
 use Graviton\SchemaBundle\SchemaUtils;
 use Symfony\Component\Routing\Route;
@@ -18,10 +19,6 @@ use Symfony\Component\Routing\Route;
  */
 class Swagger
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface service_container
-     */
-    private $container;
 
     /**
      * @var \Graviton\RestBundle\Service\RestUtils
@@ -39,50 +36,21 @@ class Swagger
     private $schemaUtils;
 
     /**
-     * sets the container
+     * Constructor
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container service_container
-     *
-     * @return void
-     */
-    public function setContainer($container = null)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     * sets restUtils
-     *
-     * @param \Graviton\RestBundle\Service\RestUtils $restUtils rest utils
-     *
-     * @return void
-     */
-    public function setRestUtils($restUtils = null)
-    {
-        $this->restUtils = $restUtils;
-    }
-
-    /**
-     * sets schemamodel
-     *
+     * @param RestUtils   $restUtils   rest utils
      * @param SchemaModel $schemaModel schema model instance
-     *
-     * @return void
-     */
-    public function setSchemaModel($schemaModel)
-    {
-        $this->schemaModel = $schemaModel;
-    }
-
-    /**
-     * set SchemaUtils
-     *
      * @param SchemaUtils $schemaUtils schema utils
      *
-     * @return void
+     * @return Swagger
      */
-    public function setSchemaUtils($schemaUtils)
-    {
+    public function __construct(
+        RestUtils $restUtils,
+        SchemaModel $schemaModel,
+        SchemaUtils $schemaUtils
+    ) {
+        $this->restUtils = $restUtils;
+        $this->schemaModel = $schemaModel;
         $this->schemaUtils = $schemaUtils;
     }
 


### PR DESCRIPTION
This PR aims to make our swagger.json pass as 'valid' from online validation, thus

**See this**
I pushed this branch to the cloud.
Swagger validation result here: http://online.swagger.io/validator/?url=http://graviton-nue-swaggerfix-unstable.nova.scapp.io/swagger.json
If you check http://graviton-nue-swaggerfix-unstable.nova.scapp.io/swagger.json - you'll see that there are the Languages listed inside the 'object' struct of an Translatable (CTRL+F for "translatable")

*Major changes in schema*
* Only output primitive types in the "field" field of the Schema, more specifics are handled in the "format" field.
* Some changes in the Schema schema to conform to spec
* Include Languages in the presentation of the Translatable object (which now has `type: object, format: translatable`)

Todo
- [x] Push to cloud first and validate
- [x] Use in wrapper context

Internally, more has changed
* Now, it's ensured that the output of the OPTIONS request to a item/collection schema is identical to the schema that is included in the swagger.json. This includes languages for translatables. 
* The previous unused "preTranslatable" feature has been moved to the `TranslatableDocumentInterface`. This can be used to flag preTranslated fields. They will be shown as translatable in Schema but are not treated like them as they are.. well.. preTranslated.. so.. already translated.. 
* As `TranslatableDocumentInterface` is used in the generated bundles; Generator also generates this new array the same way it does `translatedFields`