### PR TITLE
change the way we set the vcap_services values, move to a lower level…

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: parameters.yml }
     - { resource: services.yml }
+    - { resource: vcap.php }
 
 parameters:
     jms_serializer.camel_case_naming_strategy.class: JMS\Serializer\Naming\IdenticalPropertyNamingStrategy

--- a/app/config/vcap.php
+++ b/app/config/vcap.php
@@ -2,12 +2,29 @@
 /**
  * load config from VCAP variables
  *
- * This is here because there was no easiery way to load parameters from an environment
- * variable. Feel free to replace this if you know about a better was to get some basic
- * ENV variables (as injected by bosh or similar) into the containers param stack.
+ * this one reads out the VCAP_SERVICES variable and sets the according
+ * params on the container. this is a low-level approach that seems to work under all
+ * conditions (also i.e. when a Composer\Command wants to connect)
  *
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/GPL GPL
  * @link     http://swisscom.ch
  */
-$container->setParameter('vcap.services', getenv('SYMFONY__VCAP__SERVICES'));
+$services = getenv('VCAP_SERVICES');
+
+if (!empty($services)) {
+    $services = json_decode($services, true);
+    $mongo = $services['mongodb-2.2'][0]['credentials'];
+
+    $container->setParameter('mongodb.default.server.uri', $mongo['url']);
+    $container->setParameter('mongodb.default.server.db', $mongo['db']);
+} else {
+    $container->setParameter(
+        'mongodb.default.server.uri',
+        $container->getParameter('graviton.mongodb.default.server.uri')
+    );
+    $container->setParameter(
+        'mongodb.default.server.db',
+        $container->getParameter('graviton.mongodb.default.server.db')
+    );
+}

--- a/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
@@ -57,24 +57,5 @@ class GravitonDocumentExtension extends GravitonBundleExtension
                 $container->setParameter(strtolower(str_replace('__', '.', substr($key, 9))), $value);
             }
         }
-
-        // populated from cf's VCAP_SERVICES variable
-        $services = $container->getParameter('vcap.services');
-        if (!empty($services)) {
-            $services = json_decode($services, true);
-            $mongo = $services['mongodb-2.2'][0]['credentials'];
-
-            $container->setParameter('mongodb.default.server.uri', $mongo['url']);
-            $container->setParameter('mongodb.default.server.db', $mongo['db']);
-        } else {
-            $container->setParameter(
-                'mongodb.default.server.uri',
-                $container->getParameter('graviton.mongodb.default.server.uri')
-            );
-            $container->setParameter(
-                'mongodb.default.server.db',
-                $container->getParameter('graviton.mongodb.default.server.db')
-            );
-        }
     }
 }


### PR DESCRIPTION
:-)

I deployed this to the cloud to confirm the state.. This instance is deployed with this change:
http://graviton-nue-vcap-unstable.nova.scapp.io/i18n/translatable

Seems to work fine..

**Why this change?**
I encountered a problem - our `SwaggerGenerateCommand` was unable to connect to MongoDB upon invocation from Composer - it didn't had the vcap env settings applied (it tried to connect to localhost; the default parameter).
Setting the parameters as in this PR solved this problem.. 