### PR TITLE
make free-form objects work after introducing forms

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -81,6 +81,9 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface, LoadField
             $this->loadFields($map, $ns, $bundle, $doc);
             $this->className = null;
         }
+        if (!isset($map['stdclass'])) {
+            $map['stdclass'] = [];
+        }
         $container->setParameter('graviton.document.form.type.document.field_map', $map);
     }
 

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
@@ -53,6 +53,9 @@ class DocumentFormMapCompilerPass implements CompilerPassInterface, LoadFieldsIn
             list($doc, $bundle) = $this->getInfoFromTag($tag, $doc, $bundle);
             $this->loadFields($map, $ns, $bundle, $doc);
         }
+        if (!isset($map['stdclass'])) {
+            $map['stdclass'] = 'stdclass';
+        }
         $container->setParameter('graviton.document.form.type.document.service_map', $map);
     }
 

--- a/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
+++ b/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
@@ -71,6 +71,9 @@ class DocumentType extends AbstractType
 
             if ($type == 'form') {
                 $type = clone $this;
+                if (!isset($options['data_class'])) {
+                    $options['data_class'] = 'stdclass';
+                }
                 $type->initialize($options['data_class']);
             } elseif ($type == 'collection' && $options['type'] == 'form') {
                 $subType = clone $this;

--- a/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
+++ b/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
@@ -48,6 +48,9 @@ class DocumentType extends AbstractType
      */
     public function initialize($id)
     {
+        if (is_null($id)) {
+            throw new \RunTimeException(__CLASS__.'::initialize called with NULL id');
+        }
         if (!array_key_exists($id, $this->classMap)) {
             throw new \RuntimeException(sprintf('Could not map service %s to class for form generator', $id));
         }

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
@@ -47,7 +47,7 @@ class DocumentFormFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->method('setParameter')
             ->with(
                 $this->equalTo('graviton.document.form.type.document.field_map'),
-                ['stdclass' => 'stdclass']
+                ['stdclass' => []]
             );
 
         $sut = new DocumentFormFieldsCompilerPass;

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
@@ -47,7 +47,7 @@ class DocumentFormFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->method('setParameter')
             ->with(
                 $this->equalTo('graviton.document.form.type.document.field_map'),
-                []
+                ['stdclass' => 'stdclass']
             );
 
         $sut = new DocumentFormFieldsCompilerPass;


### PR DESCRIPTION
I still have the issue that the free-form objects are not getting save down to the innermost value... At least with this we throw less errors (it does lose some data though :rage4:)...

I'm opening this PR now since I'm kinda stumped as how to continue. In my opinion we should stop using free-form-services and implement them all.

If anyone has an idea what we can change so it works with deeply nested free-form-fields, I'd be very happy (i tried 'compound' = true to no avail).