### PR TITLE
OPTIONS response for root url

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -4,4 +4,8 @@
     <default key="_controller">graviton.core.controller.main:indexAction</default>
     <requirement key="_method">GET</requirement>
   </route>
+  <route id="graviton.core.static.main.options" path="/">
+    <default key="_controller">graviton.core.controller.main:optionsAction</default>
+    <requirement key="_method">OPTIONS</requirement>
+  </route>
 </routes>

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -201,4 +201,20 @@ class MainControllerTest extends RestTestCase
             $controller->determineServices($optionRoutes)
         );
     }
+
+    /**
+     * @retrn void
+     */
+    public function testOptionsResponse()
+    {
+        $client = static::createRestClient();
+        $client->request('OPTIONS', '/');
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            'application/schema+json',
+            $response->headers->get('Content-Type')
+        );
+    }
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -203,7 +203,7 @@ class MainControllerTest extends RestTestCase
     }
 
     /**
-     * @retrn void
+     * @return void
      */
     public function testOptionsResponse()
     {
@@ -213,8 +213,8 @@ class MainControllerTest extends RestTestCase
         $response = $client->getResponse();
 
         $this->assertContains(
-            'application/schema+json',
-            $response->headers->get('Content-Type')
+            'If-None-Match',
+            $response->headers->get('Access-Control-Allow-Headers')
         );
     }
 }

--- a/src/Graviton/RestBundle/Service/RestUtils.php
+++ b/src/Graviton/RestBundle/Service/RestUtils.php
@@ -167,6 +167,9 @@ final class RestUtils implements RestUtilsInterface
                 if ($route->getRequirement('_method') != 'OPTIONS') {
                     return false;
                 }
+                if ($route->getPath() == '/') {
+                    return false;
+                }
 
                 return is_null($route->getRequirement('id'));
             }


### PR DESCRIPTION
Makes OPTIONS requests also return CORS-Headers on ``/``. I'm not sure who requested this but had it on a branch and it seems to make sense....