### PR TITLE
dollar in name of extref fields in schema

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -291,7 +291,7 @@ class ModuleControllerTest extends RestTestCase
         $this->assertEquals('translatable', $results->items->properties->name->format);
 
         $this->assertEquals('object', $results->items->properties->app->type);
-        $this->assertEquals('string', $results->items->properties->app->properties->ref->type);
-        $this->assertEquals('extref', $results->items->properties->app->properties->ref->format);
+        $this->assertEquals('string', $results->items->properties->app->properties->{'$ref'}->type);
+        $this->assertEquals('extref', $results->items->properties->app->properties->{'$ref'}->format);
     }
 }

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -121,6 +121,10 @@ class SchemaUtils
                 $property = self::makeTranslatable($property, $languages);
             }
 
+            if ($meta->getTypeOfField($field) === 'extref' && substr($field, 0, 1) !== '$') {
+                $field = '$' . $field;
+            }
+
             $schema->addProperty($field, $property);
         }
 


### PR DESCRIPTION
Changes the schema output so extref fields are prefixed with a ``$`` as they should be...