### PR TITLE
custom form type for freeform

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -135,8 +135,7 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface, LoadField
             if (in_array($fieldName, $translatableFields)) {
                 $type = 'translatable';
             } elseif ($doctrineType == 'hash') {
-                $type = 'form';
-                $options['allow_extra_fields'] = true;
+                $type = 'freeform';
             } elseif (array_key_exists($doctrineType, $this->typeMap)) {
                 $type = $this->typeMap[$doctrineType];
             }

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -81,6 +81,9 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface, LoadField
             $this->loadFields($map, $ns, $bundle, $doc);
             $this->className = null;
         }
+        if (!isset($map['stdclass'])) {
+            $map['stdclass'] = [];
+        }
         $container->setParameter('graviton.document.form.type.document.field_map', $map);
     }
 

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
@@ -53,6 +53,9 @@ class DocumentFormMapCompilerPass implements CompilerPassInterface, LoadFieldsIn
             list($doc, $bundle) = $this->getInfoFromTag($tag, $doc, $bundle);
             $this->loadFields($map, $ns, $bundle, $doc);
         }
+        if (!isset($map['stdclass'])) {
+            $map['stdclass'] = 'stdclass';
+        }
         $container->setParameter('graviton.document.form.type.document.service_map', $map);
     }
 

--- a/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
+++ b/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
@@ -71,6 +71,9 @@ class DocumentType extends AbstractType
 
             if ($type == 'form') {
                 $type = clone $this;
+                if (!isset($options['data_class'])) {
+                    $options['data_class'] = 'stdclass';
+                }
                 $type->initialize($options['data_class']);
             } elseif ($type == 'collection' && $options['type'] == 'form') {
                 $subType = clone $this;

--- a/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
+++ b/src/Graviton/DocumentBundle/Form/Type/DocumentType.php
@@ -48,6 +48,9 @@ class DocumentType extends AbstractType
      */
     public function initialize($id)
     {
+        if (is_null($id)) {
+            throw new \RunTimeException(__CLASS__.'::initialize called with NULL id');
+        }
         if (!array_key_exists($id, $this->classMap)) {
             throw new \RuntimeException(sprintf('Could not map service %s to class for form generator', $id));
         }

--- a/src/Graviton/DocumentBundle/Form/Type/FreeForm.php
+++ b/src/Graviton/DocumentBundle/Form/Type/FreeForm.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * a dummy type based on text representing 'freeform' object ('hashes' in jsondef lingo)
+ */
+
+namespace Graviton\DocumentBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FreeForm extends AbstractType
+{
+    /**
+     * {@inheritdoc
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array());
+    }
+
+    /**
+     * {@inheritdoc
+     *
+     * @return string parent name
+     */
+    public function getParent()
+    {
+        return 'text';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string name
+     */
+    public function getName()
+    {
+        return 'freeform';
+    }
+}

--- a/src/Graviton/DocumentBundle/Form/Type/FreeForm.php
+++ b/src/Graviton/DocumentBundle/Form/Type/FreeForm.php
@@ -18,7 +18,9 @@ class FreeForm extends AbstractType
     /**
      * {@inheritdoc
      *
-     * @param OptionsResolver $resolver
+     * @param OptionsResolver $resolver resolver
+     *
+     * @return void
      */
     public function configureOptions(OptionsResolver $resolver)
     {

--- a/src/Graviton/DocumentBundle/Resources/config/services.xml
+++ b/src/Graviton/DocumentBundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
         <parameter key="graviton.document.listener.extreferencelistener.class">Graviton\DocumentBundle\Listener\ExtReferenceListener</parameter>
         <parameter key="graviton.document.form.type.extref.class">Graviton\DocumentBundle\Form\Type\ExtRefType</parameter>
         <parameter key="graviton.document.form.type.document.class">Graviton\DocumentBundle\Form\Type\DocumentType</parameter>
+        <parameter key="graviton.document.form.type.freeform.class">Graviton\DocumentBundle\Form\Type\FreeForm</parameter>
     </parameters>
     <services>
         <!-- $ref output in responses -->
@@ -23,6 +24,10 @@
         <service id="graviton.document.form.type.document" class="%graviton.document.form.type.document.class%">
             <argument>%graviton.document.form.type.document.service_map%</argument>
             <argument>%graviton.document.form.type.document.field_map%</argument>
+        </service>
+        <!-- freeform form type -->
+        <service id="graviton.document.form.type.freeform" class="%graviton.document.form.type.freeform.class%">
+          <tag name="form.type" alias="freeform" />
         </service>
     </services>
 </container>

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
@@ -47,7 +47,7 @@ class DocumentFormFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->method('setParameter')
             ->with(
                 $this->equalTo('graviton.document.form.type.document.field_map'),
-                ['stdclass' => 'stdclass']
+                ['stdclass' => []]
             );
 
         $sut = new DocumentFormFieldsCompilerPass;

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
@@ -47,7 +47,7 @@ class DocumentFormFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->method('setParameter')
             ->with(
                 $this->equalTo('graviton.document.form.type.document.field_map'),
-                []
+                ['stdclass' => 'stdclass']
             );
 
         $sut = new DocumentFormFieldsCompilerPass;


### PR DESCRIPTION
@hairmare 

This simple solution seems to work fine to solve the nightmare that began in #167..
Can u pls verify if this works for u too?

Apparently, passing an object structure to a `text` based field imposes no problem at all, passing it through the whole thing ;-)

One could argue why we don't put it in a normal `text` field then, but IMHO it's cleaner to have a dedicated type to "hashes"..