### PR TITLE
coded against interface instead of concret implementation

### DIFF
--- a/src/Graviton/RestBundle/Validator/Constraints/BooleanStrictValidator.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/BooleanStrictValidator.php
@@ -29,9 +29,10 @@ class BooleanStrictValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if ($value !== true && $value !== false) {
-            $this->context->buildViolation($constraint->message)
-                          ->setParameter('%string%', $value)
-                          ->addViolation();
+            $this->context->addViolation(
+                $constraint->message,
+                array('%string%' => $value)
+            );
         }
     }
 }


### PR DESCRIPTION
addViolation is found in ExecutionContextInterface and buildViolation in ConstraintValidator. It's better to code against an interface instead of a concret class.