### PR TITLE
don't try to rewrite 'uri' to '$ref' in personcontant..

### DIFF
--- a/src/Graviton/PersonBundle/Resources/config/schema/PersonContact.json
+++ b/src/Graviton/PersonBundle/Resources/config/schema/PersonContact.json
@@ -1,5 +1,5 @@
 {
-  "description": "Contact informationj for a person.",
+  "description": "Contact information for a person.",
   "properties": {
     "id": {
       "title": "ID",
@@ -17,7 +17,7 @@
       "title": "Contact value",
       "description": "Protocol specific value to contact."
     },
-    "$ref": {
+    "uri": {
       "title": "URI",
       "description": "URI of Contact."
     }

--- a/src/Graviton/PersonBundle/Resources/config/serializer/Document.PersonContact.xml
+++ b/src/Graviton/PersonBundle/Resources/config/serializer/Document.PersonContact.xml
@@ -5,6 +5,6 @@
     <property name="type" type="string" accessor-getter="getType" accessor-setter="setType" exclude="false" expose="true"/>
     <property name="protocol" type="string" accessor-getter="getProtocol" accessor-setter="setProtocol" exclude="false" expose="true"/>
     <property name="value" type="string" accessor-getter="getValue" accessor-setter="setValue" exclude="false" expose="true"/>
-    <property name="uri" type="string" accessor-getter="getUri" accessor-setter="setUri" exclude="false" expose="true" serialized-name="$ref"/>
+    <property name="uri" type="string" accessor-getter="getUri" accessor-setter="setUri" exclude="false" expose="true"/>
   </class>
 </serializer>


### PR DESCRIPTION
`PersonContact` seems to be only used in `ShowCase.json` (will update that as soon this one is merged).

To expose `uri` as `$ref` doesn't work anymore since `RestController` doesn't use the serializer anymore.. I don't think it should be `$ref` as this is a "real" link - this one here are (mainly) links but they don't have to be. As it's more a test character, i just render it as `uri` again..