### PR TITLE
make both compiler passes also look at reference-[one|many] xml defs..

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -141,26 +141,27 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface, LoadField
             }
             $map[$class][] = [$fieldName, $type, $options];
         }
-        $embedNodes = $xpath->query("//doctrine:embed-one");
+
+        $embedNodes = $xpath->query("//*[self::doctrine:embed-one or self::doctrine:reference-one]");
         foreach ($embedNodes as $node) {
             $fieldName = $node->getAttribute('field');
             $targetDocument = $node->getAttribute('target-document');
 
             $this->loadEmbeddedDocuments(
                 $map,
-                $xpath->query("//doctrine:embed-one[@field='".$fieldName."']"),
+                $xpath->query("//doctrine:".$node->nodeName."[@field='".$fieldName."']"),
                 $targetDocument
             );
             $map[$class][] = [$fieldName, 'form', ['data_class' => $targetDocument]];
         }
-        $embedNodes = $xpath->query("//doctrine:embed-many");
+        $embedNodes = $xpath->query("////*[self::doctrine:embed-many or self::doctrine:reference-many]");
         foreach ($embedNodes as $node) {
             $fieldName = $node->getAttribute('field');
             $targetDocument = $node->getAttribute('target-document');
 
             $this->loadEmbeddedDocuments(
                 $map,
-                $xpath->query("//doctrine:embed-many[@field='".$fieldName."']"),
+                $xpath->query("//doctrine:".$node->nodeName."[@field='".$fieldName."']"),
                 $targetDocument,
                 true
             );

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormMapCompilerPass.php
@@ -98,7 +98,10 @@ class DocumentFormMapCompilerPass implements CompilerPassInterface, LoadFieldsIn
         $name = '',
         $prefix = ''
     ) {
-        foreach (['//doctrine:embed-one', '//doctrine:embed-many'] as $basePath) {
+        foreach ([
+                     '//*[self::doctrine:embed-one or self::doctrine:reference-one]',
+                     '//*[self::doctrine:embed-many or self::doctrine:reference-many]'
+            ] as $basePath) {
             $embedNodes = $xpath->query($basePath);
             foreach ($embedNodes as $node) {
                 $fieldName = $node->getAttribute('field');
@@ -108,7 +111,7 @@ class DocumentFormMapCompilerPass implements CompilerPassInterface, LoadFieldsIn
                     $map,
                     $xpath->query(sprintf("%s[@field='%s']", $basePath, $fieldName)),
                     $targetDocument,
-                    $basePath == '//doctrine:embed-many'
+                    (strpos($basePath, '-many') !== false)
                 );
                 $map[$targetDocument] = $targetDocument;
             }


### PR DESCRIPTION
[see title]
i discovered this one while preparing the ShowCase unit test - apparently, any `reference-one` and `reference-many` in doctrine.xml was not mapped before.. this one fixes that.. ;-)