### PR TITLE
make PUT to behave like POST

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -263,17 +263,23 @@ class AppControllerTest extends RestTestCase
         $response = $client->getResponse();
         $results = $client->getResults();
 
-        $this->assertResponseContentType(self::CONTENT_TYPE, $response);
+        // we sent a location header so we don't want a body
+        $this->assertNull($results);
+        $this->assertContains('/core/app', $response->headers->get('Location'));
 
-        $this->assertEquals('tablet', $results->id);
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $response = $client->getResponse();
+        $results = $client->getResults();
+
+        $this->assertResponseContentType(self::CONTENT_TYPE, $response);
         $this->assertEquals('Tablet', $results->title->en);
         $this->assertFalse($results->showInMenu);
-
         $this->assertContains(
-            '<http://localhost/core/app/tablet>; rel="self"',
+            '<http://localhost/core/app/'.$results->id.'>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
+
     }
 
     /**
@@ -321,7 +327,13 @@ class AppControllerTest extends RestTestCase
         $response = $client->getResponse();
         $results = $client->getResults();
 
-        $this->assertResponseContentType(self::CONTENT_TYPE, $response);
+        // we sent a location header so we don't want a body
+        $this->assertNull($results);
+        $this->assertContains('/core/app', $response->headers->get('Location'));
+
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $results = $client->getResults();
 
         $this->assertEquals('tablet', $results->id);
         $this->assertEquals('New tablet', $results->title->en);

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -276,7 +276,7 @@ class AppControllerTest extends RestTestCase
         $this->assertEquals('Tablet', $results->title->en);
         $this->assertFalse($results->showInMenu);
         $this->assertContains(
-            '<http://localhost/core/app/'.$results->id.'>; rel="self"',
+            '<http://localhost/core/app/tablet>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
 

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -229,6 +229,10 @@ class ModuleControllerTest extends RestTestCase
         $client->put('/core/module/'.$moduleId, $putModule);
 
         $response = $client->getResponse();
+
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $response = $client->getResponse();
         $results = $client->getResults();
 
         $this->assertResponseContentType(self::CONTENT_TYPE, $response);

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -190,10 +190,7 @@ class FileController extends RestController
         $response->setStatusCode(Response::HTTP_OK);
 
         $routeName = $request->get('_route');
-        $routeParts = explode('.', $routeName);
-        $routeType = end($routeParts);
-
-        if ($routeType == 'put') {
+        if (substr($routeName, 0, -4) == '.put') {
             $routeName = substr($routeName, 0, -3) . 'get';
         }
 

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -101,7 +101,6 @@ class FileController extends RestController
 
         // Set status code and content
         $response->setStatusCode(Response::HTTP_CREATED);
-        $response->setContent($this->serialize($record));
 
         $routeName = $request->get('_route');
         $routeParts = explode('.', $routeName);
@@ -115,12 +114,7 @@ class FileController extends RestController
             'Location',
             $this->getRouter()->generate($routeName, array('id' => $record->getId()))
         );
-
-        return $this->render(
-            'GravitonRestBundle:Main:index.json.twig',
-            array('response' => $response->getContent()),
-            $response
-        );
+        return $response;
     }
 
     /**

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -183,8 +183,26 @@ class FileController extends RestController
 
         $this->getModel()->updateRecord($id, $record);
 
-        return parent::getAction($request, $id);
+        // store id of new record so we dont need to reparse body later when needed
+        $request->attributes->set('id', $record->getId());
 
+        $response = $this->getResponse();
+        $response->setStatusCode(Response::HTTP_OK);
+
+        $routeName = $request->get('_route');
+        $routeParts = explode('.', $routeName);
+        $routeType = end($routeParts);
+
+        if ($routeType == 'put') {
+            $routeName = substr($routeName, 0, -3) . 'get';
+        }
+
+        $response->headers->set(
+            'Location',
+            $this->getRouter()->generate($routeName, array('id' => $record->getId()))
+        );
+
+        return $response;
     }
 
 

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -117,7 +117,11 @@ class FileControllerTest extends RestTestCase
 
         $this->assertEquals($fixtureData, $results);
 
+        // change link and add second link
         $data->links[0]->{'$ref'} = 'http://localhost/core/app/admin';
+        $link = new \stdClass;
+        $link->{'$ref'} = 'http://localhost/core/app/web';
+        $data->links[] = $link;
 
         $client = static::createRestClient();
         $client->put(sprintf('/file/%s', $data->id), $data);
@@ -129,7 +133,23 @@ class FileControllerTest extends RestTestCase
         $results = $client->getResults();
 
         $this->assertEquals($data->links[0]->{'$ref'}, $results->links[0]->{'$ref'});
+        $this->assertEquals($data->links[1]->{'$ref'}, $results->links[1]->{'$ref'});
 
+        // remove a link
+        unset($data->links[1]);
+
+        $client = static::createRestClient();
+        $client->put(sprintf('/file/%s', $data->id), $data);
+        $response = $client->getResponse();
+        // re-fetch
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $results = $client->getResults();
+
+        $this->assertEquals($data->links[0]->{'$ref'}, $results->links[0]->{'$ref'});
+        $this->assertCount(1, $results->links);
+
+        // remove last link
         $data->links = [];
         $client = static::createRestClient();
         $client->put(sprintf('/file/%s', $data->id), $data);

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -79,9 +79,13 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => 'text/plain'],
             false
         );
-        $data = $client->getResults();
         $response = $client->getResponse();
         $this->assertEquals(201, $response->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $response = $client->getResponse();
+        $data = $client->getResults();
 
         $data->links = [];
         $link = new \stdClass;
@@ -97,7 +101,7 @@ class FileControllerTest extends RestTestCase
 
         $response = $client->getResponse();
 
-        // re-fetch object with location header
+        // re-fetch object from Location header
         $client = static::createRestClient();
         $client->request('GET', $response->headers->get('Location'));
         $results = $client->getResults();

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -211,9 +211,13 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => 'text/plain'],
             false
         );
-        $data = $client->getResults();
         $response = $client->getResponse();
         $this->assertEquals(201, $response->getStatusCode());
+
+        // re-fetch
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $data = $client->getResults();
 
         $client = static::createRestClient();
         $client->request('DELETE', sprintf('/file/%s', $data->id));

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -112,27 +112,16 @@ class FileControllerTest extends RestTestCase
 
         $this->assertEquals($fixtureData, $results);
 
-        var_dump($data);
-
         $data->links[0]->{'$ref'} = 'http://localhost/core/app/admin';
-
-        var_dump($data);
-
-        echo "--------------".PHP_EOL;
 
         $client = static::createRestClient();
         $client->put(sprintf('/file/%s', $data->id), $data);
         $response = $client->getResponse();
 
-        var_dump($response->headers->get('Location'));
-
         // re-fetch
         $client = static::createRestClient();
         $client->request('GET', $response->headers->get('Location'));
         $results = $client->getResults();
-
-        var_dump($results);
-        die;
 
         $this->assertEquals($data->links[0]->{'$ref'}, $results->links[0]->{'$ref'});
 
@@ -230,8 +219,15 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => $contentType],
             false
         );
-        $retData = $client->getResults();
         $this->assertEquals(201, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+
+        // re-fetch
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+        $retData = $client->getResults();
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertEquals(strlen($fixtureData), $retData->metadata->size);
         $this->assertEquals($contentType, $retData->metadata->mime);
 
@@ -244,6 +240,11 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => $contentType],
             false
         );
+        $response = $client->getResponse();
+
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+
         $retData = $client->getResults();
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertEquals(strlen($newData), $retData->metadata->size);

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -85,7 +85,6 @@ class FileControllerTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->request('GET', $response->headers->get('Location'));
-        $response = $client->getResponse();
         $data = $client->getResults();
 
         $data->links = [];

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -79,6 +79,7 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => 'text/plain'],
             false
         );
+        $this->assertEmpty($client->getResults());
         $response = $client->getResponse();
         $this->assertEquals(201, $response->getStatusCode());
 

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -92,8 +92,14 @@ class FileControllerTest extends RestTestCase
         $data->metadata->filename = $filename;
 
         $client = static::createRestClient();
+
         $client->put(sprintf('/file/%s', $data->id), $data);
 
+        $response = $client->getResponse();
+
+        // re-fetch object with location header
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
         $results = $client->getResults();
 
         $this->assertEquals($link->{'$ref'}, $results->links[0]->{'$ref'});
@@ -106,17 +112,39 @@ class FileControllerTest extends RestTestCase
 
         $this->assertEquals($fixtureData, $results);
 
+        var_dump($data);
+
         $data->links[0]->{'$ref'} = 'http://localhost/core/app/admin';
+
+        var_dump($data);
+
+        echo "--------------".PHP_EOL;
 
         $client = static::createRestClient();
         $client->put(sprintf('/file/%s', $data->id), $data);
+        $response = $client->getResponse();
+
+        var_dump($response->headers->get('Location'));
+
+        // re-fetch
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
         $results = $client->getResults();
+
+        var_dump($results);
+        die;
 
         $this->assertEquals($data->links[0]->{'$ref'}, $results->links[0]->{'$ref'});
 
         $data->links = [];
         $client = static::createRestClient();
         $client->put(sprintf('/file/%s', $data->id), $data);
+        $response = $client->getResponse();
+
+        // re-fetch
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
+
         $results = $client->getResults();
 
         $this->assertEmpty($results->links);

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -22,7 +22,7 @@
             {% if 'Graviton' in field.type %}
                 {% if field.relType is defined %}{% set relType = field.relType %}{% else %}{% set relType = "reference" %}{% endif %}
                 {% if '[]' in field.type %}
-                    <{{ relType }}-many field="{{ field.fieldName }}" target-document="{{ field.type[0:-2] }}">
+                    <{{ relType }}-many field="{{ field.fieldName }}" target-document="{{ field.type[0:-2] }}" strategy="set">
                         <cascade>
                             <all/>
                         </cascade>

--- a/src/Graviton/I18nBundle/Tests/Controller/LanguageControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/LanguageControllerTest.php
@@ -170,6 +170,16 @@ class LanguageControllerTest extends RestTestCase
         $client = static::createRestClient();
         $client->put('/i18n/language/es', $putLang, array(), array(), array('HTTP_ACCEPT_LANGUAGE' => 'es'));
         $response = $client->getResponse();
+
+        $client = static::createRestClient();
+        $client->request(
+            'GET',
+            $response->headers->get('Location'),
+            array(),
+            array(),
+            array('HTTP_ACCEPT_LANGUAGE' => 'es')
+        );
+        $response = $client->getResponse();
         $results = $client->getResults();
 
         $this->assertResponseContentType(self::CONTENT_TYPE . 'item', $response);
@@ -183,6 +193,16 @@ class LanguageControllerTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->put('/i18n/language/es', $newPutLang, array(), array(), array('HTTP_ACCEPT_LANGUAGE' => 'es'));
+        $response = $client->getResponse();
+
+        $client = static::createRestClient();
+        $client->request(
+            'GET',
+            $response->headers->get('Location'),
+            array(),
+            array(),
+            array('HTTP_ACCEPT_LANGUAGE' => 'es')
+        );
         $response = $client->getResponse();
         $results = $client->getResults();
 

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -412,13 +412,27 @@ class RestController
         } else {
             $this->getModel()->updateRecord($id, $record);
         }
+
+        // store id of new record so we dont need to reparse body later when needed
+        $request->attributes->set('id', $record->getId());
+
+        // Set status code
         $response->setStatusCode(Response::HTTP_OK);
 
-        return $this->render(
-            'GravitonRestBundle:Main:index.json.twig',
-            ['response' => $this->serialize($record)],
-            $response
+        $routeName = $request->get('_route');
+        $routeParts = explode('.', $routeName);
+        $routeType = end($routeParts);
+
+        if ($routeType == 'put') {
+            $routeName = substr($routeName, 0, -3) . 'get';
+        }
+
+        $response->headers->set(
+            'Location',
+            $this->getRouter()->generate($routeName, array('id' => $record->getId()))
         );
+
+        return $response;
     }
 
     /**
@@ -475,7 +489,7 @@ class RestController
         return $response;
     }
 
- 
+
     /**
      * Return schema GET results.
      *

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -420,10 +420,7 @@ class RestController
         $response->setStatusCode(Response::HTTP_OK);
 
         $routeName = $request->get('_route');
-        $routeParts = explode('.', $routeName);
-        $routeType = end($routeParts);
-
-        if ($routeType == 'put') {
+        if (substr($routeName, 0, -4) == '.put') {
             $routeName = substr($routeName, 0, -3) . 'get';
         }
 

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -165,7 +165,7 @@ class DocumentModel extends SchemaModel implements ModelInterface
     public function updateRecord($documentId, $entity)
     {
         $manager = $this->repository->getDocumentManager();
-        $manager->persist($entity);
+        $entity = $manager->merge($entity);
         $manager->flush();
 
         return $entity;


### PR DESCRIPTION
as was noted by our customers, PUT now behaves different from POST (returning content instead of Location/Link header)..

This PR tries to make PUT behavior the same as POST. 

This has some urgency, as (in a slightly unrelated matter) some services (as `Consultation`) fail to get there content back on the current PUT implementation is the Serializer struggles to deserialize what comes from Symfony form (ie some dates now seem to be String instead of DateTime)..

@hairmare There seems mystery is happening in `FileControllerTest` ("make array of things writable"). Do you have any insight?  Somehow, when the `links` array is altered and PUT'ted, then GET'ted again, the `links` array has two items - which lead the test to fail.

Obviously, that test needs to pass - but I struggle to understand why the changes in `RestController` could render "make array of things writable" broken - any ideas?