### PR TITLE
make sure we don't override rql limit()

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -108,6 +108,24 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * rql limit() should be *never* overwritten by $_GET['perPage'] *or* default value
+     *
+     * @return void
+     */
+    public function testGetAppPagingWithRql()
+    {
+        // does limit work?
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app?q='.urlencode('limit(1)'));
+        $this->assertEquals(1, count($client->getResults()));
+
+        // rql before GET?
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app?perPage=2&q='.urlencode('limit(1)'));
+        $this->assertEquals(1, count($client->getResults()));
+    }
+
+    /**
      * check for empty collections when no fixtures are loaded
      *
      * @return void

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -123,6 +123,23 @@ class AppControllerTest extends RestTestCase
         $client = static::createRestClient();
         $client->request('GET', '/core/app?perPage=2&q='.urlencode('limit(1)'));
         $this->assertEquals(1, count($client->getResults()));
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=limit%281%29>; rel="self"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=limit%281%29&page=2&perPage=1>; rel="next"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=limit%281%29&page=2&perPage=1>; rel="last"',
+            explode(',', $response->headers->get('Link'))
+        );
     }
 
     /**

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -140,6 +140,31 @@ class AppControllerTest extends RestTestCase
             '<http://localhost/core/app?q=limit%281%29&page=2&perPage=1>; rel="last"',
             explode(',', $response->headers->get('Link'))
         );
+
+        // "page" override - rql before get
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app?perPage=2&page=1&q='.urlencode('limit(1,1)'));
+        $this->assertEquals(1, count($client->getResults()));
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            '<http://localhost/core/app?q=limit%281%2C1%29>; rel="self"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        // we're passing page=1, but should be on last.. so next and last should be identical
+        $nextAndLastUrl = 'http://localhost/core/app?q=limit%281%2C1%29&page=2&perPage=1';
+
+        $this->assertContains(
+            '<'.$nextAndLastUrl.'>; rel="next"',
+            explode(',', $response->headers->get('Link'))
+        );
+
+        $this->assertContains(
+            '<'.$nextAndLastUrl.'>; rel="last"',
+            explode(',', $response->headers->get('Link'))
+        );
     }
 
     /**

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -116,7 +116,7 @@ class DocumentModel extends SchemaModel implements ModelInterface
         if (!array_key_exists('limit', $queryBuilder->getQuery()->getQuery())) {
             $queryBuilder->limit($numberPerPage);
         } else {
-            $numberPerPage = (int) $queryBuilder->getQuery()->getQuery();
+            $numberPerPage = (int) $queryBuilder->getQuery()->getQuery()['limit'];
         }
 
         /**

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -111,7 +111,9 @@ class DocumentModel extends SchemaModel implements ModelInterface
         }
 
         // define offset and limit
-        $queryBuilder->skip($startAt);
+        if (!array_key_exists('skip', $queryBuilder->getQuery()->getQuery())) {
+            $queryBuilder->skip($startAt);
+        }
 
         if (!array_key_exists('limit', $queryBuilder->getQuery()->getQuery())) {
             $queryBuilder->limit($numberPerPage);

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -109,9 +109,15 @@ class DocumentModel extends SchemaModel implements ModelInterface
             /** @var \Doctrine\ODM\MongoDB\Query\Builder $qb */
             $queryBuilder->find($this->repository->getDocumentName());
         }
+
         // define offset and limit
         $queryBuilder->skip($startAt);
-        $queryBuilder->limit($numberPerPage);
+
+        if (!array_key_exists('limit', $queryBuilder->getQuery()->getQuery())) {
+            $queryBuilder->limit($numberPerPage);
+        } else {
+            $numberPerPage = (int) $queryBuilder->getQuery()->getQuery();
+        }
 
         /**
          * add a default sort on id if none was specified earlier


### PR DESCRIPTION
currently, the applying of the default value of `perPage` *always* overrides whatever is passed by RQL.. Thus, limiting via RQL is not possible at all currently..

IMHO rql `limit()` should always be the master and should not be overriden by `GET[perPage]`, this PR implements that..