### PR TITLE
Ignore id of embedded documents in schema

### DIFF
--- a/src/Graviton/RestBundle/Service/RestUtils.php
+++ b/src/Graviton/RestBundle/Service/RestUtils.php
@@ -167,6 +167,10 @@ final class RestUtils implements RestUtilsInterface
                 if ($route->getRequirement('_method') != 'OPTIONS') {
                     return false;
                 }
+                // ignore all schema routes
+                if (strpos($route->getPath(), '/schema') === 0) {
+                    return false;
+                }
                 if ($route->getPath() == '/') {
                     return false;
                 }

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -128,6 +128,10 @@ class SchemaUtils
             $schema->addProperty($field, $property);
         }
 
+        if ($meta->isEmbeddedDocument && !in_array('id', $model->getRequiredFields())) {
+            $schema->removeProperty('id');
+        }
+
         $requiredFields = $model->getRequiredFields();
         foreach ($requiredFields as $index => $requiredField) {
             if ($requiredField === 'ref') {


### PR DESCRIPTION
This is just a clean cherry pick of #177. And supersedes that as such. It also contains one additional fix in that we could in theory still have embedded docs that require an id.