### PR TITLE
Deny POSTing new documents with id

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -245,6 +245,25 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     *
+     */
+    public function testPostWithId()
+    {
+        $helloApp = new \stdClass();
+        $helloApp->id = 101;
+        $helloApp->name = "tubel";
+
+        $client = static::createRestClient();
+        $client->post('/person/customer', $helloApp);
+        $response = $client->getResponse();
+        $results = $client->getResults();
+
+        $this->assertEquals('Can not be given on a POST request. Do a PUT request instead to update an existing record.', json_decode($response->getContent())[0]->message);
+
+
+
+    }
+    /**
      * test updating apps
      *
      * @return void

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -245,7 +245,9 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * tests if an error is returned when a id is send in a post
      *
+     * @return void
      */
     public function testPostWithId()
     {
@@ -258,7 +260,10 @@ class AppControllerTest extends RestTestCase
         $response = $client->getResponse();
         $results = $client->getResults();
 
-        $this->assertEquals('Can not be given on a POST request. Do a PUT request instead to update an existing record.', json_decode($response->getContent())[0]->message);
+        $this->assertEquals(
+            'Can not be given on a POST request. Do a PUT request instead to update an existing record.',
+            json_decode($response->getContent())[0]->message
+        );
 
 
 

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -245,7 +245,7 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
-     * tests if an error is returned when a id is send in a post
+     * Tests if an error is returned when an id is send in a post
      *
      * @return void
      */
@@ -257,12 +257,10 @@ class AppControllerTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->post('/person/customer', $helloApp);
-        $response = $client->getResponse();
-        $results = $client->getResults();
 
         $this->assertEquals(
             'Can not be given on a POST request. Do a PUT request instead to update an existing record.',
-            json_decode($response->getContent())[0]->message
+            $client->getResults()[0]->message
         );
 
 

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/validator/validation.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/validator/validation.xml.twig
@@ -5,19 +5,19 @@
     <class name="{{ base }}Document\{{ document }}">
 
 {% if noIdField is not defined %}
-        <!--
+
         <property name="id">
-            <constraint name="NotBlank"/>
+            <constraint name='Graviton\RestBundle\Validator\Constraints\Id\IdInPost'/>
         </property>
-        -->
+
 {% endif %}
+
 
 {% for field in fields %}
 
 {# there is an xml error if we generate <property> without <constraint> child, that's why we build array first to check #}
 
     {% set thisCons = [] %}
-
     {% if field.required is defined and field.required == true %}
         {% if field.type != 'boolean' %}
             {%  set thisCons = thisCons|merge(['<constraint name="NotBlank"/>']) %}

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -578,7 +578,7 @@ class RestController
     {
         list($service) = explode(':', $request->attributes->get('_controller'));
         $this->formType->initialize($service);
-        return $this->formFactory->create($this->formType);
+        return $this->formFactory->create($this->formType, null, array('method'=> $request->getMethod()));
     }
 
     /**

--- a/src/Graviton/RestBundle/Validator/Constraints/Id/IdInPost.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/Id/IdInPost.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Constraint for the ID in payload in PUT request
+ */
+
+namespace Graviton\RestBundle\Validator\Constraints\Id;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint for the ID in payload in PUT requests
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class IdInPost extends Constraint
+{
+
+    /**
+     * Error message
+     *
+     * @var string
+     */
+    public $message = 'Can not be given on a POST request. Do a PUT request instead to update an existing record.';
+}

--- a/src/Graviton/RestBundle/Validator/Constraints/Id/IdInPostValidator.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/Id/IdInPostValidator.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Validator for a POST request
+ */
+
+namespace Graviton\RestBundle\Validator\Constraints\Id;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator that validates if its a POST request with an ID in the payload
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class IdInPostValidator extends ConstraintValidator
+{
+
+    /**
+     * Checks if the ID is not in the payload of a POST request
+     *
+     * @param string     $value      Input value
+     * @param Constraint $constraint Constraint instance
+     *
+     * @return void
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $HTTPVerb = $this->context->getRoot()->getConfig()->getMethod();
+        $id = $this->context->getRoot()->getData()->getId();
+        if ($HTTPVerb === 'POST' && isset($id)) {
+                $this->context->addViolation($constraint->message);
+        }
+    }
+}


### PR DESCRIPTION
The problem was that it did an UPDATE request when the user did a POST request with an ID in the payload, what is actually not right. This should solve the problem and returns an error message by validating the request.