### PR TITLE
Find referenced fields as well as embedded fields in extref mapper

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -80,8 +80,17 @@ class ExtRefFieldsCompilerPass extends AbstractExtRefCompilerPass implements Loa
 
         $namePrefix = strtolower(implode('.', [$ns, $bundle, 'rest', $doc, '']));
 
-        $this->loadEmbeddedDocuments($map, $xpath->query('//doctrine:embed-one'), $namePrefix);
-        $this->loadEmbeddedDocuments($map, $xpath->query('//doctrine:embed-many'), $namePrefix, true);
+        $this->loadEmbeddedDocuments(
+            $map,
+            $xpath->query('//*[self::doctrine:embed-one or self::doctrine:reference-one]'),
+            $namePrefix
+        );
+        $this->loadEmbeddedDocuments(
+            $map,
+            $xpath->query('//*[self::doctrine:embed-many or self::doctrine:reference-many]'),
+            $namePrefix,
+            true
+        );
 
         foreach (['get', 'all'] as $suffix) {
             if ($embedded) {


### PR DESCRIPTION
With this we also support having extref fields in referenced documents and not only in embedded ones.