### PR TITLE
ShowCase Unit Test

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -77,6 +77,8 @@ class ShowcaseControllerTest extends RestTestCase
      */
     public function testMinimalPost()
     {
+        // showcase contains some datetime fields that we need rendered as UTC in the case of this test
+        ini_set('date.timezone', 'UTC');
         $document = json_decode(
             file_get_contents(dirname(__FILE__).'/../resources/showcase-minimal.json'),
             false

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * functional test for /core/product
+ * functional test for /hans/showcase
  */
 
 namespace Graviton\CoreBundle\Tests\Controller;
@@ -100,6 +100,35 @@ class ShowcaseControllerTest extends RestTestCase
         $this->assertJsonStringEqualsJsonString(
             json_encode($document),
             json_encode($result)
+        );
+    }
+
+    /**
+     * are extra fields denied?
+     *
+     * @return void
+     */
+    public function testExtraFieldPost()
+    {
+        ini_set('date.timezone', 'UTC');
+        $document = json_decode(
+            file_get_contents(dirname(__FILE__).'/../resources/showcase-minimal.json'),
+            false
+        );
+        $document->extraFields = "nice field";
+
+        $client = static::createRestClient();
+        $client->post('/hans/showcase', $document);
+        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+
+        $expectedErrors = [];
+        $expectedErrors[0] = new \stdClass();
+        $expectedErrors[0]->property_path = "";
+        $expectedErrors[0]->message = "This form should not contain extra fields.";
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expectedErrors),
+            json_encode($client->getResults())
         );
     }
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -71,16 +71,20 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
-     * insert a minimal set of data
+     * insert various formats to see if all works as expected
+     *
+     * @dataProvider postCreationDataProvider
+     *
+     * @param string $filename filename
      *
      * @return void
      */
-    public function testMinimalPost()
+    public function testPost($filename)
     {
         // showcase contains some datetime fields that we need rendered as UTC in the case of this test
         ini_set('date.timezone', 'UTC');
         $document = json_decode(
-            file_get_contents(dirname(__FILE__).'/../resources/showcase-minimal.json'),
+            file_get_contents($filename),
             false
         );
 
@@ -100,6 +104,21 @@ class ShowcaseControllerTest extends RestTestCase
         $this->assertJsonStringEqualsJsonString(
             json_encode($document),
             json_encode($result)
+        );
+    }
+
+    /**
+     * Provides test sets for the testPost() test.
+     *
+     * @return array
+     */
+    public function postCreationDataProvider()
+    {
+        $basePath = dirname(__FILE__).'/../resources/';
+
+        return array(
+            'minimal' => array($basePath.'showcase-minimal.json'),
+            'complete' => array($basePath.'showcase-complete.json')
         );
     }
 

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -8,7 +8,7 @@ namespace Graviton\CoreBundle\Tests\Controller;
 use Graviton\TestBundle\Test\RestTestCase;
 
 /**
- * Basic functional test for /core/product.
+ * Functional test for /hans/showcase
  *
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
@@ -19,12 +19,12 @@ class ShowcaseControllerTest extends RestTestCase
     /**
      * @const complete content type string expected on a resouce
      */
-    const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/core/product/item';
+    const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/hans/showcase/item';
 
     /**
      * @const corresponding vendorized schema mime type
      */
-    const COLLECTION_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/core/product/collection';
+    const COLLECTION_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/hans/showcase/collection';
 
     /**
      * setup client and load fixtures

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * functional test for /core/product
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+
+/**
+ * Basic functional test for /core/product.
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ShowcaseControllerTest extends RestTestCase
+{
+    /**
+     * @const complete content type string expected on a resouce
+     */
+    const CONTENT_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/core/product/item';
+
+    /**
+     * @const corresponding vendorized schema mime type
+     */
+    const COLLECTION_TYPE = 'application/json; charset=UTF-8; profile=http://localhost/schema/core/product/collection';
+
+    /**
+     * setup client and load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+    }
+
+    /**
+     * check if all fixtures are returned on GET
+     *
+     * @return void
+     */
+    public function testAllFeatures()
+    {
+        $fullDocument = json_decode(
+            file_get_contents(dirname(__FILE__).'/../resources/showcase-complete.json'),
+            true
+        );
+
+        $client = static::createRestClient();
+
+        $client->post('/hans/showcase', $fullDocument);
+        $response = $client->getResponse();
+
+        //var_dump($response); die;
+        //$results = $client->getResults();
+
+        //
+        //var_dump($client);
+
+    }
+}

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -36,7 +36,7 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
-     * See how our missing fields are explained to us
+     * see how our missing fields are explained to us
      *
      * @return void
      */
@@ -63,9 +63,6 @@ class ShowcaseControllerTest extends RestTestCase
         $expectedErrors[3] = new \stdClass();
         $expectedErrors[3]->property_path = "data.contact.value";
         $expectedErrors[3]->message = "This value should not be blank.";
-        $expectedErrors[4] = new \stdClass();
-        $expectedErrors[4]->property_path = "data.contactCode.text";
-        $expectedErrors[4]->message = "This value should not be blank.";
 
         $this->assertJsonStringEqualsJsonString(
             json_encode($expectedErrors),
@@ -74,29 +71,33 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
-     * check if all fixtures are returned on GET
+     * insert a minimal set of data
      *
      * @return void
      */
     public function testMinimalPost()
     {
-        $fullDocument = json_decode(
+        $document = json_decode(
             file_get_contents(dirname(__FILE__).'/../resources/showcase-minimal.json'),
-            true
+            false
         );
 
         $client = static::createRestClient();
-        $client->post('/hans/showcase', $fullDocument);
+        $client->post('/hans/showcase', $document);
         $response = $client->getResponse();
 
         $client = static::createRestClient();
         $client->request('GET', $response->headers->get('Location'));
 
-        $response = $client->getResults();
+        $result = $client->getResults();
+
+        // unset id as we cannot compare and don't care
+        $this->assertNotNull($result->id);
+        unset($result->id);
 
         $this->assertJsonStringEqualsJsonString(
-            json_encode($fullDocument),
-            json_encode($response)
+            json_encode($document),
+            json_encode($result)
         );
     }
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -36,27 +36,67 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
-     * check if all fixtures are returned on GET
+     * See how our missing fields are explained to us
      *
      * @return void
      */
-    public function testAllFeatures()
+    public function testMissingFields()
     {
-        $fullDocument = json_decode(
-            file_get_contents(dirname(__FILE__).'/../resources/showcase-complete.json'),
+        $document = json_decode(
+            file_get_contents(dirname(__FILE__).'/../resources/showcase-incomplete.json'),
             true
         );
 
         $client = static::createRestClient();
+        $client->post('/hans/showcase', $document);
 
+        $expectedErrors = [];
+        $expectedErrors[0] = new \stdClass();
+        $expectedErrors[0]->property_path = "children[someOtherField]";
+        $expectedErrors[0]->message = "This value is not valid.";
+        $expectedErrors[1] = new \stdClass();
+        $expectedErrors[1]->property_path = "data.contact.type";
+        $expectedErrors[1]->message = "This value should not be blank.";
+        $expectedErrors[2] = new \stdClass();
+        $expectedErrors[2]->property_path = "data.contact.protocol";
+        $expectedErrors[2]->message = "This value should not be blank.";
+        $expectedErrors[3] = new \stdClass();
+        $expectedErrors[3]->property_path = "data.contact.value";
+        $expectedErrors[3]->message = "This value should not be blank.";
+        $expectedErrors[4] = new \stdClass();
+        $expectedErrors[4]->property_path = "data.contactCode.text";
+        $expectedErrors[4]->message = "This value should not be blank.";
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expectedErrors),
+            json_encode($client->getResults())
+        );
+    }
+
+    /**
+     * check if all fixtures are returned on GET
+     *
+     * @return void
+     */
+    public function testMinimalPost()
+    {
+        $fullDocument = json_decode(
+            file_get_contents(dirname(__FILE__).'/../resources/showcase-minimal.json'),
+            true
+        );
+
+        $client = static::createRestClient();
         $client->post('/hans/showcase', $fullDocument);
         $response = $client->getResponse();
 
-        //var_dump($response); die;
-        //$results = $client->getResults();
+        $client = static::createRestClient();
+        $client->request('GET', $response->headers->get('Location'));
 
-        //
-        //var_dump($client);
+        $response = $client->getResults();
 
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($fullDocument),
+            json_encode($response)
+        );
     }
 }

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
@@ -6,17 +6,30 @@
   "aBoolean": false,
   "optionalBoolean": true,
   "someFloatyDouble": 11.7,
-  "modificationDate": "1984-05-02T00:00:00Z",
+  "modificationDate": "1984-05-02T00:00:00+0000",
+  "contactCode": {
+    "someDate": "1984-05-01T00:00:00+0000"
+  },
   "contact": {
     "type": "home",
     "value": "joe@example.com",
     "protocol": "mailto",
     "uri": "mailto:joe@example.com"
   },
-  "contactCode": {
-    "someDate": "2012-12-21T00:00:00Z",
-    "text": "Ad mailing campaign 2012"
-  },
+  "contacts": [
+    {
+      "type": "home2",
+      "value": "joe2@example.com",
+      "protocol": "mailto",
+      "uri": "mailto:joe2@example.com"
+    },
+    {
+      "type": "home3",
+      "value": "joe3@example.com",
+      "protocol": "mailto",
+      "uri": "mailto:joe3@example.com"
+    }
+  ],
   "nestedArray": [
     {"name": "element one"},
     {"name": "element two"}
@@ -46,6 +59,18 @@
     },
     {
       "$ref": "http://localhost/core/app/admin"
+    }
+  ],
+  "nestedCustomers": [
+    {
+      "id": "1234",
+      "name": "Hans",
+      "$ref": "http://localhost/core/app/admin"
+    },
+    {
+      "id": "1235",
+      "name": "Franz",
+      "$ref": "http://localhost/core/app/tablet"
     }
   ]
 }

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
@@ -1,0 +1,51 @@
+{
+  "anotherInt": 6555488894525,
+  "testField": {"en": "a test string"},
+  "email": "joe@example.com",
+  "someOtherField": {"en": "another good ol' test string"},
+  "aBoolean": false,
+  "optionalBoolean": true,
+  "someFloatyDouble": 11.7,
+  "modificationDate": "1984-05-02T00:00:00Z",
+  "contact": {
+    "type": "home",
+    "value": "joe@example.com",
+    "protocol": "mailto",
+    "uri": "mailto:joe@example.com"
+  },
+  "contactCode": {
+    "someDate": "2012-12-21T00:00:00Z",
+    "text": "Ad mailing campaign 2012"
+  },
+  "nestedArray": [
+    {"name": "element one"},
+    {"name": "element two"}
+  ],
+  "unstructuredObject": {
+    "intField": 17,
+    "stringField": "Tux",
+    "listField": ["Linus", "Gnu"],
+    "hashField": {
+      "someField": 21,
+      "anotherField": "half the truth"
+    },
+    "nestedArrayField": [
+      {
+        "someField": 21,
+        "anotherField": "half the truth"
+      },
+      {
+        "someField": 23,
+        "anotherField": "nothing is as it seems"
+      }
+    ]
+  },
+  "nestedApps": [
+    {
+      "$ref": "http://localhost/core/app/tablet"
+    },
+    {
+      "$ref": "http://localhost/core/app/admin"
+    }
+  ]
+}

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-incomplete.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-incomplete.json
@@ -1,0 +1,4 @@
+{
+  "anotherInt": 6555488894525,
+  "testField": {"en": "a test string"}
+}

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
@@ -1,0 +1,15 @@
+{
+  "anotherInt": 6555488894525,
+  "testField": {"en": "a test string"},
+  "someOtherField": {"en": "another good ol' test string"},
+  "contact": {
+    "type": "home",
+    "value": "joe@example.com",
+    "protocol": "mailto",
+    "uri": "mailto:joe@example.com"
+  },
+  "contactCode": {
+    "someDate": "2012-12-21T00:00:00Z",
+    "text": {"en": "Ad mailing campaign 2012"}
+  }
+}

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
@@ -1,15 +1,21 @@
 {
   "anotherInt": 6555488894525,
   "testField": {"en": "a test string"},
+  "modificationDate": "1984-05-02T00:00:00+0000",
   "someOtherField": {"en": "another good ol' test string"},
+  "aBoolean": false,
+  "optionalBoolean": false,
   "contact": {
     "type": "home",
     "value": "joe@example.com",
     "protocol": "mailto",
     "uri": "mailto:joe@example.com"
   },
+  "contacts": [],
+  "nestedCustomers": [],
   "contactCode": {
-    "someDate": "2012-12-21T00:00:00Z",
-    "text": {"en": "Ad mailing campaign 2012"}
-  }
+    "someDate": "1984-05-01T00:00:00+0000"
+  },
+  "nestedArray": [],
+  "nestedApps": []
 }

--- a/src/Graviton/I18nBundle/Listener/I18nSerializationListener.php
+++ b/src/Graviton/I18nBundle/Listener/I18nSerializationListener.php
@@ -61,7 +61,7 @@ class I18nSerializationListener
                     $getter = 'get'.ucfirst($field);
 
                     // only allow objects that we can update during postSerialize
-                    if (method_exists($object, $setter)) {
+                    if (method_exists($object, $setter) && $object->$getter() != null) {
                             $this->localizedFields[\spl_object_hash($object)][$field] = $object->$getter();
                             // remove untranslated field to make space for translation struct
                             $object->$setter(null);


### PR DESCRIPTION
this is a PR that should cover the Generator results by testing our `ShowCase.json` service.

Results found, stuff we need to fix/decide
- [x] **Current fail**: If you don't POST a translatable at all; Graviton returns it empty (`{text: {en: ''}}`) - this is IMHO wrong as it's not possible to actually POST that to Graviton. Or is the test assertion wrong? 

