### PR TITLE
Make module translatable

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Module.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Module.json
@@ -10,13 +10,17 @@
         "app": {
           "$ref": "http://localhost/core/app/tablet"
         },
-        "name": "Real Estate",
+        "name": {
+          "en": "Real Estate"
+        },
         "path": "/module/realestate",
         "order": 1,
         "service": [
           {
-            "name": "1st admin GUI",
             "description" : "...",
+            "name": {
+              "en": "1st admin GUI"
+            },
             "gui": {
               "$ref": "/core/product/1"
             },
@@ -31,13 +35,17 @@
         "app": {
           "$ref": "http://localhost/core/app/tablet"
         },
-        "name": "Investment",
+        "name": {
+          "en": "Investment"
+        },
         "path": "/module/investment",
         "order": 2,
         "service": [
           {
-            "name": "1st admin GUI",
             "description" : "...",
+            "name": {
+              "en": "1st admin GUI"
+            },
             "gui": {
               "$ref": "/core/product/3"
             },
@@ -46,8 +54,10 @@
             }
           },
           {
-            "name": "2nd admin GUI",
             "description" : "...",
+            "name": {
+              "en": "2nd admin GUI"
+            },
             "gui": {
               "$ref": "/core/product/5"
             },
@@ -62,7 +72,9 @@
         "app": {
           "$ref": "http://localhost/core/app/tablet"
         },
-        "name": "Retirement",
+        "name": {
+          "en": "Retirement"
+        },
         "path": "/module/retirement",
         "order": 3,
         "service": []
@@ -72,7 +84,9 @@
         "app": {
           "$ref": "http://localhost/core/app/tablet"
         },
-        "name": "Requisition",
+        "name": {
+          "en": "Requisition"
+        },
         "path": "/module/requisition",
         "order": 4,
         "service": []
@@ -82,7 +96,9 @@
         "app": {
           "$ref": "http://localhost/core/app/tablet"
         },
-        "name": "Pay & Save",
+        "name": {
+          "en": "Pay & Save"
+        },
         "path": "/module/payandsave",
         "order": 5,
         "service": []
@@ -119,7 +135,8 @@
         "type": "varchar",
         "title": "Name",
         "description": "Name of this module",
-        "required": true
+        "required": true,
+        "translatable": true
       },
       {
         "name": "path",
@@ -138,7 +155,8 @@
         "type": "varchar",
         "title": "Service name",
         "description": "Displayed service name",
-        "required": true
+        "required": true,
+        "translatable": true
       },
       {
         "name": "service.0.description",

--- a/src/Graviton/CoreBundle/Resources/definition/Module.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Module.json
@@ -17,9 +17,11 @@
         "order": 1,
         "service": [
           {
-            "description" : "...",
             "name": {
               "en": "1st admin GUI"
+            },
+            "description" : {
+              "en": "..."
             },
             "gui": {
               "$ref": "/core/product/1"
@@ -42,9 +44,11 @@
         "order": 2,
         "service": [
           {
-            "description" : "...",
             "name": {
               "en": "1st admin GUI"
+            },
+            "description" : {
+              "en": "..."
             },
             "gui": {
               "$ref": "/core/product/3"
@@ -54,9 +58,11 @@
             }
           },
           {
-            "description" : "...",
             "name": {
               "en": "2nd admin GUI"
+            },
+            "description" : {
+              "en": "..."
             },
             "gui": {
               "$ref": "/core/product/5"
@@ -163,7 +169,8 @@
         "type": "varchar",
         "title": "Service description",
         "description": "Displayed service description",
-        "required": true
+        "required": false,
+        "translatable": true
       },
       {
         "name": "service.0.gui.ref",

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -343,7 +343,8 @@ class ModuleControllerTest extends RestTestCase
         $this->assertEquals('array', $service->type);
         $this->assertEquals('object', $service->items->properties->name->type);
         $this->assertEquals('string', $service->items->properties->name->properties->en->type);
-        $this->assertEquals('string', $service->items->properties->description->type);
+        $this->assertEquals('object', $service->items->properties->description->type);
+        $this->assertEquals('string', $service->items->properties->description->properties->en->type);
         $this->assertEquals('object', $service->items->properties->gui->type);
         $this->assertEquals('object', $service->items->properties->service->type);
         $this->assertEquals('string', $service->items->properties->gui->properties->{'$ref'}->type);

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -143,7 +143,8 @@ class ModuleControllerTest extends RestTestCase
         $testModule->key = 'test';
         $testModule->app = new \stdClass;
         $testModule->app->{'$ref'} = 'http://localhost/core/app/testapp';
-        $testModule->name = 'Name';
+        $testModule->name = new \stdClass;
+        $testModule->name->en = 'Name';
         $testModule->path = '/test/test';
         $testModule->order = 50;
 
@@ -220,7 +221,8 @@ class ModuleControllerTest extends RestTestCase
         $putModule->key = 'test';
         $putModule->app = new \stdClass;
         $putModule->app->{'$ref'} = 'http://localhost/core/app/test';
-        $putModule->name = 'testerle';
+        $putModule->name = new \stdClass;
+        $putModule->name->en = 'testerle';
         $putModule->path = '/test/test';
         $putModule->order = 500;
 
@@ -339,7 +341,8 @@ class ModuleControllerTest extends RestTestCase
 
         $service = $results->items->properties->service;
         $this->assertEquals('array', $service->type);
-        $this->assertEquals('string', $service->items->properties->name->type);
+        $this->assertEquals('object', $service->items->properties->name->type);
+        $this->assertEquals('string', $service->items->properties->name->properties->en->type);
         $this->assertEquals('string', $service->items->properties->description->type);
         $this->assertEquals('object', $service->items->properties->gui->type);
         $this->assertEquals('object', $service->items->properties->service->type);

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-complete.json
@@ -8,7 +8,8 @@
   "someFloatyDouble": 11.7,
   "modificationDate": "1984-05-02T00:00:00+0000",
   "contactCode": {
-    "someDate": "1984-05-01T00:00:00+0000"
+    "someDate": "1984-05-01T00:00:00+0000",
+    "text": {"en": "Some Text"}
   },
   "contact": {
     "type": "home",

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-incomplete.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-incomplete.json
@@ -1,4 +1,8 @@
 {
   "anotherInt": 6555488894525,
-  "testField": {"en": "a test string"}
+  "testField": {"en": "a test string"},
+  "contactCode": {
+    "someDate": "1984-05-01T00:00:00+0000",
+    "text": {"en": "Some Text"}
+  }
 }

--- a/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
+++ b/src/Graviton/CoreBundle/Tests/resources/showcase-minimal.json
@@ -14,7 +14,8 @@
   "contacts": [],
   "nestedCustomers": [],
   "contactCode": {
-    "someDate": "1984-05-01T00:00:00+0000"
+    "someDate": "1984-05-01T00:00:00+0000",
+    "text": {"en": "Some Text"}
   },
   "nestedArray": [],
   "nestedApps": []

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -124,9 +124,9 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface, LoadField
             $translatableFields = [];
             if (in_array(
                 'Graviton\I18nBundle\Document\TranslatableDocumentInterface',
-                array_keys(class_implements($this->className))
+                array_keys(class_implements($class))
             )) {
-                $fieldInstance = new $this->className;
+                $fieldInstance = new $class;
                 $translatableFields = $fieldInstance->getTranslatableFields();
             }
 

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
@@ -194,7 +194,11 @@ class {{ document }} implements TranslatableDocumentInterface
      */
     public function getTranslatableFields()
     {
+{% if translatableFields is empty %}
+        return [];
+{% else %}
         return array('{{ translatableFields|join('\',\'') }}');
+{% endif %}
     }
 
     /**
@@ -204,7 +208,11 @@ class {{ document }} implements TranslatableDocumentInterface
      */
     public function getPreTranslatedFields()
     {
-        return array('{{ preTranslatedFields|join('\',\'') }}');
+{% if preTranslatedFields is empty %}
+        return [];
+{% else %}
+        return ['{{ preTranslatedFields|join('\',\'') }}'];
+{% endif %}
     }
 
 }


### PR DESCRIPTION
Also fixes some bits and pieces that where in the way of having multiple translatable fields in a single object and some generator stuff.

We'll need to do some serious refactoring on the translatable stuff before it becomes real useable and not as smelly as it is right now, but for the time being this has to make do.