### PR TITLE
ensure RQL encoding is correct in Link header

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Config.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Config.json
@@ -21,6 +21,14 @@
                     "$ref": "http://localhost/core/app/admin"
                 },
                 "default": "/"
+            },
+            {
+                "id": "admin-additional+setting",
+                "key": "additional-setting",
+                "app": {
+                    "$ref": "http://localhost/core/app/admin"
+                },
+                "default": "stronghold"
             }
         ]
     },

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -37,17 +37,60 @@ class ConfigControllerTest extends RestTestCase
      * We need to make sure that our Link headers are properly encoded for our RQL parser.
      * This test tries to ensure that as we have resources named-like-this in /core/config.
      *
+     * @param string $expression  expression
+     * @param int    $resultCount expected res count
+     *
+     * @dataProvider rqlCheckDataProvider
+     *
      * @return void
      */
-    public function testLinkHeaderEncoding()
+    public function testLinkHeaderEncodingDash($expression, $resultCount)
     {
-        $correctlyEncodedString = 'tablet%252Dhello%252Dmessage';
-
+        $expression = urlencode($expression);
         $client = static::createRestClient();
-        $client->request('GET', '/core/config?q=eq(id,'.$correctlyEncodedString.')');
+        $client->request('GET', '/core/config?q='.$expression);
         $response = $client->getResponse();
 
-        $this->assertContains($correctlyEncodedString, $response->headers->get('Link'));
-        $this->assertEquals(1, count($client->getResults()));
+        $this->assertContains($expression, $response->headers->get('Link'));
+        $this->assertEquals($resultCount, count($client->getResults()));
+    }
+
+    /**
+     * Data provider for self-Link-header check
+     *
+     * @return array data
+     */
+    public function rqlCheckDataProvider()
+    {
+        return array(
+            array(
+                'eq(id,'.$this->encodeString('tablet-hello-message').')',
+                1
+            ),
+            array(
+                'eq(id,'.$this->encodeString('admin-additional+setting').')',
+                1
+            ),
+            array(
+                'like(key,'.$this->encodeString('hello-').'*)',
+                1
+            )
+        );
+    }
+
+    /**
+     * Encodes our expressions
+     *
+     * @param string $value value
+     *
+     * @return string encoded value
+     */
+    private function encodeString($value)
+    {
+        return str_replace(
+            array('-', '_', '.', '~'),
+            array('%2D', '%5F', '%2E', '%7E'),
+            $value
+        );
     }
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * functional test for /core/config
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+
+/**
+ * Basic functional test for /core/config.
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ConfigControllerTest extends RestTestCase
+{
+
+    /**
+     * setup client and load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->loadFixtures(
+            array(
+                'GravitonDyn\ConfigBundle\DataFixtures\MongoDB\LoadConfigData'
+            ),
+            null,
+            'doctrine_mongodb'
+        );
+    }
+
+    /**
+     * We need to make sure that our Link headers are properly encoded for our RQL parser.
+     * This test tries to ensure that as we have resources named-like-this in /core/config.
+     *
+     * @return void
+     */
+    public function testLinkHeaderEncoding()
+    {
+        $correctlyEncodedString = 'tablet%252Dhello%252Dmessage';
+
+        $client = static::createRestClient();
+        $client->request('GET', '/core/config?q=eq(id,'.$correctlyEncodedString.')');
+        $response = $client->getResponse();
+
+        $this->assertContains($correctlyEncodedString, $response->headers->get('Link'));
+        $this->assertEquals(1, count($client->getResults()));
+    }
+}


### PR DESCRIPTION
It was suggested that the encoding of RQL parser specialties (ie the encoding of the dash ["-"] character in an encoded string) is wrongly encoded in the generated Link header.

I added a test to ensure it's correct. As it turns out, the encoding is fine. 

I need to check with the Graviphoton people for an example that gets encoded wrong..
@hairmare You know any wrongly encoded expression?