### PR TITLE
Update parser and parser bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
         "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": ">=0.5.0",
+        "graviton/rql-parser-bundle": "dev-develop",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
         "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": "dev-develop",
+        "graviton/rql-parser-bundle": "~0.6",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dbc6d4075d4caf773abbfc5774a68698",
+    "hash": "9edaf160d0e9c7e09f3c2ba1735cd33f",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -1740,16 +1740,16 @@
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "dev-develop",
+            "version": "v0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "9d9ca9040313c51860833bd87f0149b3b93f848d"
+                "reference": "a7fd99ac48c140a8eea4c9660a3c31e23a075682"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/9d9ca9040313c51860833bd87f0149b3b93f848d",
-                "reference": "9d9ca9040313c51860833bd87f0149b3b93f848d",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/a7fd99ac48c140a8eea4c9660a3c31e23a075682",
+                "reference": "a7fd99ac48c140a8eea4c9660a3c31e23a075682",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-07-27 13:51:19"
+            "time": "2015-07-28 11:58:50"
         },
         {
             "name": "guzzle/guzzle",
@@ -5118,7 +5118,6 @@
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
         "graviton/php-rql-parser": 15,
-        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5f6c04eceb94c0202275c78445123fe1",
+    "hash": "dbc6d4075d4caf773abbfc5774a68698",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -54,16 +54,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "2.8.14",
+            "version": "2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "cc3f63f695e15e4b1e6ee0e090c32bfde78115a4"
+                "reference": "5c9cd0d0da069ae556db2900d34c9140bb9166b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/cc3f63f695e15e4b1e6ee0e090c32bfde78115a4",
-                "reference": "cc3f63f695e15e4b1e6ee0e090c32bfde78115a4",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5c9cd0d0da069ae556db2900d34c9140bb9166b5",
+                "reference": "5c9cd0d0da069ae556db2900d34c9140bb9166b5",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2015-07-14 20:48:28"
+            "time": "2015-07-24 00:30:15"
         },
         {
             "name": "behat/transliterator",
@@ -1684,16 +1684,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "v2.0.0-alpha8",
+            "version": "v2.0.0-alpha9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "3a37db415450a22ad0e6f0183030d70df15c8ad1"
+                "reference": "90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/3a37db415450a22ad0e6f0183030d70df15c8ad1",
-                "reference": "3a37db415450a22ad0e6f0183030d70df15c8ad1",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e",
+                "reference": "90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e",
                 "shasum": ""
             },
             "require": {
@@ -1736,20 +1736,20 @@
                 "rest",
                 "rql"
             ],
-            "time": "2015-07-09 11:05:39"
+            "time": "2015-07-27 13:04:21"
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "v0.5.0",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "7b7d10a9b34e6484af30b5433237271878ae14f5"
+                "reference": "9d9ca9040313c51860833bd87f0149b3b93f848d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/7b7d10a9b34e6484af30b5433237271878ae14f5",
-                "reference": "7b7d10a9b34e6484af30b5433237271878ae14f5",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/9d9ca9040313c51860833bd87f0149b3b93f848d",
+                "reference": "9d9ca9040313c51860833bd87f0149b3b93f848d",
                 "shasum": ""
             },
             "require": {
@@ -1769,7 +1769,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Graviton\\RqlParserBundle\\": ""
+                    "Graviton\\RqlParserBundle\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1783,7 +1783,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-06-24 12:24:39"
+            "time": "2015-07-27 13:51:19"
         },
         {
             "name": "guzzle/guzzle",
@@ -3708,16 +3708,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.6.10",
+            "version": "v2.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "e246af5f3bdf64fa5a85936ee78e3574e094cf5f"
+                "reference": "c6ab380a577e7bfb8db6e6f3105f470f97c83235"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/e246af5f3bdf64fa5a85936ee78e3574e094cf5f",
-                "reference": "e246af5f3bdf64fa5a85936ee78e3574e094cf5f",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/c6ab380a577e7bfb8db6e6f3105f470f97c83235",
+                "reference": "c6ab380a577e7bfb8db6e6f3105f470f97c83235",
                 "shasum": ""
             },
             "require": {
@@ -3821,7 +3821,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2015-07-13 09:34:32"
+            "time": "2015-07-26 10:44:22"
         },
         {
             "name": "twig/extensions",
@@ -4299,16 +4299,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.8",
+            "version": "2.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6044546998c7627ab997501a3d0db972b3db9790"
+                "reference": "5bd48b86cd282da411bb80baac1398ce3fefac41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6044546998c7627ab997501a3d0db972b3db9790",
-                "reference": "6044546998c7627ab997501a3d0db972b3db9790",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5bd48b86cd282da411bb80baac1398ce3fefac41",
+                "reference": "5bd48b86cd282da411bb80baac1398ce3fefac41",
                 "shasum": ""
             },
             "require": {
@@ -4357,20 +4357,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-07-13 11:25:58"
+            "time": "2015-07-26 12:54:47"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
@@ -4404,7 +4404,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4449,16 +4449,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -4486,7 +4486,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-13 07:35:30"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -4611,22 +4611,23 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.5",
+            "version": "2.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c"
+                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/1c330b1b6e1ea8fd15f2fbea46770576e366855c",
-                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
+                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "~1.0,>=1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -4662,20 +4663,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-07-04 05:41:32"
+            "time": "2015-07-10 06:54:24"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
                 "shasum": ""
             },
             "require": {
@@ -4689,7 +4690,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -4726,7 +4727,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-01-29 16:28:08"
+            "time": "2015-07-26 15:48:44"
         },
         {
             "name": "sebastian/diff",
@@ -4782,16 +4783,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e"
+                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5a8c7d31914337b69923db26c4221b81ff5a196e",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
+                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
                 "shasum": ""
             },
             "require": {
@@ -4828,20 +4829,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-01-01 10:01:08"
+            "time": "2015-07-26 06:42:57"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
                 "shasum": ""
             },
             "require": {
@@ -4894,7 +4895,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2015-06-21 07:55:53"
         },
         {
             "name": "sebastian/global-state",
@@ -4949,16 +4950,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
                 "shasum": ""
             },
             "require": {
@@ -4998,7 +4999,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2015-06-21 08:04:50"
         },
         {
             "name": "sebastian/version",
@@ -5117,6 +5118,7 @@
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
         "graviton/php-rql-parser": 15,
+        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -40,8 +40,6 @@
                  class="%graviton.core.model.app.class%"
                  parent="graviton.rest.model">
             <argument type="service" id="graviton.rql.visitor_factory"/>
-            <argument type="service" id="graviton.rql.parser"/>
-            <argument type="service" id="graviton.rql.lexer"/>
             <call method="setRepository">
                 <argument type="service" id="graviton.core.repository.app"/>
             </call>
@@ -65,8 +63,6 @@
                  class="%graviton.core.model.product.class%"
                  parent="graviton.rest.model">
             <argument type="service" id="graviton.rql.visitor_factory"/>
-            <argument type="service" id="graviton.rql.parser"/>
-            <argument type="service" id="graviton.rql.lexer"/>
             <call method="setRepository">
                 <argument type="service" id="graviton.core.repository.product"/>
             </call>

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -39,7 +39,9 @@
         <service id="graviton.core.model.app"
                  class="%graviton.core.model.app.class%"
                  parent="graviton.rest.model">
-            <argument type="service" id="graviton.rql.factory"/>
+            <argument type="service" id="graviton.rql.visitor_factory"/>
+            <argument type="service" id="graviton.rql.parser"/>
+            <argument type="service" id="graviton.rql.lexer"/>
             <call method="setRepository">
                 <argument type="service" id="graviton.core.repository.app"/>
             </call>
@@ -62,7 +64,9 @@
         <service id="graviton.core.model.product"
                  class="%graviton.core.model.product.class%"
                  parent="graviton.rest.model">
-            <argument type="service" id="graviton.rql.factory"/>
+            <argument type="service" id="graviton.rql.visitor_factory"/>
+            <argument type="service" id="graviton.rql.parser"/>
+            <argument type="service" id="graviton.rql.lexer"/>
             <call method="setRepository">
                 <argument type="service" id="graviton.core.repository.product"/>
             </call>

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -72,7 +72,7 @@ class AppControllerTest extends RestTestCase
 
         $this->assertContains(
             '<http://localhost/core/app>; rel="self"',
-            explode(',', $response->headers->get('Link'))
+            $response->headers->get('Link')
         );
         $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
     }
@@ -85,24 +85,26 @@ class AppControllerTest extends RestTestCase
     public function testGetAppWithFilteringAndPaging()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?perPage=1&q='.urlencode('eq(showInMenu,true)'));
+        $_SERVER['QUERY_STRING'] = 'perPage=1&q=eq(showInMenu,true)';
+        $client->request('GET', '/core/app?perPage=1&q=eq(showInMenu,true)');
+        unset($_SERVER['QUERY_STRING']);
         $response = $client->getResponse();
 
         $this->assertEquals(1, count($client->getResults()));
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29>; rel="self"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=eq(showInMenu,true)>; rel="self"',
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29&page=2&perPage=1>; rel="next"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=eq(showInMenu,true)&page=2&perPage=1>; rel="next"',
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq%28showInMenu%2Ctrue%29&page=2&perPage=1>; rel="last"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=eq(showInMenu,true)&page=2&perPage=1>; rel="last"',
+            $response->headers->get('Link')
         );
 
     }
@@ -116,54 +118,54 @@ class AppControllerTest extends RestTestCase
     {
         // does limit work?
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?q='.urlencode('limit(1)'));
+        $client->request('GET', '/core/app?q=limit(1)');
         $this->assertEquals(1, count($client->getResults()));
 
         // rql before GET?
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?perPage=2&q='.urlencode('limit(1)'));
+        $client->request('GET', '/core/app?perPage=2&q=limit(1)');
         $this->assertEquals(1, count($client->getResults()));
 
         $response = $client->getResponse();
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit%281%29>; rel="self"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=limit(1)>; rel="self"',
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit%281%29&page=2&perPage=1>; rel="next"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=limit(1)&page=2&perPage=1>; rel="next"',
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit%281%29&page=2&perPage=1>; rel="last"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=limit(1)&page=2&perPage=1>; rel="last"',
+            $response->headers->get('Link')
         );
 
         // "page" override - rql before get
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?perPage=2&page=1&q='.urlencode('limit(1,1)'));
+        $client->request('GET', '/core/app?perPage=2&page=1&q=limit(1,1)');
         $this->assertEquals(1, count($client->getResults()));
 
         $response = $client->getResponse();
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit%281%2C1%29>; rel="self"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/app?q=limit(1,1)>; rel="self"',
+            $response->headers->get('Link')
         );
 
         // we're passing page=1, but should be on last.. so next and last should be identical
-        $nextAndLastUrl = 'http://localhost/core/app?q=limit%281%2C1%29&page=2&perPage=1';
+        $nextAndLastUrl = 'http://localhost/core/app?q=limit(1,1)&page=2&perPage=1';
 
         $this->assertContains(
             '<'.$nextAndLastUrl.'>; rel="next"',
-            explode(',', $response->headers->get('Link'))
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
             '<'.$nextAndLastUrl.'>; rel="last"',
-            explode(',', $response->headers->get('Link'))
+            $response->headers->get('Link')
         );
     }
 
@@ -207,7 +209,7 @@ class AppControllerTest extends RestTestCase
 
         $this->assertContains(
             '<http://localhost/core/app/admin>; rel="self"',
-            explode(',', $response->headers->get('Link'))
+            $response->headers->get('Link')
         );
         $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
     }

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -93,17 +93,17 @@ class AppControllerTest extends RestTestCase
         $this->assertEquals(1, count($client->getResults()));
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu,true)>; rel="self"',
+            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)>; rel="self"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu,true)&page=2&perPage=1>; rel="next"',
+            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)&page=2&perPage=1>; rel="next"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu,true)&page=2&perPage=1>; rel="last"',
+            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)&page=2&perPage=1>; rel="last"',
             $response->headers->get('Link')
         );
 
@@ -151,12 +151,12 @@ class AppControllerTest extends RestTestCase
         $response = $client->getResponse();
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit(1,1)>; rel="self"',
+            '<http://localhost/core/app?q=limit(1%2C1)>; rel="self"',
             $response->headers->get('Link')
         );
 
         // we're passing page=1, but should be on last.. so next and last should be identical
-        $nextAndLastUrl = 'http://localhost/core/app?q=limit(1,1)&page=2&perPage=1';
+        $nextAndLastUrl = 'http://localhost/core/app?q=limit(1%2C1)&page=2&perPage=1';
 
         $this->assertContains(
             '<'.$nextAndLastUrl.'>; rel="next"',

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -46,9 +46,10 @@ class ConfigControllerTest extends RestTestCase
      */
     public function testLinkHeaderEncodingDash($expression, $resultCount)
     {
-        $expression = urlencode($expression);
         $client = static::createRestClient();
+        $_SERVER['QUERY_STRING'] = 'q=' . $expression;
         $client->request('GET', '/core/config?q='.$expression);
+        unset($_SERVER['QUERY_STRING']);
         $response = $client->getResponse();
 
         $this->assertContains($expression, $response->headers->get('Link'));

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -65,15 +65,15 @@ class ConfigControllerTest extends RestTestCase
     {
         return array(
             array(
-                'eq(id,'.$this->encodeString('tablet-hello-message').')',
+                'eq(id'.$this->encodeString(',tablet-hello-message').')',
                 1
             ),
             array(
-                'eq(id,'.$this->encodeString('admin-additional+setting').')',
+                'eq(id'.$this->encodeString(',admin-additional+setting').')',
                 1
             ),
             array(
-                'like(key,'.$this->encodeString('hello-').'*)',
+                'like(key'.$this->encodeString(',hello-').'*)',
                 1
             )
         );

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -90,7 +90,7 @@ class ConfigControllerTest extends RestTestCase
         return str_replace(
             array('-', '_', '.', '~'),
             array('%2D', '%5F', '%2E', '%7E'),
-            $value
+            rawurlencode($value)
         );
     }
 }

--- a/src/Graviton/ExceptionBundle/Listener/RqlSyntaxErrorListener.php
+++ b/src/Graviton/ExceptionBundle/Listener/RqlSyntaxErrorListener.php
@@ -31,9 +31,7 @@ class RqlSyntaxErrorListener extends RestExceptionListener
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        if (($exception = $event->getException()) instanceof BadRequestHttpException &&
-            $exception->getPrevious() instanceof SyntaxErrorException
-        ) {
+        if (($exception = $event->getException()) instanceof SyntaxErrorException) {
             // Set status code and content
             $response = new Response();
             $response
@@ -41,7 +39,7 @@ class RqlSyntaxErrorListener extends RestExceptionListener
                 ->setContent(
                     $this->getSerializedContent(
                         [
-                            'message' => $exception->getMessage()
+                            'message' => sprintf('syntax error in rql: %s', $exception->getMessage())
                         ]
                     )
                 );

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -751,7 +751,15 @@ class ResourceGenerator extends AbstractGenerator
             [
                 [
                     'type' => 'service',
-                    'id' => 'graviton.rql.factory',
+                    'id' => 'graviton.rql.visitor_factory',
+                ],
+                [
+                    'type' => 'service',
+                    'id' => 'graviton.rql.parser',
+                ],
+                [
+                    'type' => 'service',
+                    'id' => 'graviton.rql.lexer',
                 ],
             ]
         );

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -753,14 +753,6 @@ class ResourceGenerator extends AbstractGenerator
                     'type' => 'service',
                     'id' => 'graviton.rql.visitor_factory',
                 ],
-                [
-                    'type' => 'service',
-                    'id' => 'graviton.rql.parser',
-                ],
-                [
-                    'type' => 'service',
-                    'id' => 'graviton.rql.lexer',
-                ],
             ]
         );
 

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -36,7 +36,9 @@
     <service id="graviton.i18n.model.language"
              class="%graviton.i18n.model.language.class%"
              parent="graviton.rest.model">
-      <argument type="service" id="graviton.rql.factory"/>
+      <argument type="service" id="graviton.rql.visitor_factory"/>
+      <argument type="service" id="graviton.rql.parser"/>
+      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.language"/>
       </call>
@@ -64,7 +66,9 @@
     <service id="graviton.i18n.model.translatable"
       class="%graviton.i18n.model.translatable.class%"
       parent="graviton.rest.model">
-      <argument type="service" id="graviton.rql.factory"/>
+      <argument type="service" id="graviton.rql.visitor_factory"/>
+      <argument type="service" id="graviton.rql.parser"/>
+      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.translatable"/>
       </call>
@@ -72,7 +76,9 @@
     <service id="graviton.i18n.model.translatablelanguage"
       class="%graviton.i18n.model.translatablelanguage.class%"
       parent="graviton.rest.model">
-      <argument type="service" id="graviton.rql.factory"/>
+      <argument type="service" id="graviton.rql.visitor_factory"/>
+      <argument type="service" id="graviton.rql.parser"/>
+      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.translatablelanguage"/>
       </call>

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -37,8 +37,6 @@
              class="%graviton.i18n.model.language.class%"
              parent="graviton.rest.model">
       <argument type="service" id="graviton.rql.visitor_factory"/>
-      <argument type="service" id="graviton.rql.parser"/>
-      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.language"/>
       </call>
@@ -67,8 +65,6 @@
       class="%graviton.i18n.model.translatable.class%"
       parent="graviton.rest.model">
       <argument type="service" id="graviton.rql.visitor_factory"/>
-      <argument type="service" id="graviton.rql.parser"/>
-      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.translatable"/>
       </call>
@@ -77,8 +73,6 @@
       class="%graviton.i18n.model.translatablelanguage.class%"
       parent="graviton.rest.model">
       <argument type="service" id="graviton.rql.visitor_factory"/>
-      <argument type="service" id="graviton.rql.parser"/>
-      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.translatablelanguage"/>
       </call>

--- a/src/Graviton/PersonBundle/Resources/config/services.xml
+++ b/src/Graviton/PersonBundle/Resources/config/services.xml
@@ -30,7 +30,9 @@
     <service id="graviton.person.model.personcontact"
              class="%graviton.person.model.personcontact.class%"
              parent="graviton.rest.model">
-      <argument type="service" id="graviton.rql.factory"/>
+      <argument type="service" id="graviton.rql.visitor_factory"/>
+      <argument type="service" id="graviton.rql.parser"/>
+      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.person.repository.personcontact"/>
       </call>

--- a/src/Graviton/PersonBundle/Resources/config/services.xml
+++ b/src/Graviton/PersonBundle/Resources/config/services.xml
@@ -31,8 +31,6 @@
              class="%graviton.person.model.personcontact.class%"
              parent="graviton.rest.model">
       <argument type="service" id="graviton.rql.visitor_factory"/>
-      <argument type="service" id="graviton.rql.parser"/>
-      <argument type="service" id="graviton.rql.lexer"/>
       <call method="setRepository">
         <argument type="service" id="graviton.person.repository.personcontact"/>
       </call>

--- a/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
+++ b/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
@@ -15,7 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 trait GetRqlUrlTrait
 {
     /**
-     * @param string $url url with rql query that needs to be sanitized
+     * @param Request $request request to grab real rql from
+     * @param string  $url     url with rql query that needs to be sanitized
      *
      * @return string
      */

--- a/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
+++ b/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The logic used to make an url for use in a Link header that contains rql
+ */
+
+namespace Graviton\RestBundle\Listener;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+trait GetRqlUrlTrait
+{
+    /**
+     * @param string $url url with rql query that needs to be sanitized
+     *
+     * @return string
+     */
+    protected function getRqlUrl(Request $request, $url)
+    {
+        if ($request->attributes->get('hasRql', false)) {
+            $rawRql = $request->attributes->get('rawRql');
+
+            $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
+        }
+        return $url;
+    }
+}

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -21,6 +21,8 @@ use Graviton\RestBundle\Event\RestEvent;
  */
 class PagingLinkResponseListener
 {
+    use GetRqlUrlTrait;
+
     /**
      * @var Router
      */
@@ -126,13 +128,10 @@ class PagingLinkResponseListener
         if ($perPage) {
             $parameters['perPage'] = $perPage;
         }
-        $url = $this->router->generate($routeName, $parameters, true);
-
-        if ($request->attributes->get('hasRql', false)) {
-            $rawRql = $request->attributes->get('rawRql');
-
-            $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
-        }
+        $url = $this->getRqlUrl(
+            $request,
+            $this->router->generate($routeName, $parameters, true)
+        );
 
         $this->linkHeader->add(new LinkHeaderItem($url, array('rel' => $type)));
     }

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -59,7 +59,7 @@ class PagingLinkResponseListener
         // only collections have paging
         if ($routeType == 'all' && $request->attributes->get('paging')) {
             $additionalParams = array();
-            if ($request->attributes->get('filtering')) {
+            if ($request->attributes->get('hasRql', false)) {
                 $additionalParams['q'] = $request->attributes->get('rawRql', '');
             }
 
@@ -128,10 +128,10 @@ class PagingLinkResponseListener
         }
         $url = $this->router->generate($routeName, $parameters, true);
 
-        if ($request->attributes->get('filtering', false)) {
+        if ($request->attributes->get('hasRql', false)) {
             $rawRql = $request->attributes->get('rawRql');
 
-            $url = str_replace('q=' . urlencode($rawRql), 'q=' . $rawRql, $url);
+            $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
         }
 
         $this->linkHeader->add(new LinkHeaderItem($url, array('rel' => $type)));

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -72,6 +72,12 @@ class SelfLinkResponseListener
 
         try {
             $url = $this->router->generate($routeName, $this->generateParameters($routeType, $request), true);
+
+            if ($request->attributes->get('filtering', false)) {
+                $rawRql = $request->attributes->get('rawRql');
+
+                $url = str_replace('q=' . urlencode($rawRql), 'q=' . $rawRql, $url);
+            }
         } catch (\Exception $e) {
             $addHeader = false;
         }
@@ -116,7 +122,7 @@ class SelfLinkResponseListener
         }
 
         if ($routeType == 'all' && $request->attributes->get('filtering')) {
-            $parameters = array('q' => $request->get('q', ''));
+            $parameters = ['q' => $request->attributes->get('rawRql')];
         }
 
         return $parameters;

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -73,10 +73,10 @@ class SelfLinkResponseListener
         try {
             $url = $this->router->generate($routeName, $this->generateParameters($routeType, $request), true);
 
-            if ($request->attributes->get('filtering', false)) {
+            if ($request->attributes->get('hasRql', false)) {
                 $rawRql = $request->attributes->get('rawRql');
 
-                $url = str_replace('q=' . urlencode($rawRql), 'q=' . $rawRql, $url);
+                $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
             }
         } catch (\Exception $e) {
             $addHeader = false;
@@ -121,7 +121,7 @@ class SelfLinkResponseListener
             }
         }
 
-        if ($routeType == 'all' && $request->attributes->get('filtering')) {
+        if ($routeType == 'all' && $request->attributes->get('hasRql')) {
             $parameters = ['q' => $request->attributes->get('rawRql')];
         }
 

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -21,6 +21,8 @@ use Graviton\RestBundle\Event\RestEvent;
  */
 class SelfLinkResponseListener
 {
+    use GetRqlUrlTrait;
+
     /**
      * @var Router
      */
@@ -71,13 +73,11 @@ class SelfLinkResponseListener
         $url = '';
 
         try {
-            $url = $this->router->generate($routeName, $this->generateParameters($routeType, $request), true);
+            $url = $this->getRqlUrl(
+                $request,
+                $this->router->generate($routeName, $this->generateParameters($routeType, $request), true)
+            );
 
-            if ($request->attributes->get('hasRql', false)) {
-                $rawRql = $request->attributes->get('rawRql');
-
-                $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
-            }
         } catch (\Exception $e) {
             $addHeader = false;
         }

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -98,12 +98,10 @@ class DocumentModel extends SchemaModel implements ModelInterface
             ->createQueryBuilder();
 
         // *** do we have an RQL expression, do we need to filter data?
-        $filter = '';
         if ($request->attributes->get('hasRql', false)) {
             // set filtering attributes on request
             $request->attributes->set('filtering', true);
 
-            $filter = $request->attributes->get('rawRql');
             $queryBuilder = $this->doRqlQuery(
                 $queryBuilder,
                 $request->attributes->get('rqlQuery')

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -99,14 +99,10 @@ class DocumentModel extends SchemaModel implements ModelInterface
 
         // *** do we have an RQL expression, do we need to filter data?
         if ($request->attributes->get('hasRql', false)) {
-            // set filtering attributes on request
-            $request->attributes->set('filtering', true);
-
             $queryBuilder = $this->doRqlQuery(
                 $queryBuilder,
                 $request->attributes->get('rqlQuery')
             );
-
         } else {
             // @todo [lapistano]: seems the offset is missing for this query.
             /** @var \Doctrine\ODM\MongoDB\Query\Builder $qb */

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -108,6 +108,18 @@ class DocumentModel extends SchemaModel implements ModelInterface
             // set filtering attributes on request
             $request->attributes->set('filtering', true);
 
+            // grab unencoded version of rql extract q arg
+            // has to grab the query direclty from _SERVER so it does not get unecoded by php beforehand
+            if (array_key_exists('QUERY_STRING', $_SERVER)) {
+                $filter = array_filter(
+                    explode('&', $_SERVER['QUERY_STRING']),
+                    function ($param) {
+                        return (substr($param, 0, 2) == 'q=');
+                    }
+                );
+                $filter = substr(reset($filter), 2);
+            }
+
             $queryBuilder = $this->doRqlQuery($queryBuilder, $filter);
 
         } else {

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -75,7 +75,7 @@
         <service id="graviton.rest.model" abstract="true" parent="graviton.schema.model.schemamodel"/>
 
         <!-- Response object wrapper with scope request (get a new one for each request) -->
-        <service id="graviton.rest.response" class="%graviton.rest.response.class%" scope="request"/>
+        <service id="graviton.rest.response" class="%graviton.rest.response.class%"/>
 
         <!-- Json Request listener -->
         <service id="graviton.rest.listener.jsonrequestlistener"

--- a/src/Graviton/RestBundle/Tests/HttpFoundation/LinkHeaderTest.php
+++ b/src/Graviton/RestBundle/Tests/HttpFoundation/LinkHeaderTest.php
@@ -61,6 +61,17 @@ class LinkHeaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * check if , works in link
+     *
+     * @return void
+     */
+    public function testCommaInLink()
+    {
+        $headers = LinkHeader::fromString('<http://localhost/core/test?q=limit(1%2C1)>')->all();
+        $this->assertCount(1, $headers);
+    }
+
+    /**
      * test building of strings
      *
      * @dataProvider headerStringProvider


### PR DESCRIPTION
The updates to ``graviton/php-rql-parser`` and ``graviton/rql-parser-bundle`` remove quite some cruft and make integrating with the parser much easier.

This PR changes the bare minimum to get everything up and running with the latest parser version. I'm expecting to do some more cleaning over the course of implementing the changes I'm actually after.

Feature wise this does the following things.

* [x] use ``RequestListener`` from parser bundle to do parsing
* [x] apply query to visitor in ``DocumentModel``
* [x] update various deps that made sense to update anyhow
* [x] fix ``./app/console debug:event-dispatcher`` my removing ``scope="request"`` from ``graviton.rest.response``
* [x] make rql in ``Link`` headers less encoded

It also fixes the issue where ``$`` was already being decoded php all of PHP's magic methods. I originally had that fix in graviton, but It became part of the silly ``$_SERVER`` parsing in [the listener](https://github.com/libgraviton/GravitonRqlParserBundle/blob/develop/src/Listener/RequestListener.php#L60).