### PR TITLE
Fix branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,9 +142,6 @@
                 }
             }
         ],
-        "branch-alias": {
-            "dev-master": "2.6-dev"
-        },
         "installer-paths": {
             "vendor/composer_phpcs": ["libgraviton/codesniffer"]
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7b4b1d89ce62c8261d900e5f50540353",
+    "hash": "edbc78a0f9bcd4a51031b1ad3bbeb2ca",
     "packages": [
         {
             "name": "aws/aws-sdk-php",


### PR DESCRIPTION
Having this does more harm than good as it stands. It seems that this was copied over from symfony at some stage.