### PR TITLE
Remove perPage. page and q param and switch to full query string being rql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
         "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": "~0.7.1",
+        "graviton/rql-parser-bundle": "dev-feature/direct-rql-query-strings",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
         "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": "dev-feature/direct-rql-query-strings",
+        "graviton/rql-parser-bundle": "~0.8.0",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7dad2fc1fdaefbae5ab433c437bb2f48",
+    "hash": "049fa5fa9bb73456423adc3d4848ac87",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1742,16 +1742,16 @@
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "v0.7.1",
+            "version": "dev-feature/direct-rql-query-strings",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "b4006ca73af2c060f2a21b0806d57a5bd04c36eb"
+                "reference": "85d6769be325048e85fb20de4359b9fbb1d23d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/b4006ca73af2c060f2a21b0806d57a5bd04c36eb",
-                "reference": "b4006ca73af2c060f2a21b0806d57a5bd04c36eb",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/85d6769be325048e85fb20de4359b9fbb1d23d93",
+                "reference": "85d6769be325048e85fb20de4359b9fbb1d23d93",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-08-03 11:09:35"
+            "time": "2015-08-06 10:50:06"
         },
         {
             "name": "guzzle/guzzle",
@@ -5118,6 +5118,7 @@
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
         "graviton/php-rql-parser": 15,
+        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "049fa5fa9bb73456423adc3d4848ac87",
+    "hash": "e758215d8fbb58cc0b42bb6ad5f3e4d0",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1742,16 +1742,16 @@
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "dev-feature/direct-rql-query-strings",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "85d6769be325048e85fb20de4359b9fbb1d23d93"
+                "reference": "0fe8b6bce3da7076dd9cfb8d49e2a730de695f21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/85d6769be325048e85fb20de4359b9fbb1d23d93",
-                "reference": "85d6769be325048e85fb20de4359b9fbb1d23d93",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/0fe8b6bce3da7076dd9cfb8d49e2a730de695f21",
+                "reference": "0fe8b6bce3da7076dd9cfb8d49e2a730de695f21",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-08-06 10:50:06"
+            "time": "2015-08-10 12:27:27"
         },
         {
             "name": "guzzle/guzzle",
@@ -5118,7 +5118,6 @@
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
         "graviton/php-rql-parser": 15,
-        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -113,7 +113,7 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
-     * rql limit() should *never* by overwritten by default value
+     * rql limit() should *never* be overwritten by default value
      *
      * @return void
      */

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -153,16 +153,9 @@ class AppControllerTest extends RestTestCase
             $response->headers->get('Link')
         );
 
-        // we're passing page=1, but should be on last.. so next and last should be identical
-        $nextAndLastUrl = 'http://localhost/core/app?limit(1%2C1)';
-
+        // we're passing page=1 and are on the last page, so next isn't set here
         $this->assertContains(
-            '<'.$nextAndLastUrl.'>; rel="next"',
-            $response->headers->get('Link')
-        );
-
-        $this->assertContains(
-            '<'.$nextAndLastUrl.'>; rel="last"',
+            '<http://localhost/core/app?limit(1%2C1)>; rel="last"',
             $response->headers->get('Link')
         );
     }

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -88,32 +88,32 @@ class AppControllerTest extends RestTestCase
     public function testGetAppWithFilteringAndPaging()
     {
         $client = static::createRestClient();
-        $_SERVER['QUERY_STRING'] = 'perPage=1&q=eq(showInMenu,true)';
-        $client->request('GET', '/core/app?perPage=1&q=eq(showInMenu,true)');
+        $_SERVER['QUERY_STRING'] = 'eq(showInMenu,true)&limit(1)';
+        $client->request('GET', '/core/app?eq(showInMenu,true)&limit(1)');
         unset($_SERVER['QUERY_STRING']);
         $response = $client->getResponse();
 
         $this->assertEquals(1, count($client->getResults()));
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)>; rel="self"',
+            '<http://localhost/core/app?eq(showInMenu%2Ctrue)&limit(1)>; rel="self"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)&page=2&perPage=1>; rel="next"',
+            '<http://localhost/core/app?eq(showInMenu%2Ctrue)&limit(1%2C1)>; rel="next"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=eq(showInMenu%2Ctrue)&page=2&perPage=1>; rel="last"',
+            '<http://localhost/core/app?eq(showInMenu%2Ctrue)&limit(1%2C1)>; rel="last"',
             $response->headers->get('Link')
         );
 
     }
 
     /**
-     * rql limit() should be *never* overwritten by $_GET['perPage'] *or* default value
+     * rql limit() should *never* by overwritten by default value
      *
      * @return void
      */
@@ -121,45 +121,40 @@ class AppControllerTest extends RestTestCase
     {
         // does limit work?
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?q=limit(1)');
-        $this->assertEquals(1, count($client->getResults()));
-
-        // rql before GET?
-        $client = static::createRestClient();
-        $client->request('GET', '/core/app?perPage=2&q=limit(1)');
+        $client->request('GET', '/core/app?limit(1)');
         $this->assertEquals(1, count($client->getResults()));
 
         $response = $client->getResponse();
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit(1)>; rel="self"',
+            '<http://localhost/core/app?limit(1)>; rel="self"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit(1)&page=2&perPage=1>; rel="next"',
+            '<http://localhost/core/app?limit(1%2C1)>; rel="next"',
             $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit(1)&page=2&perPage=1>; rel="last"',
+            '<http://localhost/core/app?limit(1%2C1)>; rel="last"',
             $response->headers->get('Link')
         );
 
         // "page" override - rql before get
         $client = static::createRestClient();
-        $client->request('GET', '/core/app?perPage=2&page=1&q=limit(1,1)');
+        $client->request('GET', '/core/app?limit(1,1)');
         $this->assertEquals(1, count($client->getResults()));
 
         $response = $client->getResponse();
 
         $this->assertContains(
-            '<http://localhost/core/app?q=limit(1%2C1)>; rel="self"',
+            '<http://localhost/core/app?limit(1%2C1)>; rel="self"',
             $response->headers->get('Link')
         );
 
         // we're passing page=1, but should be on last.. so next and last should be identical
-        $nextAndLastUrl = 'http://localhost/core/app?q=limit(1%2C1)&page=2&perPage=1';
+        $nextAndLastUrl = 'http://localhost/core/app?limit(1%2C1)';
 
         $this->assertContains(
             '<'.$nextAndLastUrl.'>; rel="next"',
@@ -566,7 +561,7 @@ class AppControllerTest extends RestTestCase
         $client = static::createRestClient();
         $client->request(
             'GET',
-            '/core/app?q='.$expr,
+            '/core/app?'.$expr,
             array(),
             array(),
             array('HTTP_ACCEPT_LANGUAGE' => 'en, de')
@@ -602,7 +597,7 @@ class AppControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
 
-        $client->request('GET', '/core/app?q=eq(name)');
+        $client->request('GET', '/core/app?eq(name)');
 
         $response = $client->getResponse();
         $results = $client->getResults();

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -47,8 +47,8 @@ class ConfigControllerTest extends RestTestCase
     public function testLinkHeaderEncodingDash($expression, $resultCount)
     {
         $client = static::createRestClient();
-        $_SERVER['QUERY_STRING'] = 'q=' . $expression;
-        $client->request('GET', '/core/config?q='.$expression);
+        $_SERVER['QUERY_STRING'] = $expression;
+        $client->request('GET', '/core/config?'.$expression);
         unset($_SERVER['QUERY_STRING']);
         $response = $client->getResponse();
 

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -52,24 +52,24 @@ class ModuleControllerTest extends RestTestCase
     public function testGetModuleWithPaging()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/module?perPage=1');
+        $client->request('GET', '/core/module?limit(1)');
         $response = $client->getResponse();
 
         $this->assertEquals(1, count($client->getResults()));
 
         $this->assertContains(
-            '<http://localhost/core/module?page=1&perPage=1>; rel="self"',
+            '<http://localhost/core/module?limit(1)>; rel="self"',
             explode(',', $response->headers->get('Link'))
         );
 
         $this->assertContains(
-            '<http://localhost/core/module?page=2&perPage=1>; rel="next"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/module?limit(1%2C1)>; rel="next"',
+            $response->headers->get('Link')
         );
 
         $this->assertContains(
-            '<http://localhost/core/module?page=5&perPage=1>; rel="last"',
-            explode(',', $response->headers->get('Link'))
+            '<http://localhost/core/module?limit(1%2C4)>; rel="last"',
+            $response->headers->get('Link')
         );
 
         $this->assertEquals('http://localhost/core/app/tablet', $client->getResults()[0]->app->{'$ref'});
@@ -103,7 +103,7 @@ class ModuleControllerTest extends RestTestCase
     public function testGetModuleWithKeyAndUseId()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/module?q=eq(key,investment)');
+        $client->request('GET', '/core/module?eq(key,investment)');
         $response = $client->getResponse();
         $results = $client->getResults();
 
@@ -206,7 +206,7 @@ class ModuleControllerTest extends RestTestCase
     {
         // get id first..
         $client = static::createRestClient();
-        $client->request('GET', '/core/module?q=eq(key,investment)');
+        $client->request('GET', '/core/module?eq(key,investment)');
         $response = $client->getResponse();
         $results = $client->getResults();
 
@@ -258,7 +258,7 @@ class ModuleControllerTest extends RestTestCase
     {
         // get id first..
         $client = static::createRestClient();
-        $client->request('GET', '/core/module?q=eq(key,investment)');
+        $client->request('GET', '/core/module?eq(key,investment)');
         $results = $client->getResults();
 
         // get entry by id
@@ -287,7 +287,7 @@ class ModuleControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
 
-        $client->request('GET', '/core/module?q=eq(key,investment)');
+        $client->request('GET', '/core/module?eq(key,investment)');
         $results = $client->getResults();
         $this->assertCount(1, $results);
 
@@ -331,7 +331,7 @@ class ModuleControllerTest extends RestTestCase
     public function testExtReferenceValidation()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/module?q=eq(key,investment)');
+        $client->request('GET', '/core/module?eq(key,investment)');
         $this->assertCount(1, $client->getResults());
 
         $module = $client->getResults()[0];

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -193,7 +193,7 @@ class ShowcaseControllerTest extends RestTestCase
         $rqlSelect = 'select('.implode(',', array_map([$this, 'encodeRqlString'], $fields)).')';
 
         $client = static::createRestClient();
-        $client->request('GET', '/hans/showcase?q='.$rqlSelect);
+        $client->request('GET', '/hans/showcase?'.$rqlSelect);
         $this->assertEquals($filtred, $client->getResults());
     }
 

--- a/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
+++ b/src/Graviton/RestBundle/Listener/GetRqlUrlTrait.php
@@ -25,7 +25,7 @@ trait GetRqlUrlTrait
         if ($request->attributes->get('hasRql', false)) {
             $rawRql = $request->attributes->get('rawRql');
 
-            $url = str_replace('q=' . urlencode($rawRql), 'q=' . str_replace(',', '%2C', $rawRql), $url);
+            $url = str_replace(urlencode($rawRql), str_replace(',', '%2C', $rawRql), $url);
         }
         return $url;
     }

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
-use Graviton\RestBundle\Event\RestEvent;
 
 /**
  * FilterResponseListener for adding a rel=self Link header to a response.
@@ -124,6 +123,7 @@ class PagingLinkResponseListener
      */
     private function generateLink($routeName, $page, $perPage, $type, Request $request, $rql)
     {
+        $limit = '';
         if ($perPage) {
             $page = ($page - 1) * $perPage;
             $limit = sprintf('limit(%s,%s)', $perPage, $page);

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -60,9 +60,9 @@ class PagingLinkResponseListener
 
         // only collections have paging
         if ($routeType == 'all' && $request->attributes->get('paging')) {
-            $additionalParams = array();
+            $rql = array();
             if ($request->attributes->get('hasRql', false)) {
-                $additionalParams['q'] = $request->attributes->get('rawRql', '');
+                $rql = $request->attributes->get('rawRql', '');
             }
 
             $this->linkHeader = LinkHeader::fromResponse($response);
@@ -73,7 +73,7 @@ class PagingLinkResponseListener
                 $request->attributes->get('numPages'),
                 $request->attributes->get('perPage'),
                 $request,
-                $additionalParams
+                $rql
             );
             $response->headers->set(
                 'Link',
@@ -85,52 +85,57 @@ class PagingLinkResponseListener
     /**
      * generate headers for all paging links
      *
-     * @param string  $route            name of route
-     * @param integer $page             current page
-     * @param integer $numPages         number of all pages
-     * @param integer $perPage          number of records per page
-     * @param Request $request          request to get rawRql from
-     * @param array   $additionalParams Optional array of additional params to include
+     * @param string  $route    name of route
+     * @param integer $page     page to link to
+     * @param integer $numPages number of all pages
+     * @param integer $perPage  number of records per page
+     * @param Request $request  request to get rawRql from
+     * @param string  $rql      rql query string
      *
      * @return void
      */
-    private function generateLinks($route, $page, $numPages, $perPage, Request $request, $additionalParams = array())
+    private function generateLinks($route, $page, $numPages, $perPage, Request $request, $rql)
     {
         if ($page > 2) {
-            $this->generateLink($route, 1, $perPage, 'first', $request, $additionalParams);
+            $this->generateLink($route, 1, $perPage, 'first', $request, $rql);
         }
         if ($page > 1) {
-            $this->generateLink($route, $page - 1, $perPage, 'prev', $request, $additionalParams);
+            $this->generateLink($route, $page - 1, $perPage, 'prev', $request, $rql);
         }
         if ($page < $numPages) {
-            $this->generateLink($route, $page + 1, $perPage, 'next', $request, $additionalParams);
+            $this->generateLink($route, $page + 1, $perPage, 'next', $request, $rql);
         }
         if ($page != $numPages) {
-            $this->generateLink($route, $numPages, $perPage, 'last', $request, $additionalParams);
+            $this->generateLink($route, $numPages, $perPage, 'last', $request, $rql);
         }
     }
 
     /**
      * generate link header passed on params and type
      *
-     * @param string  $routeName        use with router to generate urls
-     * @param integer $page             page to link to
-     * @param integer $perPage          number of items per page
-     * @param string  $type             rel type of link to generate
-     * @param Request $request          request to get rawRql from
-     * @param array   $additionalParams Optional array of additional params to include
+     * @param string  $routeName use with router to generate urls
+     * @param integer $page      page to link to
+     * @param integer $perPage   number of items per page
+     * @param string  $type      rel type of link to generate
+     * @param Request $request   request to get rawRql from
+     * @param string  $rql       rql query string
      *
      * @return string
      */
-    private function generateLink($routeName, $page, $perPage, $type, Request $request, $additionalParams = array())
+    private function generateLink($routeName, $page, $perPage, $type, Request $request, $rql)
     {
-        $parameters = array_merge($additionalParams, array('page' => $page));
         if ($perPage) {
-            $parameters['perPage'] = $perPage;
+            $page = ($page - 1) * $perPage;
+            $limit = sprintf('limit(%s,%s)', $perPage, $page);
+        }
+        if (strpos($rql, 'limit') !== false) {
+            $rql = preg_replace('/limit\(.*\)/', $limit, $rql);
+        } else {
+            $rql = $limit;
         }
         $url = $this->getRqlUrl(
             $request,
-            $this->router->generate($routeName, $parameters, true)
+            $this->router->generate($routeName, [], true) . '?' . strtr($rql, [',' => '%2C'])
         );
 
         $this->linkHeader->add(new LinkHeaderItem($url, array('rel' => $type)));

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -73,9 +73,15 @@ class SelfLinkResponseListener
         $url = '';
 
         try {
+            $params = $this->generateParameters($routeType, $request);
+            $query = '';
+            if (array_key_exists('q', $params)) {
+                $query = '?' . strtr($params['q'], [',' => '%2C']);
+                unset($params['q']);
+            }
             $url = $this->getRqlUrl(
                 $request,
-                $this->router->generate($routeName, $this->generateParameters($routeType, $request), true)
+                $this->router->generate($routeName, $params, true) . $query
             );
 
         } catch (\Exception $e) {

--- a/src/Graviton/RestBundle/Tests/HttpFoundation/LinkHeaderTest.php
+++ b/src/Graviton/RestBundle/Tests/HttpFoundation/LinkHeaderTest.php
@@ -67,7 +67,7 @@ class LinkHeaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCommaInLink()
     {
-        $headers = LinkHeader::fromString('<http://localhost/core/test?q=limit(1%2C1)>')->all();
+        $headers = LinkHeader::fromString('<http://localhost/core/test?limit(1%2C1)>')->all();
         $this->assertCount(1, $headers);
     }
 


### PR DESCRIPTION
* [x] remove ``q``, ``perPage`` and ``page`` params from tests and link headers
* [x] add some docs explaining what is going on with ``,`` vs ``%2C`` in Link headers
* [x] update ``composer.lock`` with a tagged version of rql-parser-bundle when https://github.com/libgraviton/GravitonRqlParserBundle/pull/25 is merged in a tagged release.

I'm aiming at tagging a new graviton release as soon as this has been merged...