### PR TITLE
20150812 rql parse route list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
         "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": "~0.8.0",
+        "graviton/rql-parser-bundle": "~0.9.0",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3a5d78f628bf1181e1b909dbbd12cb84",
+    "hash": "3ac22ad53d0d28b8540cab94fc28f41b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1739,16 +1739,16 @@
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "v0.8.0",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "0fe8b6bce3da7076dd9cfb8d49e2a730de695f21"
+                "reference": "52212ada6a2d7ee970dccc839f8cb55ebbbfd929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/0fe8b6bce3da7076dd9cfb8d49e2a730de695f21",
-                "reference": "0fe8b6bce3da7076dd9cfb8d49e2a730de695f21",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/52212ada6a2d7ee970dccc839f8cb55ebbbfd929",
+                "reference": "52212ada6a2d7ee970dccc839f8cb55ebbbfd929",
                 "shasum": ""
             },
             "require": {
@@ -1780,7 +1780,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-08-10 12:27:27"
+            "time": "2015-08-13 10:45:35"
         },
         {
             "name": "guzzle/guzzle",
@@ -2169,7 +2169,7 @@
             ],
             "authors": [
                 {
-                    "name": "Johannes Schmitt",
+                    "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com",
                     "homepage": "https://github.com/schmittjoh",
                     "role": "Developer of wrapped JMSSerializerBundle"

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -7,6 +7,7 @@ namespace Graviton\CoreBundle\Tests\Controller;
 
 use Graviton\CoreBundle\Service\CoreUtils;
 use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Basic functional test for /.
@@ -25,6 +26,18 @@ class MainControllerTest extends RestTestCase
      * @const corresponding vendorized schema mime type
      */
     const SCHEMA_TYPE = 'application/json; charset=UTF-8';
+
+    /**
+     * RQL query is ignored
+     *
+     * @return void
+     */
+    public function testRqlIsIgnored()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/?invalidrqlquery');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
 
     /**
      * check if version is returned in header

--- a/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPass.php
+++ b/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPass.php
@@ -26,11 +26,7 @@ class RqlQueryDecoratorCompilerPass implements CompilerPassInterface
         $innerDefinition = $container->getDefinition('graviton.rest.listener.rqlqueryrequestlistener.inner');
         $outerDefinition = $container->getDefinition('graviton.rest.listener.rqlqueryrequestlistener');
 
-        foreach ($innerDefinition->getTags() as $name => $attrsList) {
-            foreach ($attrsList as $attrs) {
-                $outerDefinition->addTag($name, $attrs);
-            }
-        }
+        $outerDefinition->setTags($innerDefinition->getTags());
         $innerDefinition->clearTags();
     }
 }

--- a/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPass.php
+++ b/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPass.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * RqlQueryDecoratorCompilerPass class file
+ */
+
+namespace Graviton\RestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryDecoratorCompilerPass implements CompilerPassInterface
+{
+    /**
+     * We have to manually copy all tags from decorated service
+     *
+     * @param ContainerBuilder $container Container builder
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $innerDefinition = $container->getDefinition('graviton.rest.listener.rqlqueryrequestlistener.inner');
+        $outerDefinition = $container->getDefinition('graviton.rest.listener.rqlqueryrequestlistener');
+
+        foreach ($innerDefinition->getTags() as $name => $attrsList) {
+            foreach ($attrsList as $attrs) {
+                $outerDefinition->addTag($name, $attrs);
+            }
+        }
+        $innerDefinition->clearTags();
+    }
+}

--- a/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryRoutesCompilerPass.php
+++ b/src/Graviton/RestBundle/DependencyInjection/Compiler/RqlQueryRoutesCompilerPass.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * RqlQueryRoutesCompilerPass class file
+ */
+
+namespace Graviton\RestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryRoutesCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Find "allAction" routes and set it to allowed routes for RQL parsing
+     *
+     * @param ContainerBuilder $container Container builder
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $routes = [];
+        foreach ($container->getParameter('graviton.rest.services') as $service => $params) {
+            list($app, $bundle, , $entity) = explode('.', $service);
+            $routes[] = implode('.', [$app, $bundle, 'rest', $entity, 'all']);
+        }
+
+        $container->setParameter('graviton.rest.listener.rqlqueryrequestlistener.allowedroutes', $routes);
+    }
+}

--- a/src/Graviton/RestBundle/GravitonRestBundle.php
+++ b/src/Graviton/RestBundle/GravitonRestBundle.php
@@ -7,11 +7,14 @@ namespace Graviton\RestBundle;
 
 use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Graviton\BundleBundle\GravitonBundleInterface;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Misd\GuzzleBundle\MisdGuzzleBundle;
 use Graviton\RestBundle\DependencyInjection\Compiler\RestServicesCompilerPass;
+use Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryDecoratorCompilerPass;
+use Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryRoutesCompilerPass;
 
 /**
  * GravitonRestBundle
@@ -50,5 +53,7 @@ class GravitonRestBundle extends Bundle implements GravitonBundleInterface
         parent::build($container);
 
         $container->addCompilerPass(new RestServicesCompilerPass);
+        $container->addCompilerPass(new RqlQueryRoutesCompilerPass());
+        $container->addCompilerPass(new RqlQueryDecoratorCompilerPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }

--- a/src/Graviton/RestBundle/Listener/RqlQueryRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/RqlQueryRequestListener.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * RqlQueryRequestListener class file
+ */
+
+namespace Graviton\RestBundle\Listener;
+
+use Graviton\RqlParserBundle\Listener\RequestListener;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * RQL query listener
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryRequestListener extends RequestListener
+{
+    /**
+     * @var array Allowed route IDs
+     */
+    private $allowedRoutes = [];
+    /**
+     * @var RequestListener
+     */
+    private $requestListener;
+
+    /**
+     * Constructor
+     *
+     * @param RequestListener $requestListener Original RQL listener
+     * @param array           $allowedRoutes   Allowed route IDs
+     */
+    public function __construct(RequestListener $requestListener, array $allowedRoutes)
+    {
+        $this->requestListener = $requestListener;
+        $this->allowedRoutes = $allowedRoutes;
+    }
+
+    /**
+     * Process RQL query if it is allowed for current route
+     *
+     * @param GetResponseEvent $event Event
+     * @return void
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!in_array($event->getRequest()->attributes->get('_route'), $this->allowedRoutes, true)) {
+            return;
+        }
+
+        $this->requestListener->onKernelRequest($event);
+    }
+}

--- a/src/Graviton/RestBundle/Listener/RqlQueryRequestListener.php
+++ b/src/Graviton/RestBundle/Listener/RqlQueryRequestListener.php
@@ -5,7 +5,7 @@
 
 namespace Graviton\RestBundle\Listener;
 
-use Graviton\RqlParserBundle\Listener\RequestListener;
+use Graviton\RqlParserBundle\Listener\RequestListenerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
@@ -15,24 +15,24 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class RqlQueryRequestListener extends RequestListener
+class RqlQueryRequestListener implements RequestListenerInterface
 {
     /**
      * @var array Allowed route IDs
      */
     private $allowedRoutes = [];
     /**
-     * @var RequestListener
+     * @var RequestListenerInterface
      */
     private $requestListener;
 
     /**
      * Constructor
      *
-     * @param RequestListener $requestListener Original RQL listener
-     * @param array           $allowedRoutes   Allowed route IDs
+     * @param RequestListenerInterface $requestListener Original RQL listener
+     * @param array                    $allowedRoutes   Allowed route IDs
      */
-    public function __construct(RequestListener $requestListener, array $allowedRoutes)
+    public function __construct(RequestListenerInterface $requestListener, array $allowedRoutes)
     {
         $this->requestListener = $requestListener;
         $this->allowedRoutes = $allowedRoutes;

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -15,10 +15,12 @@
         <parameter key="graviton.rest.request.class">Symfony\Component\HttpFoundation\Request</parameter>
         <parameter key="graviton.rest.listener.xversionresponselistener.class">Graviton\RestBundle\Listener\XVersionResponseListener</parameter>
         <parameter key="graviton.rest.listener.rqlselectresponselistener.class">Graviton\RestBundle\Listener\RqlSelectResponseListener</parameter>
+        <parameter key="graviton.rest.listener.rqlqueryrequestlistener.class">Graviton\RestBundle\Listener\RqlQueryRequestListener</parameter>
         <parameter key="graviton.rest.event.subscriber.class">Graviton\RestBundle\Subscriber\RestEventSubscriber</parameter>
         <parameter key="graviton.rest.validator.readonly.class">Graviton\RestBundle\Validator\Constraints\ReadOnly\ReadOnlyValidator</parameter>
         <parameter key="graviton.rest.validator.extref.class">Graviton\RestBundle\Validator\Constraints\ExtReference\ExtReferenceValidator</parameter>
         <parameter key="graviton.rest.services" type="collection"/>
+        <parameter key="graviton.rest.listener.rqlqueryrequestlistener.allowedroutes" type="collection"/>
     </parameters>
     <services>
         <!-- Serializer / Serializer context -->
@@ -181,6 +183,15 @@
                  class="%graviton.rest.listener.rqlselectresponselistener.class%">
             <argument type="service" id="graviton.rest.objectslicer"/>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
+        </service>
+
+        <!-- RQL query listener (see RqlQueryDecoratorCompilerPass) -->
+        <service id="graviton.rest.listener.rqlqueryrequestlistener"
+                 class="%graviton.rest.listener.rqlqueryrequestlistener.class%"
+                 decorates="graviton.rql.listener.request"
+                 decoration-inner-name="graviton.rest.listener.rqlqueryrequestlistener.inner">
+            <argument type="service" id="graviton.rest.listener.rqlqueryrequestlistener.inner"/>
+            <argument>%graviton.rest.listener.rqlqueryrequestlistener.allowedroutes%</argument>
         </service>
 
         <!-- Validators -->

--- a/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPassTest.php
+++ b/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPassTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * RqlQueryDecoratorCompilerPassTest class file
+ */
+
+namespace Graviton\RestBundle\Tests\DependencyInjection\Compiler;
+
+use Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryDecoratorCompilerPass;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryDecoratorCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test RqlQueryDecoratorCompilerPass::process()
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $tags = [
+            'tag1' => [
+                ['attr1' => 'value1', 'attr2' => 'value2'],
+                ['attr3' => 'value3', 'attr4' => 'value4'],
+            ],
+            'tag2' => [
+                ['attr5' => 'value5', 'attr6' => 'value6'],
+                ['attr7' => 'value7', 'attr8' => 'value8'],
+            ],
+        ];
+
+        $innerDefinition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $innerDefinition
+            ->expects($this->once())
+            ->method('getTags')
+            ->willReturn($tags);
+        $innerDefinition
+            ->expects($this->once())
+            ->method('clearTags');
+
+        $outerDefinition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $outerDefinition
+            ->expects($this->exactly(4))
+            ->method('addTag')
+            ->withConsecutive(
+                ['tag1', ['attr1' => 'value1', 'attr2' => 'value2']],
+                ['tag1', ['attr3' => 'value3', 'attr4' => 'value4']],
+                ['tag2', ['attr5' => 'value5', 'attr6' => 'value6']],
+                ['tag2', ['attr7' => 'value7', 'attr8' => 'value8']]
+            );
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $container
+            ->expects($this->at(0))
+            ->method('getDefinition')
+            ->with('graviton.rest.listener.rqlqueryrequestlistener.inner')
+            ->willReturn($innerDefinition);
+        $container
+            ->expects($this->at(1))
+            ->method('getDefinition')
+            ->with('graviton.rest.listener.rqlqueryrequestlistener')
+            ->willReturn($outerDefinition);
+
+        $sut = new RqlQueryDecoratorCompilerPass();
+        $sut->process($container);
+    }
+}

--- a/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPassTest.php
+++ b/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryDecoratorCompilerPassTest.php
@@ -48,14 +48,9 @@ class RqlQueryDecoratorCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $outerDefinition
-            ->expects($this->exactly(4))
-            ->method('addTag')
-            ->withConsecutive(
-                ['tag1', ['attr1' => 'value1', 'attr2' => 'value2']],
-                ['tag1', ['attr3' => 'value3', 'attr4' => 'value4']],
-                ['tag2', ['attr5' => 'value5', 'attr6' => 'value6']],
-                ['tag2', ['attr7' => 'value7', 'attr8' => 'value8']]
-            );
+            ->expects($this->once())
+            ->method('setTags')
+            ->with($tags);
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
             ->disableOriginalConstructor()

--- a/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryRoutesCompilerPassTest.php
+++ b/src/Graviton/RestBundle/Tests/DependencyInjection/Compiler/RqlQueryRoutesCompilerPassTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * RqlQueryRoutesCompilerPassTest class file
+ */
+
+namespace Graviton\RestBundle\Tests\DependencyInjection\Compiler;
+
+use Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryRoutesCompilerPass;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryRoutesCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test RqlQueryRoutesCompilerPass::process()
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $services = [
+            'namespace1.bundle1.unused.service1' => [],
+            'namespace2.bundle2.unused.service2' => [],
+        ];
+        $routes = [
+            'namespace1.bundle1.rest.service1.all',
+            'namespace2.bundle2.rest.service2.all',
+        ];
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('graviton.rest.services')
+            ->willReturn($services);
+        $container
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('graviton.rest.listener.rqlqueryrequestlistener.allowedroutes', $routes);
+
+        $sut = new RqlQueryRoutesCompilerPass();
+        $sut->process($container);
+    }
+}

--- a/src/Graviton/RestBundle/Tests/GravitonRestBundleTest.php
+++ b/src/Graviton/RestBundle/Tests/GravitonRestBundleTest.php
@@ -9,6 +9,7 @@ use Graviton\RestBundle\GravitonRestBundle;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Misd\GuzzleBundle\MisdGuzzleBundle;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 /**
  * GravitonMessagingBundleTest
@@ -60,10 +61,23 @@ class GravitonRestBundleTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('addCompilerPass'))
             ->getMock();
         $containerDouble
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('addCompilerPass')
             ->with(
                 $this->isInstanceOf('\Graviton\RestBundle\DependencyInjection\Compiler\RestServicesCompilerPass')
+            );
+        $containerDouble
+            ->expects($this->at(1))
+            ->method('addCompilerPass')
+            ->with(
+                $this->isInstanceOf('\Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryRoutesCompilerPass')
+            );
+        $containerDouble
+            ->expects($this->at(2))
+            ->method('addCompilerPass')
+            ->with(
+                $this->isInstanceOf('\Graviton\RestBundle\DependencyInjection\Compiler\RqlQueryDecoratorCompilerPass'),
+                PassConfig::TYPE_OPTIMIZE
             );
 
         $bundle = new GravitonRestBundle();

--- a/src/Graviton/RestBundle/Tests/Listener/RqlQueryRequestListenerTest.php
+++ b/src/Graviton/RestBundle/Tests/Listener/RqlQueryRequestListenerTest.php
@@ -25,7 +25,7 @@ class RqlQueryRequestListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequest($routeId, $isAllowed)
     {
-        $innerListener = $this->getMockBuilder('Graviton\RqlParserBundle\Listener\RequestListener')
+        $innerListener = $this->getMockBuilder('Graviton\RqlParserBundle\Listener\RequestListenerInterface')
             ->disableOriginalConstructor()
             ->getMock();
         $innerListener->expects($isAllowed ? $this->once() : $this->never())

--- a/src/Graviton/RestBundle/Tests/Listener/RqlQueryRequestListenerTest.php
+++ b/src/Graviton/RestBundle/Tests/Listener/RqlQueryRequestListenerTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * RqlQueryRequestListenerTest class file
+ */
+
+namespace Graviton\RestBundle\Tests\Listener;
+
+use Graviton\RestBundle\Listener\RqlQueryRequestListener;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlQueryRequestListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test RqlQueryRequestListener::onKernelRequest()
+     *
+     * @param string $routeId   Current route ID
+     * @param bool   $isAllowed Is RQL parsing allowed
+     * @return void
+     * @dataProvider dataOnKernelRequest
+     */
+    public function testOnKernelRequest($routeId, $isAllowed)
+    {
+        $innerListener = $this->getMockBuilder('Graviton\RqlParserBundle\Listener\RequestListener')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $innerListener->expects($isAllowed ? $this->once() : $this->never())
+            ->method('onKernelRequest');
+
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getRequest')
+            ->willReturn(new Request([], [], ['_route' => $routeId]));
+
+        $listener = new RqlQueryRequestListener($innerListener, ['allowed.route.id']);
+        $listener->onKernelRequest($event);
+    }
+
+    /**
+     * Data RqlQueryRequestListener::onKernelRequest()
+     *
+     * @return array
+     */
+    public function dataOnKernelRequest()
+    {
+        return [
+            [
+                'not.allowed.route.id',
+                false,
+            ],
+            [
+                'allowed.route.id',
+                true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
`Bad Request` occurs even if I request `/_profiler/f2ef11/search/results?ip=&limit=10`.
This disables RQL parsing for all not "allAction" routes.

I added `RqlQueryRequestListener` that decorates (not overwrites) `Graviton\RqlParserBundle\Listener\RequestListener`.