### PR TITLE
Reflect changes in swagger.json

### DIFF
--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -237,28 +237,11 @@ class Swagger
             );
 
             $thisPath['parameters'][] = array(
-                'name' => 'q',
+                'name' => '',
                 'in' => 'query',
                 'description' => 'Optional RQL filter',
                 'required' => false,
                 'type' => 'string'
-            );
-            // paging params
-            $thisPath['parameters'][] = array(
-                'name' => 'page',
-                'in' => 'query',
-                'description' => '(Paging) Page to fetch',
-                'required' => false,
-                'default' => 1,
-                'type' => 'integer'
-            );
-            $thisPath['parameters'][] = array(
-                'name' => 'perPage',
-                'in' => 'query',
-                'description' => '(Paging) Items per page',
-                'required' => false,
-                'default' => 10,
-                'type' => 'integer'
             );
         }
 

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -237,9 +237,9 @@ class Swagger
             );
 
             $thisPath['parameters'][] = array(
-                'name' => '',
+                'name' => 'rql',
                 'in' => 'query',
-                'description' => 'Optional RQL filter',
+                'description' => 'Optional RQL filter, replaces the complete query string if available',
                 'required' => false,
                 'type' => 'string'
             );

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -235,14 +235,6 @@ class Swagger
                     'items' => array('$ref' => '#/definitions/' . $entityClassName)
                 )
             );
-
-            $thisPath['parameters'][] = array(
-                'name' => 'rql',
-                'in' => 'query',
-                'description' => 'Optional RQL filter, replaces the complete query string if available',
-                'required' => false,
-                'type' => 'string'
-            );
         }
 
         return $thisPath;


### PR DESCRIPTION
It looks like swagger has no way to express that a query string should be used as the fully query string.

The proper way would be to document all the possible fields as param using FIQL based syntax. I don't really feel like going down that rabbit hole right now since it would make things rather more complex.

~~For now I'm also preparing a version of swagger-ui that has some code that handles rql params as the special little cookie they are.~~ Turns out that the changes I wanted to implement in swagger-ui where both non-trivial and rather smelly. For now I ended up just removing the param from swagger... This means users will have to test their RQL stuff without swagger-ui.

