### PR TITLE
Fix escaping error that made errbit log to much

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -151,5 +151,5 @@ eo_airbrake:
         host: %graviton.errbit.host%
         api_key: %graviton.errbit.api_key%
         ignored_exceptions: 
-            - "Symfony\Component\HttpKernel\Exception\HttpException"
-            - "Xiag\Rql\Parser\Exception\SyntaxErrorException"
+            - 'Symfony\Component\HttpKernel\Exception\HttpException'
+            - 'Xiag\Rql\Parser\Exception\SyntaxErrorException'


### PR DESCRIPTION
As it turned out, yml config files does support escaping stuff in strings...

With this I can finally mark all the parser errors being reported to errbit as resolved...