### PR TITLE
1454 fix empty fixtures

### DIFF
--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Service.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Service.xml
@@ -20,7 +20,7 @@
                   type="integer"
                   serialized-name="fixtureOrder"/>
         <property name="fixtures"
-                  type="array&lt;array&gt;"
+                  type="array&lt;ArrayObject&gt;"
                   serialized-name="fixtures"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/config/services.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
         <parameter key="graviton_generator.command.generateresource.class">Graviton\GeneratorBundle\Command\GenerateResourceCommand</parameter>
         <parameter key="graviton_generator.manipulator.xml_file.class">Graviton\GeneratorBundle\Manipulator\File\XmlManipulator</parameter>
         <parameter key="graviton_generator.command_runner.class">Graviton\GeneratorBundle\CommandRunner</parameter>
+        <parameter key="graviton.document.serializer.handler.arrayobject.class">Graviton\GeneratorBundle\Serializer\Handler\ArrayObjectHandler</parameter>
     </parameters>
 
     <services>
@@ -35,6 +36,14 @@
         <service id="graviton_generator.resourcegenerator.field_type_mapper" class="%graviton_generator.resourcegenerator.field_type_mapper.class%"/>
         <service id="graviton_generator.resourcegenerator.field_name_mapper" class="%graviton_generator.resourcegenerator.field_name_mapper.class%"/>
         <service id="graviton_generator.resourcegenerator.field_json_mapper" class="%graviton_generator.resourcegenerator.field_json_mapper.class%"/>
+
+        <!-- ArrayObject serializer handler -->
+        <service id="graviton.document.serializer.handler.arrayobject"
+                 class="%graviton.document.serializer.handler.arrayobject.class%">
+            <tag name="jms_serializer.handler"
+                 type="ArrayObject"
+                 format="json"/>
+        </service>
 
         <service id="graviton_generator.definition.loader" class="%graviton_generator.definition.loader.class%">
             <call method="addStrategy">

--- a/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
+++ b/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
@@ -32,7 +32,6 @@ class ArrayObjectHandler
         array $type,
         Context $context
     ) {
-        $type['name'] = 'array';
         return new \ArrayObject($visitor->visitArray($data->getArrayCopy(), $type, $context));
     }
 
@@ -51,7 +50,6 @@ class ArrayObjectHandler
         array $type,
         Context $context
     ) {
-        $type['name'] = 'array';
         return new \ArrayObject($visitor->visitArray($data, $type, $context));
     }
 }

--- a/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
+++ b/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ArrayObjectHandler class file
+ */
+
+namespace Graviton\GeneratorBundle\Serializer\Handler;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\VisitorInterface;
+
+/**
+ * ArrayObject handler
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ArrayObjectHandler
+{
+    /**
+     * Serialize ArrayObject
+     *
+     * @param VisitorInterface $visitor Visitor
+     * @param \ArrayObject     $data    Data
+     * @param array            $type    Type
+     * @param Context          $context Context
+     * @return \ArrayObject
+     */
+    public function serializeArrayObjectToJson(VisitorInterface $visitor, \ArrayObject $data, array $type, Context $context)
+    {
+        $type['name'] = 'array';
+        return new \ArrayObject($visitor->visitArray($data->getArrayCopy(), $type, $context));
+    }
+
+    /**
+     * Deserialize ArrayObject
+     *
+     * @param VisitorInterface $visitor Visitor
+     * @param array            $data    Data
+     * @param array            $type    Type
+     * @param Context          $context Context
+     * @return \ArrayObject
+     */
+    public function deserializeArrayObjectFromJson(VisitorInterface $visitor, array $data, array $type, Context $context)
+    {
+        $type['name'] = 'array';
+        return new \ArrayObject($visitor->visitArray($data, $type, $context));
+    }
+}

--- a/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
+++ b/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
@@ -26,8 +26,12 @@ class ArrayObjectHandler
      * @param Context          $context Context
      * @return \ArrayObject
      */
-    public function serializeArrayObjectToJson(VisitorInterface $visitor, \ArrayObject $data, array $type, Context $context)
-    {
+    public function serializeArrayObjectToJson(
+        VisitorInterface $visitor,
+        \ArrayObject $data,
+        array $type,
+        Context $context
+    ) {
         $type['name'] = 'array';
         return new \ArrayObject($visitor->visitArray($data->getArrayCopy(), $type, $context));
     }
@@ -41,8 +45,12 @@ class ArrayObjectHandler
      * @param Context          $context Context
      * @return \ArrayObject
      */
-    public function deserializeArrayObjectFromJson(VisitorInterface $visitor, array $data, array $type, Context $context)
-    {
+    public function deserializeArrayObjectFromJson(
+        VisitorInterface $visitor,
+        array $data,
+        array $type,
+        Context $context
+    ) {
         $type['name'] = 'array';
         return new \ArrayObject($visitor->visitArray($data, $type, $context));
     }

--- a/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
+++ b/src/Graviton/GeneratorBundle/Serializer/Handler/ArrayObjectHandler.php
@@ -6,7 +6,8 @@
 namespace Graviton\GeneratorBundle\Serializer\Handler;
 
 use JMS\Serializer\Context;
-use JMS\Serializer\VisitorInterface;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
 
 /**
  * ArrayObject handler
@@ -20,14 +21,14 @@ class ArrayObjectHandler
     /**
      * Serialize ArrayObject
      *
-     * @param VisitorInterface $visitor Visitor
-     * @param \ArrayObject     $data    Data
-     * @param array            $type    Type
-     * @param Context          $context Context
+     * @param JsonSerializationVisitor $visitor Visitor
+     * @param \ArrayObject             $data    Data
+     * @param array                    $type    Type
+     * @param Context                  $context Context
      * @return \ArrayObject
      */
     public function serializeArrayObjectToJson(
-        VisitorInterface $visitor,
+        JsonSerializationVisitor $visitor,
         \ArrayObject $data,
         array $type,
         Context $context
@@ -38,14 +39,14 @@ class ArrayObjectHandler
     /**
      * Deserialize ArrayObject
      *
-     * @param VisitorInterface $visitor Visitor
-     * @param array            $data    Data
-     * @param array            $type    Type
-     * @param Context          $context Context
+     * @param JsonDeserializationVisitor $visitor Visitor
+     * @param array                      $data    Data
+     * @param array                      $type    Type
+     * @param Context                    $context Context
      * @return \ArrayObject
      */
     public function deserializeArrayObjectFromJson(
-        VisitorInterface $visitor,
+        JsonDeserializationVisitor $visitor,
         array $data,
         array $type,
         Context $context

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * ArrayObjectHandlerTest class file
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Serializer\Handler;
+
+use Graviton\GeneratorBundle\Serializer\Handler\ArrayObjectHandler;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerBuilder;
+
+/**
+ * Test ArrayObjectHandler
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ArrayObjectHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test ArrayObjectHandler::serializeArrayObjectToJson()
+     *
+     * @return void
+     */
+    public function testSerializeArrayObjectToJson()
+    {
+        $serialized = ['a' => __LINE__, 'b' => __LINE__];
+        $deserialized = new \ArrayObject(['c' => __LINE__, 'd' => __LINE__]);
+
+        $type = [__METHOD__];
+        $context = SerializationContext::create();
+
+        $serializationVisitor = $this->getMockBuilder('JMS\Serializer\JsonSerializationVisitor')
+            ->disableOriginalConstructor()
+            ->setMethods(['visitArray'])
+            ->getMock();
+        $serializationVisitor
+            ->expects($this->once())
+            ->method('visitArray')
+            ->with(
+                $deserialized->getArrayCopy(),
+                array_merge($type, ['name' => 'array']),
+                $context
+            )
+            ->willReturn($serialized);
+
+        $this->assertEquals(
+            new \ArrayObject($serialized),
+            (new ArrayObjectHandler())->serializeArrayObjectToJson(
+                $serializationVisitor,
+                $deserialized,
+                $type,
+                $context
+            )
+        );
+    }
+
+    /**
+     * Test ArrayObjectHandler::deserializeArrayObjectFromJson()
+     *
+     * @return void
+     */
+    public function testDeserializeArrayObjectFromJson()
+    {
+        $serialized = ['a' => __LINE__, 'b' => __LINE__];
+        $deserialized = new \ArrayObject(['c' => __LINE__, 'd' => __LINE__]);
+
+        $type = [__METHOD__];
+        $context = DeserializationContext::create();
+
+        $deserializationVisitor = $this->getMockBuilder('JMS\Serializer\JsonDeserializationVisitor')
+            ->disableOriginalConstructor()
+            ->setMethods(['visitArray'])
+            ->getMock();
+        $deserializationVisitor
+            ->expects($this->once())
+            ->method('visitArray')
+            ->with(
+                $serialized,
+                array_merge($type, ['name' => 'array']),
+                $context
+            )
+            ->willReturn($deserialized->getArrayCopy());
+
+        $this->assertEquals(
+            $deserialized,
+            (new ArrayObjectHandler())->deserializeArrayObjectFromJson(
+                $deserializationVisitor,
+                $serialized,
+                $type,
+                $context
+            )
+        );
+    }
+
+    /**
+     * Test serializer
+     *
+     * @param string   $serialized   Serialized data
+     * @param TestData $deserialized Deserialized data
+     * @return void
+     * @dataProvider dataSerializerTest
+     */
+    public function testSerializer($serialized, $deserialized)
+    {
+        $handler = new ArrayObjectHandler();
+        $serializer = SerializerBuilder::create()
+            ->addDefaultHandlers()
+            ->addDefaultSerializationVisitors()
+            ->addDefaultDeserializationVisitors()
+            ->configureHandlers(
+                function (HandlerRegistry $registry) use ($handler) {
+                    $registry->registerHandler(
+                        GraphNavigator::DIRECTION_SERIALIZATION,
+                        'ArrayObject',
+                        'json',
+                        [$handler, 'serializeArrayObjectToJson']
+                    );
+                    $registry->registerHandler(
+                        GraphNavigator::DIRECTION_DESERIALIZATION,
+                        'ArrayObject',
+                        'json',
+                        [$handler, 'deserializeArrayObjectFromJson']
+                    );
+                }
+            )
+            ->addMetadataDir(
+                __DIR__.'/resources/config/serializer',
+                'Graviton\\GeneratorBundle\\Tests\\Serializer\\Handler'
+            )
+            ->setCacheDir(sys_get_temp_dir())
+            ->setDebug(true)
+            ->build();
+
+        $this->assertEquals(
+            $serialized,
+            $serializer->serialize($deserialized, 'json')
+        );
+        $this->assertEquals(
+            $deserialized,
+            $serializer->deserialize($serialized, get_class($deserialized), 'json')
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataSerializerTest()
+    {
+        return [
+            [
+                '{"a":{"a":"a"},"b":[{"b":true,"c":1}]}',
+                (new TestData())
+                    ->setA(new \ArrayObject(['a' => 'a']))
+                    ->setB([new \ArrayObject(['b' => true, 'c' => 1])]),
+            ],
+            [
+                '{"a":{},"b":[{},{}]}',
+                (new TestData())
+                    ->setA(new \ArrayObject())
+                    ->setB([new \ArrayObject(), new \ArrayObject()]),
+            ],
+        ];
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
@@ -41,11 +41,7 @@ class ArrayObjectHandlerTest extends \PHPUnit_Framework_TestCase
         $serializationVisitor
             ->expects($this->once())
             ->method('visitArray')
-            ->with(
-                $deserialized->getArrayCopy(),
-                array_merge($type, ['name' => 'array']),
-                $context
-            )
+            ->with($deserialized->getArrayCopy(), $type, $context)
             ->willReturn($serialized);
 
         $this->assertEquals(
@@ -79,11 +75,7 @@ class ArrayObjectHandlerTest extends \PHPUnit_Framework_TestCase
         $deserializationVisitor
             ->expects($this->once())
             ->method('visitArray')
-            ->with(
-                $serialized,
-                array_merge($type, ['name' => 'array']),
-                $context
-            )
+            ->with($serialized, $type, $context)
             ->willReturn($deserialized->getArrayCopy());
 
         $this->assertEquals(

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/ArrayObjectHandlerTest.php
@@ -107,24 +107,23 @@ class ArrayObjectHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializer($serialized, $deserialized)
     {
-        $handler = new ArrayObjectHandler();
         $serializer = SerializerBuilder::create()
             ->addDefaultHandlers()
             ->addDefaultSerializationVisitors()
             ->addDefaultDeserializationVisitors()
             ->configureHandlers(
-                function (HandlerRegistry $registry) use ($handler) {
+                function (HandlerRegistry $registry) {
                     $registry->registerHandler(
                         GraphNavigator::DIRECTION_SERIALIZATION,
                         'ArrayObject',
                         'json',
-                        [$handler, 'serializeArrayObjectToJson']
+                        [new ArrayObjectHandler(), 'serializeArrayObjectToJson']
                     );
                     $registry->registerHandler(
                         GraphNavigator::DIRECTION_DESERIALIZATION,
                         'ArrayObject',
                         'json',
-                        [$handler, 'deserializeArrayObjectFromJson']
+                        [new ArrayObjectHandler(), 'deserializeArrayObjectFromJson']
                     );
                 }
             )

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/TestData.php
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/TestData.php
@@ -39,7 +39,7 @@ class TestData
     }
 
     /**
-     * @param \ArrayObject $a
+     * @param \ArrayObject $a A
      * @return $this
      */
     public function setA(\ArrayObject $a)
@@ -57,7 +57,7 @@ class TestData
     }
 
     /**
-     * @param \ArrayObject[] $b
+     * @param \ArrayObject[] $b B
      * @return $this
      */
     public function setB(array $b)

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/TestData.php
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/TestData.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Test class file
+ */
+
+namespace Graviton\GeneratorBundle\Tests\Serializer\Handler;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class TestData
+{
+    /**
+     * @var \ArrayObject
+     */
+    private $a;
+    /**
+     * @var \ArrayObject[]
+     */
+    private $b;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->a = new \ArrayObject();
+        $this->b = [];
+    }
+
+    /**
+     * @return \ArrayObject
+     */
+    public function getA()
+    {
+        return $this->a;
+    }
+
+    /**
+     * @param \ArrayObject $a
+     * @return $this
+     */
+    public function setA(\ArrayObject $a)
+    {
+        $this->a = $a;
+        return $this;
+    }
+
+    /**
+     * @return \ArrayObject[]
+     */
+    public function getB()
+    {
+        return $this->b;
+    }
+
+    /**
+     * @param \ArrayObject[] $b
+     * @return $this
+     */
+    public function setB(array $b)
+    {
+        $this->b = $b;
+        return $this;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/resources/config/serializer/TestData.xml
+++ b/src/Graviton/GeneratorBundle/Tests/Serializer/Handler/resources/config/serializer/TestData.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="Graviton\GeneratorBundle\Tests\Serializer\Handler\TestData">
+        <property name="a"
+                  type="ArrayObject"
+                  serialized-name="a"/>
+        <property name="b"
+                  type="array&lt;ArrayObject&gt;"
+                  serialized-name="b"/>
+    </class>
+</serializer>


### PR DESCRIPTION
This allows to use empty fixtures `{}` (see [File.json](https://github.com/libgraviton/graviton/blob/develop/src/Graviton/FileBundle/Resources/definition/File.json#L9)).
In current implementation, we are losing the type during deserialization and serialization:
```php
// outputs "[[]]"
echo $serializer->serialize(
    $serializer->deserialize('[{}]', 'array<array>', 'json'),
    'json'
);
````