### PR TITLE
Set default ID strategy to "UUID".

### DIFF
--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -13,7 +13,7 @@
   <{{ docType }} name="{{ base }}Document\{{ document }}" repository-class="{{ base }}Repository\{{ document}}Repository">
 
   {% if idField is defined %}
-      <field fieldName="id" type="{{ idField.doctrineType }}" id="true"/>
+      <field fieldName="id" type="{{ idField.doctrineType }}" id="true" strategy="UUID"/>
   {% else %}
       <field fieldName="id" type="string" id="true" strategy="UUID"/>
   {% endif %}


### PR DESCRIPTION
MongoDB ODM was released [today](https://github.com/doctrine/mongodb-odm/releases).

ID value validation for default strategy (`AUTO`) was changed in:
https://github.com/doctrine/mongodb-odm/commit/3dd6a2f10e14f389d760fb9857d7dbeca9199972

I get the following errors when I try to load fixtures:
```bash
[vagrant@localhost fork]$ composer.phar update
.....

[vagrant@localhost fork]$ app/console doctrine:mongodb:fixtures:load
  > purging database
  > loading Graviton\I18nBundle\DataFixtures\MongoDB\LoadMultiLanguageData
  > loading Graviton\CoreBundle\DataFixtures\MongoDB\LoadProductData
  > loading Graviton\I18nBundle\DataFixtures\MongoDB\LoadLanguageData
  > loading Graviton\I18nBundle\DataFixtures\MongoDB\LoadTranslatablesApp
  > loading Graviton\CoreBundle\DataFixtures\MongoDB\LoadAppData
  > loading Graviton\I18nBundle\DataFixtures\MongoDB\LoadTranslatableData
  > loading [45] GravitonDyn\CustomerBundle\DataFixtures\MongoDB\LoadCustomerData


  [InvalidArgumentException]                                                                                                           
  GravitonDyn\CustomerBundle\Document\Customer uses AUTO identifier generation strategy but provided identifier is not valid MongoId.  
```