### PR TITLE
Fix module test by using pre-defined identifiers

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Module.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Module.json
@@ -6,7 +6,7 @@
     "routerBase": "/core/module/",
     "fixtures": [
       {
-        "id": "55c1c99a7f8b9ac7dd8b456f",
+        "id": "tablet-realEstate",
         "key": "realEstate",
         "app": {
           "$ref": "http://localhost/core/app/tablet"
@@ -34,7 +34,7 @@
         ]
       },
       {
-        "id": "55c1c99a7f8b9ac7dd8b456d",
+        "id": "tablet-investment",
         "key": "investment",
         "app": {
           "$ref": "http://localhost/core/app/tablet"
@@ -76,6 +76,7 @@
         ]
       },
       {
+        "id": "tablet-retirement",
         "key": "retirement",
         "app": {
           "$ref": "http://localhost/core/app/tablet"
@@ -88,6 +89,7 @@
         "service": []
       },
       {
+        "id": "tablet-requisition",
         "key": "requisition",
         "app": {
           "$ref": "http://localhost/core/app/tablet"
@@ -100,6 +102,7 @@
         "service": []
       },
       {
+        "id": "tablet-payAndSave",
         "key": "payAndSave",
         "app": {
           "$ref": "http://localhost/core/app/tablet"
@@ -112,6 +115,7 @@
         "service": []
       },
       {
+        "id": "admin-AdminRef",
         "key": "AdminRef",
         "app": {
           "$ref": "http://localhost/core/app/admin"

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -72,7 +72,7 @@ class ModuleControllerTest extends RestTestCase
             $response->headers->get('Link')
         );
 
-        $this->assertEquals('http://localhost/core/app/tablet', $client->getResults()[0]->app->{'$ref'});
+        $this->assertEquals('http://localhost/core/app/admin', $client->getResults()[0]->app->{'$ref'});
     }
 
     /**


### PR DESCRIPTION
This way the order of the loaded records is always the same in each run.

This should make travis work as intended again. We noticed this in both #236 and #238...