### PR TITLE
fix for loading array fixtures

### DIFF
--- a/src/Graviton/GeneratorBundle/Resources/skeleton/fixtures/LoadFixtures.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/fixtures/LoadFixtures.php.twig
@@ -68,8 +68,8 @@ class Load{{ document }}Data extends AbstractFixture implements OrderedFixtureIn
                     // cheap attempt for arrays..
                     if (is_array($val) && isset($val[0]->$refName) && isset($val[0]->$idName)) {
                         $relRecs = [];
-                        foreach ($val as $subkey => $subval) {
-                            $relRecs[$subkey] = $this->getReference($subval->$refName.'-'.$subval->$idName);
+                        foreach ($val as $subval) {
+                            $relRecs[] = $this->getReference($subval->$refName.'-'.$subval->$idName);
                         }
 
                         $setterFunction = 'set'.ucfirst($key);

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/fixtures/LoadFixtures.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/fixtures/LoadFixtures.php.twig
@@ -67,14 +67,13 @@ class Load{{ document }}Data extends AbstractFixture implements OrderedFixtureIn
 
                     // cheap attempt for arrays..
                     if (is_array($val) && isset($val[0]->$refName) && isset($val[0]->$idName)) {
-                        // clear first..
-                        $setterFunction = 'set'.ucfirst($key);
-                        $thisRecord->$setterFunction(array());
-
+                        $relRecs = [];
                         foreach ($val as $subkey => $subval) {
-                            $addFunction = 'add'.ucfirst($key);
-                            $thisRecord->$addFunction($this->getReference($subval->$refName.'-'.$subval->$idName));
+                            $relRecs[$subkey] = $this->getReference($subval->$refName.'-'.$subval->$idName);
                         }
+
+                        $setterFunction = 'set'.ucfirst($key);
+                        $thisRecord->$setterFunction($relRecs);
                     }
                 }
 


### PR DESCRIPTION
this is a very small PR fixing a minor bug..

if a field is named in a plural way, the current fixture loading process doesn't work as it calls `add{fieldName}()` and `set{fieldName}()`. and those fields get generated in a different name, as the `add*` function is generated in the singularName.

so i made this small change that it only calls the `set*()` function that always has the *correct* name