### PR TITLE
20150827 fix searching by extref

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -109,24 +109,26 @@ class ExtRefFieldsCompilerPass implements CompilerPassInterface
     /**
      * Recursive doctrine document processing
      *
-     * @param Document $document Document
-     * @param string   $prefix   Field prefix
+     * @param Document $document       Document
+     * @param string   $documentPrefix Document field prefix
+     * @param string   $exposedPrefix  Exposed field prefix
      * @return array
      */
-    private function processDocument(Document $document, $prefix = '')
+    private function processDocument(Document $document, $documentPrefix = '', $exposedPrefix = '')
     {
         $result = [];
         foreach ($document->getFields() as $field) {
             if ($field instanceof Field) {
                 if ($field->getType() === 'extref') {
-                    $result[] = $prefix.$field->getExposedName();
+                    $result[$documentPrefix.$field->getFieldName()] = $exposedPrefix.$field->getExposedName();
                 }
             } elseif ($field instanceof EmbedOne) {
                 $result = array_merge(
                     $result,
                     $this->processDocument(
                         $field->getDocument(),
-                        $prefix.$field->getExposedName().'.'
+                        $documentPrefix.$field->getFieldName().'.',
+                        $exposedPrefix.$field->getExposedName().'.'
                     )
                 );
             } elseif ($field instanceof EmbedMany) {
@@ -134,7 +136,8 @@ class ExtRefFieldsCompilerPass implements CompilerPassInterface
                     $result,
                     $this->processDocument(
                         $field->getDocument(),
-                        $prefix.$field->getExposedName().'.0.'
+                        $documentPrefix.$field->getFieldName().'.0.',
+                        $exposedPrefix.$field->getExposedName().'.0.'
                     )
                 );
             }

--- a/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
+++ b/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
@@ -154,13 +154,6 @@ class ExtReferenceSearchListener
      */
     private function processArrayNode(AbstractArrayOperatorNode $node, Builder $builder)
     {
-        $route = $this->request->attributes->get('_route');
-        if (!array_key_exists($route, $this->fields)) {
-            throw new \LogicException('Missing ' . $route . ' from extref fields map.');
-        }
-        if (!in_array(strtr($node->getField(), ['..' => '.0.']), $this->fields[$route])) {
-            return;
-        }
         if ($node->getValues() === []) {
             return;
         }

--- a/src/Graviton/DocumentBundle/Service/ExtReferenceConverterInterface.php
+++ b/src/Graviton/DocumentBundle/Service/ExtReferenceConverterInterface.php
@@ -18,7 +18,7 @@ interface ExtReferenceConverterInterface
      * return the mongodb representation from a extref URL
      *
      * @param string $url Extref URL
-     * @return array
+     * @return object
      * @throws \InvalidArgumentException
      */
     public function getDbRef($url);

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
@@ -53,26 +53,26 @@ class ExtRefFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('graviton.document.type.extref.fields'),
                 [
                     'gravitontest.document.rest.a.get' => [
-                        '$exposedRefA',
+                        'ref'                         => '$exposedRefA',
 
-                        'achild.$exposedRefB',
-                        'achild.bchild.$exposedRefC',
-                        'achild.bchildren.0.$exposedRefC',
+                        'achild.ref'                  => 'achild.$exposedRefB',
+                        'achild.bchild.ref'           => 'achild.bchild.$exposedRefC',
+                        'achild.bchildren.0.ref'      => 'achild.bchildren.0.$exposedRefC',
 
-                        'achildren.0.$exposedRefB',
-                        'achildren.0.bchild.$exposedRefC',
-                        'achildren.0.bchildren.0.$exposedRefC',
+                        'achildren.0.ref'             => 'achildren.0.$exposedRefB',
+                        'achildren.0.bchild.ref'      => 'achildren.0.bchild.$exposedRefC',
+                        'achildren.0.bchildren.0.ref' => 'achildren.0.bchildren.0.$exposedRefC',
                     ],
                     'gravitontest.document.rest.a.all' => [
-                        '$exposedRefA',
+                        'ref'                         => '$exposedRefA',
 
-                        'achild.$exposedRefB',
-                        'achild.bchild.$exposedRefC',
-                        'achild.bchildren.0.$exposedRefC',
+                        'achild.ref'                  => 'achild.$exposedRefB',
+                        'achild.bchild.ref'           => 'achild.bchild.$exposedRefC',
+                        'achild.bchildren.0.ref'      => 'achild.bchildren.0.$exposedRefC',
 
-                        'achildren.0.$exposedRefB',
-                        'achildren.0.bchild.$exposedRefC',
-                        'achildren.0.bchildren.0.$exposedRefC',
+                        'achildren.0.ref'             => 'achildren.0.$exposedRefB',
+                        'achildren.0.bchild.ref'      => 'achildren.0.bchild.$exposedRefC',
+                        'achildren.0.bchildren.0.ref' => 'achildren.0.bchildren.0.$exposedRefC',
                     ],
                 ]
             );


### PR DESCRIPTION
`ExtReferenceSearchListener` searches for extref in array fields only by first array element (see `ShowcaseControllerTest::testFindByExtref()`) because we generate the following queries:
```json
{
  "nestedApps.0.ref.$ref": "App",
  "nestedApps.0.ref.$id": "admin"
}
```

I tried to change the query to:
```json
{
  "nestedApps.ref.$ref": "App",
  "nestedApps.ref.$id": "admin"
}
```

But Doctrine processes such queries so strange:
```php
$repository = $this->container
    ->get('doctrine_mongodb.odm.default_document_manager')
    ->getRepository('GravitonDynModuleBundle:Module');
dump(
    $repository->createQueryBuilder()
        ->field('service.gui.ref.$ref')
        ->equals('A')
        ->field('service.gui.ref.$id')
        ->equals('a')
        ->getQuery()
        ->getQuery()['query']
);
```
outputs:
```
array:2 [
  "service.gui.ref.$ref.$ref" => "A"
  "service.gui.ref.$id.$id" => "a"
]
```


Then I changed the query to:
```php
$repository = $this->container
    ->get('doctrine_mongodb.odm.default_document_manager')
    ->getRepository('GravitonDynModuleBundle:Module');
dump(
    $repository->createQueryBuilder()
        ->field('service.gui.ref')
        ->equals(\MongoDBRef::create('A', 'a'))
        ->getQuery()
        ->getQuery()['query']
);
```
and the output:
```
array:1 [
  "service.gui.ref" => array:2 [
    "$ref" => "A"
    "$id" => "a"
  ]
]
```

Also `ExtReferenceSearchListener` now uses correct mapping `exposedField -> documentField`