### PR TITLE
20150904 ref validation

### DIFF
--- a/src/Graviton/RestBundle/Tests/Validator/ExtReference/ExtReferenceValidatorTest.php
+++ b/src/Graviton/RestBundle/Tests/Validator/ExtReference/ExtReferenceValidatorTest.php
@@ -83,6 +83,23 @@ class ExtReferenceValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test validate() null value
+     *
+     * @return void
+     */
+    public function testValidateNull()
+    {
+        $url = null;
+        $constraint = new ExtReference();
+
+        $this->converter->expects($this->never())
+            ->method('getDbRef');
+
+        $validator = $this->createValidator();
+        $validator->validate($url, $constraint);
+    }
+
+    /**
      * Test validate()
      *
      * @return void

--- a/src/Graviton/RestBundle/Tests/Validator/ExtReference/ExtReferenceValidatorTest.php
+++ b/src/Graviton/RestBundle/Tests/Validator/ExtReference/ExtReferenceValidatorTest.php
@@ -68,7 +68,7 @@ class ExtReferenceValidatorTest extends \PHPUnit_Framework_TestCase
      * Test validate()
      *
      * @return void
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      */
     public function testValidateInvalidConstraint()
     {

--- a/src/Graviton/RestBundle/Validator/Constraints/ExtReference/ExtReferenceValidator.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/ExtReference/ExtReferenceValidator.php
@@ -8,6 +8,7 @@ namespace Graviton\RestBundle\Validator\Constraints\ExtReference;
 use Graviton\DocumentBundle\Service\ExtReferenceConverterInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Validator for the extref type
@@ -45,13 +46,7 @@ class ExtReferenceValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof ExtReference) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Constraint must be instance of %s (%s given)',
-                    'Graviton\RestBundle\Validator\Constraints\ExtReference\ExtReference',
-                    get_class($constraint)
-                )
-            );
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\ExtReference');
         }
 
         try {

--- a/src/Graviton/RestBundle/Validator/Constraints/ExtReference/ExtReferenceValidator.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/ExtReference/ExtReferenceValidator.php
@@ -49,6 +49,10 @@ class ExtReferenceValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\ExtReference');
         }
 
+        if ($value === null) {
+            return;
+        }
+
         try {
             $extref = $this->converter->getDbRef($value);
             if (is_array($constraint->allowedCollections) &&


### PR DESCRIPTION
Skipping validation for `null` in `ExtReferenceValidator`.
`null` values should be validated by `NotNullValidator` or `NotBlankValidator`.