### PR TITLE
20150908 empty objects in array

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4004,16 +4004,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.7.0",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "8339fbaf787dd34822ac34043556592ab4b5bfbf"
+                "reference": "eed4c331a156cdb6a360730443fb665895e3c823"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/8339fbaf787dd34822ac34043556592ab4b5bfbf",
-                "reference": "8339fbaf787dd34822ac34043556592ab4b5bfbf",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/eed4c331a156cdb6a360730443fb665895e3c823",
+                "reference": "eed4c331a156cdb6a360730443fb665895e3c823",
                 "shasum": ""
             },
             "type": "library",
@@ -4028,10 +4028,10 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.7.0",
+                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.9.0",
                 "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
             },
-            "time": "2015-08-25 09:53:07"
+            "time": "2015-09-08 06:48:41"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/src/Graviton/CoreBundle/Tests/Controller/EmptyObjectControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/EmptyObjectControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * EmptyObjectControllerTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class EmptyObjectControllerTest extends RestTestCase
+{
+    /**
+     * load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if (!class_exists('GravitonDyn\TestCaseEmptyObjectBundle\DataFixtures\MongoDB\LoadTestCaseEmptyObjectData')) {
+            $this->markTestSkipped('TestCaseEmptyObject definition is not loaded');
+        }
+
+        $this->loadFixtures(
+            ['GravitonDyn\TestCaseEmptyObjectBundle\DataFixtures\MongoDB\LoadTestCaseEmptyObjectData'],
+            null,
+            'doctrine_mongodb'
+        );
+    }
+
+    /**
+     * Test GET one method
+     *
+     * @param string $id ID
+     * @return void
+     * @dataProvider dataCheckGetOne
+     */
+    public function testCheckGetOne($id)
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/emptyObject/?id='.$id);
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertInternalType('array', $client->getResults());
+        $this->assertCount(1, $client->getResults());
+    }
+
+    /**
+     * Data for GET one test
+     *
+     * @return array
+     */
+    public function dataCheckGetOne()
+    {
+        return [
+            'empty all' => [
+                'emptyAll',
+            ],
+            'empty hash' => [
+                'emptyHash',
+            ],
+            'empty unstructured' => [
+                'emptyUnstructured',
+            ],
+            'no empty objects' => [
+                'noEmpty',
+            ],
+        ];
+    }
+
+    /**
+     * Test GET all method
+     *
+     * @return void
+     */
+    public function testCheckGetAll()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/emptyObject/');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertInternalType('array', $client->getResults());
+        $this->assertCount(4, $client->getResults());
+    }
+}

--- a/src/Graviton/CoreBundle/Tests/Controller/NullExtrefControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/NullExtrefControllerTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * NullExtrefControllerTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class NullExtrefControllerTest extends RestTestCase
+{
+    /**
+     * load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if (!class_exists('GravitonDyn\TestCaseNullExtrefBundle\DataFixtures\MongoDB\LoadTestCaseNullExtrefData')) {
+            $this->markTestSkipped('TestCaseNullExtref definition is not loaded');
+        }
+
+        $this->loadFixtures(
+            ['GravitonDyn\TestCaseNullExtrefBundle\DataFixtures\MongoDB\LoadTestCaseNullExtrefData'],
+            null,
+            'doctrine_mongodb'
+        );
+    }
+
+    /**
+     * Test GET one method
+     *
+     * @return void
+     */
+    public function testCheckGetOne()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/nullExtref/testdata');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertNotEmpty($client->getResults());
+
+        $data = $client->getResults();
+        $expectedRefVal = 'http://localhost/core/app/admin';
+
+        $this->assertFalse(isset($data->optionalExtref->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtref->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtref->{'$ref'});
+
+        $this->assertFalse(isset($data->optionalExtrefArray[0]->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtrefArray[0]->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtrefArray[0]->{'$ref'});
+
+        $this->assertFalse(isset($data->optionalExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'});
+    }
+
+    /**
+     * Test GET all method
+     *
+     * @return void
+     */
+    public function testCheckGetAll()
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/nullExtref/');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertCount(1, $client->getResults());
+
+        $data = $client->getResults()[0];
+        $expectedRefVal = 'http://localhost/core/app/admin';
+
+        $this->assertFalse(isset($data->optionalExtref->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtref->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtref->{'$ref'});
+
+        $this->assertFalse(isset($data->optionalExtrefArray[0]->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtrefArray[0]->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtrefArray[0]->{'$ref'});
+
+        $this->assertFalse(isset($data->optionalExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'}));
+        $this->assertTrue(isset($data->requiredExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'}));
+        $this->assertEquals($expectedRefVal, $data->requiredExtrefDeep[0]->deep[0]->deep->deep[0]->{'$ref'});
+    }
+
+    /**
+     * Test POST method
+     *
+     * @param array $data Data to POST
+     * @return void
+     * @dataProvider dataTestData
+     */
+    public function testPostMethod(array $data)
+    {
+        $client = static::createRestClient();
+        $client->post('/testcase/nullExtref/', $data);
+        $this->assertEquals(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $this->assertEmpty($client->getResults());
+
+        $location = $client->getResponse()->headers->get('Location');
+
+        $client = static::createRestClient();
+        $client->request('GET', $location);
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $result = $client->getResults();
+        $this->assertNotNull($result->id);
+        unset($result->id);
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($this->removeNullRefs($data)),
+            json_encode($client->getResults())
+        );
+    }
+
+    /**
+     * Test PUT method
+     *
+     * @param array $data Data to PUT
+     * @return void
+     * @dataProvider dataTestData
+     */
+    public function testPutMethod(array $data)
+    {
+        $data['id'] = 'testdata';
+
+        $client = static::createRestClient();
+        $client->put('/testcase/nullExtref/testdata', $data);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $this->assertEmpty($client->getResults());
+
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/nullExtref/testdata');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($this->removeNullRefs($data)),
+            json_encode($client->getResults())
+        );
+    }
+
+    /**
+     * Remove null $ref recursively
+     *
+     * @param array $data Data to process
+     * @return array|object
+     */
+    private function removeNullRefs(array $data)
+    {
+        foreach ($data as $key => $value) {
+            if ($key === '$ref' && $value === null) {
+                unset($data[$key]);
+                if ($data === []) {
+                    return (object) $data;
+                }
+            } elseif (is_array($value)) {
+                $data[$key] = $this->removeNullRefs($value);
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Data for tests
+     *
+     * @return array
+     */
+    public function dataTestData()
+    {
+        return [
+            'empty refs' => [
+                [
+                    'optionalExtref'      => ['$ref' => null],
+                    'requiredExtref'      => ['$ref' => 'http://localhost/core/app/admin'],
+                    'optionalExtrefArray' => [
+                        ['$ref' => null],
+                    ],
+                    'requiredExtrefArray' => [
+                        ['$ref' => 'http://localhost/core/app/admin'],
+                    ],
+                    'optionalExtrefDeep'  => [
+                        [
+                            'deep' => [
+                                [
+                                    'deep' => [
+                                        'deep' => [
+                                            ['$ref' => null],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'requiredExtrefDeep'  => [
+                        [
+                            'deep' => [
+                                [
+                                    'deep' => [
+                                        'deep' => [
+                                            ['$ref' => 'http://localhost/core/app/admin'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            ],
+            'filled refs' => [
+                [
+                    'optionalExtref'      => ['$ref' => 'http://localhost/core/app/tablet'],
+                    'requiredExtref'      => ['$ref' => 'http://localhost/core/app/admin'],
+                    'optionalExtrefArray' => [
+                        ['$ref' => 'http://localhost/core/app/tablet'],
+                    ],
+                    'requiredExtrefArray' => [
+                        ['$ref' => 'http://localhost/core/app/admin'],
+                    ],
+                    'optionalExtrefDeep'  => [
+                        [
+                            'deep' => [
+                                [
+                                    'deep' => [
+                                        'deep' => [
+                                            ['$ref' => 'http://localhost/core/app/tablet'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'requiredExtrefDeep'  => [
+                        [
+                            'deep' => [
+                                [
+                                    'deep' => [
+                                        'deep' => [
+                                            ['$ref' => 'http://localhost/core/app/admin'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            ],
+        ];
+    }
+}

--- a/src/Graviton/DocumentBundle/Service/FormDataMapper.php
+++ b/src/Graviton/DocumentBundle/Service/FormDataMapper.php
@@ -82,7 +82,7 @@ class FormDataMapper implements FormDataMapperInterface
                 if (isset($item->$topLevel)) {
                     $this->mapField($item->$topLevel, $subField, $name);
                 }
-            } elseif (isset($item->$path)) {
+            } elseif (isset($item->$path) || property_exists($item, $path)) {
                 $item->$name = $item->$path;
                 unset($item->$path);
             }

--- a/src/Graviton/DocumentBundle/Tests/Service/FormDataMapperTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/FormDataMapperTest.php
@@ -75,4 +75,50 @@ class FormDataMapperTest extends \PHPUnit_Framework_TestCase
             $formDataMapper->convertToFormData(json_encode($requestData), 'A')
         );
     }
+
+    /**
+     * Test FormDataMapper::convertToFormData() with NULL
+     *
+     * @return void
+     */
+    public function testConvertToFormDataWithNullValues()
+    {
+        $fieldMap = [
+            '$field'                => '_field_',
+
+            '$hash.$field'          => '_hash_field_',
+            '$hash'                 => '_hash_',
+
+            '$arrayhash.0.$field'   => '_arrayhash_field_',
+            '$arrayhash'            => '_arrayhash_',
+        ];
+        $requestData =[
+            '$field'        => null,
+            'abc'           => null,
+            '$hash'         => null,
+            '$arrayhash'    => [
+                [
+                    '$field' => null,
+                    'ghi'    => null,
+                ],
+            ],
+        ];
+        $formData = [
+            '_field_'       => null,
+            'abc'           => null,
+            '_hash_'        => null,
+            '_arrayhash_'   => [
+                [
+                    '_arrayhash_field_' => null,
+                    'ghi'               => null,
+                ],
+            ],
+        ];
+
+        $formDataMapper = new FormDataMapper(['NullableValues' => $fieldMap]);
+        $this->assertEquals(
+            $formData,
+            $formDataMapper->convertToFormData(json_encode($requestData), 'NullableValues')
+        );
+    }
 }

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
@@ -306,6 +306,12 @@ class JsonDefinition
         } else {
             $fields = [];
             foreach ($definition as $subname => $subdefinition) {
+                // TODO: this is hotfix for new hash field syntax
+                // TODO: this must be removed in PR #224
+                if (!$subdefinition instanceof Schema\Field && !is_array($subdefinition)) {
+                    continue;
+                }
+
                 $fields[$subname] = $this->processFieldHierarchyRecursive($subname, $subdefinition);
             }
 


### PR DESCRIPTION
This fixes array serialization and adds new tests for nulls in `extref`.
@narcoticfresh this pull request depends on https://github.com/libgraviton/GravitonTestServicesBundle/pull/13