### PR TITLE
expose readonly fields as readonly

### DIFF
--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -447,5 +447,4 @@ class FileControllerTest extends RestTestCase
         );
         $this->assertObjectNotHasAttribute('readOnly', $schema->properties->links->items->properties->{'$ref'});
     }
-
 }

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
@@ -21,6 +21,10 @@
       "collection": {{ field.collection|json_encode() }},
 {% endif %}
 
+{% if field.readOnly is defined and field.readOnly == true %}
+      "readOnly": {{ field.readOnly|json_encode() }},
+{% endif %}
+
 {% if field.description is defined %}
       "description": {{ field.description|json_encode() }}
 {% else %}

--- a/src/Graviton/SchemaBundle/Document/Schema.php
+++ b/src/Graviton/SchemaBundle/Document/Schema.php
@@ -60,6 +60,11 @@ class Schema
     protected $refCollection = array();
 
     /**
+     * @var bool
+     */
+    protected $readOnly = false;
+
+    /**
      * these are the BSON primitive types.
      * http://json-schema.org/latest/json-schema-core.html#anchor8
      * every type set *not* in this set will be carried over to 'format'
@@ -351,5 +356,26 @@ class Schema
         }
 
         return $collection;
+    }
+
+    /**
+     * Set the readOnly flag
+     *
+     * @param bool $readOnly ReadOnly flag
+     */
+    public function setReadOnly($readOnly)
+    {
+        $this->readOnly = (bool) $readOnly;
+    }
+
+    /**
+     * Get the readOnly flag.
+     * Returns null if the flag is set to false so the serializer will ignore it.
+     *
+     * @return bool|null true if readOnly isset to true or null if not
+     */
+    public function getReadOnly()
+    {
+        return $this->readOnly ? true : null;
     }
 }

--- a/src/Graviton/SchemaBundle/Document/Schema.php
+++ b/src/Graviton/SchemaBundle/Document/Schema.php
@@ -362,6 +362,8 @@ class Schema
      * Set the readOnly flag
      *
      * @param bool $readOnly ReadOnly flag
+     *
+     * @return void
      */
     public function setReadOnly($readOnly)
     {

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -155,6 +155,17 @@ class SchemaModel implements ContainerAwareInterface
     }
 
     /**
+     * get readOnly flag for a given field
+     *
+     * @param string $field field name
+     * @return bool the readOnly flag
+     */
+    public function getReadOnlyOfField($field)
+    {
+        return $this->getSchemaField($field, 'readOnly', false);
+    }
+
+    /**
      * get schema field value
      *
      * @param string $field         field name

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -173,7 +173,7 @@ class SchemaModel implements ContainerAwareInterface
      * @param string $property      property name
      * @param mixed  $fallbackValue fallback value if property isn't set
      *
-     * @return array
+     * @return mixed
      */
     private function getSchemaField($field, $property, $fallbackValue = '')
     {

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -158,7 +158,8 @@ class SchemaModel implements ContainerAwareInterface
      * get readOnly flag for a given field
      *
      * @param string $field field name
-     * @return bool the readOnly flag
+     *
+     * @return boolean the readOnly flag
      */
     public function getReadOnlyOfField($field)
     {

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -19,9 +19,9 @@
       "description": "Primitive data type of the property"
     },
     "readOnly": {
-      "title": "Readonly",
+      "title": "Read-only",
       "type": "boolean",
-      "description": "Defines whether the property is readonly"
+      "description": "Defines whether the property is read-only"
     },
     "format": {
       "title": "Format",

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -18,7 +18,7 @@
       "type": "string",
       "description": "Primitive data type of the property"
     },
-    "readonly": {
+    "readOnly": {
       "title": "Readonly",
       "type": "boolean",
       "description": "Defines whether the property is readonly"

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -18,6 +18,11 @@
       "type": "string",
       "description": "Primitive data type of the property"
     },
+    "readOnly": {
+      "title": "Readonly",
+      "type": "boolean",
+      "description": "Defines whether the property is readonly"
+    },
     "format": {
       "title": "Format",
       "type": "string",

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -18,7 +18,7 @@
       "type": "string",
       "description": "Primitive data type of the property"
     },
-    "readOnly": {
+    "readonly": {
       "title": "Readonly",
       "type": "boolean",
       "description": "Defines whether the property is readonly"

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -4,7 +4,7 @@
     <property name="title" type="string" accessor-getter="getTitle" accessor-setter="setTitle" expose="true"/>
     <property name="description" type="string" accessor-getter="getDescription" accessor-setter="setDescription" expose="true"/>
     <property name="type" type="string" accessor-getter="getType" accessor-setter="setType" expose="true"/>
-    <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" expose="true"/>
+    <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" serialized-name="readonly" expose="true"/>
     <property name="format" type="string" accessor-getter="getFormat" accessor-setter="setFormat" expose="true"/>
     <property name="items" type="Graviton\SchemaBundle\Document\Schema" accessor-getter="getItems" accessor-setter="setItems" expose="true"/>
     <property name="refCollection" accessor-getter="getRefCollection" accessor-setter="setRefCollection" serialized-name="x-collection" expose="true">

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -4,7 +4,7 @@
     <property name="title" type="string" accessor-getter="getTitle" accessor-setter="setTitle" expose="true"/>
     <property name="description" type="string" accessor-getter="getDescription" accessor-setter="setDescription" expose="true"/>
     <property name="type" type="string" accessor-getter="getType" accessor-setter="setType" expose="true"/>
-    <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" serialized-name="readonly" expose="true"/>
+    <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" expose="true"/>
     <property name="format" type="string" accessor-getter="getFormat" accessor-setter="setFormat" expose="true"/>
     <property name="items" type="Graviton\SchemaBundle\Document\Schema" accessor-getter="getItems" accessor-setter="setItems" expose="true"/>
     <property name="refCollection" accessor-getter="getRefCollection" accessor-setter="setRefCollection" serialized-name="x-collection" expose="true">

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -4,6 +4,7 @@
     <property name="title" type="string" accessor-getter="getTitle" accessor-setter="setTitle" expose="true"/>
     <property name="description" type="string" accessor-getter="getDescription" accessor-setter="setDescription" expose="true"/>
     <property name="type" type="string" accessor-getter="getType" accessor-setter="setType" expose="true"/>
+    <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" expose="true"/>
     <property name="format" type="string" accessor-getter="getFormat" accessor-setter="setFormat" expose="true"/>
     <property name="items" type="Graviton\SchemaBundle\Document\Schema" accessor-getter="getItems" accessor-setter="setItems" expose="true"/>
     <property name="refCollection" accessor-getter="getRefCollection" accessor-setter="setRefCollection" serialized-name="x-collection" expose="true">

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -141,7 +141,9 @@ class SchemaUtils
             $property->setDescription($model->getDescriptionOfField($field));
 
             $property->setType($meta->getTypeOfField($field));
-            $property->setReadOnly($model->getReadOnlyOfField($field));
+            $property->setReadOnly(
+                $model->getReadOnlyOfField($field) || ($meta->isIdentifier($field) && !$meta->isIdGeneratorNone())
+            );
 
             if ($meta->getTypeOfField($field) === 'many') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -141,9 +141,7 @@ class SchemaUtils
             $property->setDescription($model->getDescriptionOfField($field));
 
             $property->setType($meta->getTypeOfField($field));
-            $property->setReadOnly(
-                $model->getReadOnlyOfField($field) || ($meta->isIdentifier($field) && !$meta->isIdGeneratorNone())
-            );
+            $property->setReadOnly($model->getReadOnlyOfField($field));
 
             if ($meta->getTypeOfField($field) === 'many') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -141,6 +141,7 @@ class SchemaUtils
             $property->setDescription($model->getDescriptionOfField($field));
 
             $property->setType($meta->getTypeOfField($field));
+            $property->setReadOnly($model->getReadOnlyOfField($field));
 
             if ($meta->getTypeOfField($field) === 'many') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));
@@ -190,7 +191,6 @@ class SchemaUtils
             $requiredFields[] = $documentFieldNames[$field];
         }
         $schema->setRequired($requiredFields);
-
 
         return $schema;
     }


### PR DESCRIPTION
This pull request adds a `readOnly` property to the item schema as [defined in JSON Schema v4](http://json-schema.org/latest/json-schema-hypermedia.html#anchor15). So the schema of all fields, which are defined as readonly within the `Resources/config/schema/$Service.json`, will be extended by `"readOnly": true`.