### PR TITLE
Fix updating of files through PUT in cors scenarios

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -187,7 +187,7 @@ class FileController extends RestController
         $request->attributes->set('id', $record->getId());
 
         $response = $this->getResponse();
-        $response->setStatusCode(Response::HTTP_OK);
+        $response->setStatusCode(Response::HTTP_NO_CONTENT);
 
         $routeName = $request->get('_route');
         if (substr($routeName, 0, -4) == '.put') {

--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -194,11 +194,6 @@ class FileController extends RestController
             $routeName = substr($routeName, 0, -3) . 'get';
         }
 
-        $response->headers->set(
-            'Location',
-            $this->getRouter()->generate($routeName, array('id' => $record->getId()))
-        );
-
         return $response;
     }
 

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -95,7 +95,7 @@ class FileControllerTest extends RestTestCase
         );
         $this->assertEmpty($client->getResults());
         $response = $client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $client = static::createRestClient();
         $client->request('GET', $response->headers->get('Location'));

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -83,10 +83,12 @@ class FileControllerTest extends RestTestCase
         $response = $client->getResponse();
         $this->assertEquals(201, $response->getStatusCode());
 
+        $fileLocation = $response->headers->get('Location');
+
         // update file contents to update mod date
         $client = static::createRestClient();
         $client->put(
-            $response->headers->get('Location'),
+            $fileLocation,
             $fixtureData,
             [],
             [],
@@ -98,7 +100,7 @@ class FileControllerTest extends RestTestCase
         $this->assertEquals(204, $response->getStatusCode());
 
         $client = static::createRestClient();
-        $client->request('GET', $response->headers->get('Location'));
+        $client->request('GET', $fileLocation);
         $data = $client->getResults();
 
         // check for valid format


### PR DESCRIPTION
Having Location redirect after a PUT request triggered some edge cases in [CORS](http://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0).

This makes updating files behave like updating metadata for the sake of replacing documents.