### PR TITLE
Generate swagger without relying on mongodb

### DIFF
--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -27,6 +27,7 @@
       <argument type="service" id="router"/>
       <argument>%graviton.document.type.extref.mapping%</argument>
       <argument>%graviton.document.field.names%</argument>
+      <argument>%locale%</argument>
     </service>
   </services>
 </container>

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -42,10 +42,16 @@ class SchemaUtils
      * @var array service mapping
      */
     private $extrefServiceMapping;
+
     /**
      * @var array [document class => [field name -> exposed name]]
      */
     private $documentFieldNames;
+
+    /**
+     * @var string
+     */
+    private $defaultLocale;
 
     /**
      * Constructor
@@ -54,17 +60,20 @@ class SchemaUtils
      * @param RouterInterface    $router               router
      * @param array              $extrefServiceMapping Extref service mapping
      * @param array              $documentFieldNames   Document field names
+     * @param string             $defaultLocale        Default Language
      */
     public function __construct(
         LanguageRepository $languageRepository,
         RouterInterface $router,
         array $extrefServiceMapping,
-        array $documentFieldNames
+        array $documentFieldNames,
+        $defaultLocale
     ) {
         $this->languageRepository = $languageRepository;
         $this->router = $router;
         $this->extrefServiceMapping = $extrefServiceMapping;
         $this->documentFieldNames = $documentFieldNames;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -90,10 +99,11 @@ class SchemaUtils
      *
      * @param string        $modelName name of mode to generate schema for
      * @param DocumentModel $model     model to generate schema for
+     * @param boolean       $online    if we are online and have access to mongodb during this build
      *
      * @return Schema
      */
-    public function getModelSchema($modelName, DocumentModel $model)
+    public function getModelSchema($modelName, DocumentModel $model, $online = true)
     {
         // build up schema data
         $schema = new Schema;
@@ -123,12 +133,18 @@ class SchemaUtils
             $this->documentFieldNames[$repo->getClassName()] :
             [];
 
-        $languages = array_map(
-            function (Language $language) {
-                return $language->getId();
-            },
-            $this->languageRepository->findAll()
-        );
+        if ($online) {
+            $languages = array_map(
+                function (Language $language) {
+                    return $language->getId();
+                },
+                $this->languageRepository->findAll()
+            );
+        } else {
+            $languages = [
+                $this->defaultLocale
+            ];
+        }
 
         foreach ($meta->getFieldNames() as $field) {
             // don't describe hidden fields
@@ -145,13 +161,13 @@ class SchemaUtils
 
             if ($meta->getTypeOfField($field) === 'many') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));
-                $property->setItems($this->getModelSchema($field, $propertyModel));
+                $property->setItems($this->getModelSchema($field, $propertyModel, $online));
                 $property->setType('array');
             }
 
             if ($meta->getTypeOfField($field) === 'one') {
                 $propertyModel = $model->manyPropertyModelForTarget($meta->getAssociationTargetClass($field));
-                $property = $this->getModelSchema($field, $propertyModel);
+                $property = $this->getModelSchema($field, $propertyModel, $online);
             }
 
             if (in_array($field, $translatableFields, true)) {

--- a/src/Graviton/SwaggerBundle/Service/Swagger.php
+++ b/src/Graviton/SwaggerBundle/Service/Swagger.php
@@ -94,7 +94,7 @@ class Swagger
 
                 $entityClassName = str_replace('\\', '', get_class($thisModel));
 
-                $schema = $this->schemaUtils->getModelSchema($entityClassName, $thisModel);
+                $schema = $this->schemaUtils->getModelSchema($entityClassName, $thisModel, false);
 
                 $ret['definitions'][$entityClassName] = json_decode(
                     $this->restUtils->serializeContent($schema),


### PR DESCRIPTION
This fixes us not being able to ``composer update && dev-cleanstart.sh`` in wrappers by making all the triggered commands work without access to a database.

It also fixes running ``docker-compose run --rm install`` by making a simple ``composer install`` possible without needing a running mongodb.

The change it introduces is that only the default locale ``en`` will be documented in swagger from here on out.

Schema endpoints (``/schema/*/item`` and ``/schema/*/collection``) are not affected.

 This doesn't fix the underlying issues I'm seeing in wrappers after a ``composer update`` that probably pertain to ``doctrine/*`` stuff.