### PR TITLE
Get rid of obsolete php-5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,10 @@ php:
 - hhvm
 - 5.6
 - 5.5
-- 5.4
 - 7.0
 matrix:
   allow_failures:
   - php: hhvm
-  - php: 5.4
   - php: 7.0
 script:
 - "./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "symfony/symfony": "~2.7",
         "doctrine/orm": "~2.4",
         "twig/extensions": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "de4afd3fc454ff9614619d0ad35f3ea4",
+    "hash": "8f6549dd9d79066c04d2754fee2c9f3b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -2646,7 +2646,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpGaufretteBundle/zipball/b6dbd93d1263f3f57d9c0b5e3b5935b281fcbd9c",
+                "url": "https://api.github.com/repos/KnpLabs/KnpGaufretteBundle/zipball/bf9652537f8458b105613db64fdbc7ea087256fc",
                 "reference": "b6dbd93d1263f3f57d9c0b5e3b5935b281fcbd9c",
                 "shasum": ""
             },
@@ -4039,12 +4039,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnkary/phpunit-speedtrap.git",
-                "reference": "ad70c60c6d77ddd51e6aca9fdf165538e43b0193"
+                "reference": "76a26f8a903a9434608cdad2b41c40cd134ea326"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/ad70c60c6d77ddd51e6aca9fdf165538e43b0193",
-                "reference": "ad70c60c6d77ddd51e6aca9fdf165538e43b0193",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/76a26f8a903a9434608cdad2b41c40cd134ea326",
+                "reference": "76a26f8a903a9434608cdad2b41c40cd134ea326",
                 "shasum": ""
             },
             "require": {
@@ -4081,7 +4081,7 @@
                 "profile",
                 "slow"
             ],
-            "time": "2015-03-21 19:00:39"
+            "time": "2015-09-13 19:01:00"
         },
         {
             "name": "lapistano/proxy-object",
@@ -5149,7 +5149,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.5"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
PHP-5.4 is EOL and does not get and more security updates. Hence we stop supporting it.