### PR TITLE
Make app.$ref in /core/config optional

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Config.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Config.json
@@ -29,6 +29,11 @@
                     "$ref": "http://localhost/core/app/admin"
                 },
                 "default": "stronghold"
+            },
+            {
+                "id": "global-settingWithoutApp",
+                "key": "settingWithoutApp",
+                "default": ""
             }
         ]
     },
@@ -57,7 +62,7 @@
                 "description": "Link to the application this configuration value relates to.",
                 "exposeAs": "$ref",
                 "collection": ["App"],
-                "required": true
+                "required": false
             },
             {
                 "name": "default",


### PR DESCRIPTION
We do have some global config that we want to add.

I'm fully aware that this now exposes the silly ``app: {}`` artefact everywhere. We'll just have to live with that for the time being...

Also, this is for [EVO-443](https://issue.swisscom.ch/browse/EVO-443)...