### PR TITLE
fix pagination, add X-Total-Count header

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -142,7 +142,9 @@ class AppControllerTest extends RestTestCase
             $response->headers->get('Link')
         );
 
-        // "page" override - rql before get
+        $this->assertSame('2', $response->headers->get('X-Total-Count'));
+
+        /*** pagination tests **/
         $client = static::createRestClient();
         $client->request('GET', '/core/app/?limit(1,1)');
         $this->assertEquals(1, count($client->getResults()));
@@ -154,11 +156,18 @@ class AppControllerTest extends RestTestCase
             $response->headers->get('Link')
         );
 
-        // we're passing page=1 and are on the last page, so next isn't set here
         $this->assertContains(
-            '<http://localhost/core/app/?limit(1%2C1)>; rel="last"',
+            '<http://localhost/core/app/?limit(1%2C0)>; rel="prev"',
             $response->headers->get('Link')
         );
+
+        // we're on the 'last' page - so 'last' should not be in in Link header
+        $this->assertNotContains(
+            'rel="last"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertSame('2', $response->headers->get('X-Total-Count'));
     }
 
     /**

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -68,7 +68,7 @@ class PagingLinkResponseListener
 
             $this->generateLinks(
                 $routeName,
-                $request->get('page', 1),
+                $request->attributes->get('page'),
                 $request->attributes->get('numPages'),
                 $request->attributes->get('perPage'),
                 $request,
@@ -77,6 +77,10 @@ class PagingLinkResponseListener
             $response->headers->set(
                 'Link',
                 (string) $this->linkHeader
+            );
+            $response->headers->set(
+                'X-Total-Count',
+                (string) $request->attributes->get('totalCount')
             );
         }
     }

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -121,6 +121,8 @@ class DocumentModel extends SchemaModel implements ModelInterface
         // define offset and limit
         if (!array_key_exists('skip', $queryBuilder->getQuery()->getQuery())) {
             $queryBuilder->skip($startAt);
+        } else {
+            $startAt = (int) $queryBuilder->getQuery()->getQuery()['skip'];
         }
 
         if (!array_key_exists('limit', $queryBuilder->getQuery()->getQuery())) {
@@ -144,10 +146,13 @@ class DocumentModel extends SchemaModel implements ModelInterface
 
         $totalCount = $query->count();
         $numPages = (int) ceil($totalCount / $numberPerPage);
+        $page = (int) ceil($startAt / $numberPerPage) + 1;
         if ($numPages > 1) {
             $request->attributes->set('paging', true);
+            $request->attributes->set('page', $page);
             $request->attributes->set('numPages', $numPages);
             $request->attributes->set('perPage', $numberPerPage);
+            $request->attributes->set('totalCount', $totalCount);
         }
 
         return $records;

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -177,6 +177,9 @@
             <call method="addHeader">
                 <argument>Location</argument>
             </call>
+            <call method="addHeader">
+                <argument>X-Total-Count</argument>
+            </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 


### PR DESCRIPTION
The `Link` header contents regarding pagination are currently wrong
* It still checked for the GET param `page` to determine the page - this leads to correct headers, but the `prev` part is missing and `last` is rendered on the last page (as it's always assuming we are on page `1`).

I reflected the new correct behavior in `AppControllerTest` - it was not checked for the `prev` part there..

Additionally, I added a new header `X-Total-Count` returning the total number of records. Clients asked for this and it doesn't hurt to add it (the total count from mongo was already fetched to determine the number of pages). I got the name of the header from [here](http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#pagination), a [google search](https://www.google.ch/search?q=X-Total-Count) indicates that this header name is used in the world alreay for that purpose ;-)