### PR TITLE
Use setMethods() instead of '_method' requirement

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing">
-  <route id="graviton.core.static.main.all" path="/">
+  <route id="graviton.core.static.main.all" path="/" methods="GET">
     <default key="_controller">graviton.core.controller.main:indexAction</default>
-    <requirement key="_method">GET</requirement>
   </route>
-  <route id="graviton.core.static.main.options" path="/">
+  <route id="graviton.core.static.main.options" path="/" methods="OPTIONS">
     <default key="_controller">graviton.core.controller.main:optionsAction</default>
-    <requirement key="_method">OPTIONS</requirement>
   </route>
 </routes>

--- a/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
+++ b/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
@@ -50,9 +50,7 @@ class ActionUtils
             '_format' => '~',
         );
 
-        $requirements = array(
-            '_method' => $method,
-        );
+        $requirements = [];
 
         foreach ($parameters as $paramName => $paramPattern) {
             $pattern .= '{' . $paramName . '}';
@@ -60,6 +58,8 @@ class ActionUtils
         }
 
         $route = new Route($pattern, $defaults, $requirements);
+
+        $route->setMethods($method);
 
         return $route;
     }
@@ -188,11 +188,8 @@ class ActionUtils
             '_format' => '~',
         );
 
-        $requirements = array(
-            '_method' => $method,
-        );
-
-        $route = new Route($pattern, $defaults, $requirements);
+        $route = new Route($pattern, $defaults, []);
+        $route->setMethods($method);
 
         return $route;
     }

--- a/src/Graviton/RestBundle/Service/RestUtils.php
+++ b/src/Graviton/RestBundle/Service/RestUtils.php
@@ -164,7 +164,7 @@ final class RestUtils implements RestUtilsInterface
             $router->getRouteCollection()
                    ->all(),
             function ($route) {
-                if ($route->getRequirement('_method') != 'OPTIONS') {
+                if (!in_array('OPTIONS', $route->getMethods())) {
                     return false;
                 }
                 // ignore all schema routes


### PR DESCRIPTION
The _method thingy was deprecated many moons ago as per [symfony/symfony/UPGRADE-3.0.md](https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#routing).

This should help overall performance due to much less log entries getting written... There are still heaps remaining though.