### PR TITLE
Allow configuration of composer command path

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -39,3 +39,6 @@ parameters:
 
     # pagination defaults
     graviton.rest.pagination.limit: 10
+    
+    # how to call composer on this machine
+    graviton.composer.cmd: composer

--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,8 @@
                     "graviton.mongodb.default.server.uri": "MONGODB_URI",
                     "graviton.errbit.api_key": "ERRBIT_API_KEY",
                     "graviton.errbit.host": "ERRBIT_HOST",
-                    "graviton.rest.pagination.limit": "PAGINATION_LIMIT"
+                    "graviton.rest.pagination.limit": "PAGINATION_LIMIT",
+                    "graviton.composer.cmd": "COMPOSER_CMD"
                 }
             },
             {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "664e5cac5ec4617552dd830e66cd6e9d",
+    "hash": "0a1aa71056aa765481165de0c82f18ae",
     "packages": [
         {
             "name": "aws/aws-sdk-php",

--- a/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
+++ b/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
@@ -37,6 +37,7 @@ class VersionCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $this->rootDir = $container->getParameter('kernel.root_dir');
+        $this->composerCmd = $container->getParameter('graviton.composer.cmd');
         $this->config = $this->getVersionConfig();
         $container->setParameter(
             'graviton.core.version.data',
@@ -70,7 +71,7 @@ class VersionCompilerPass implements CompilerPassInterface
      */
     private function getContextVersion()
     {
-        $output = $this->runCommandInContext('composer show -s --no-ansi');
+        $output = $this->runCommandInContext($this->composerCmd . ' show -s --no-ansi');
         $lines = explode(PHP_EOL, $output);
         $wrapper = array();
         foreach ($lines as $line) {
@@ -92,7 +93,7 @@ class VersionCompilerPass implements CompilerPassInterface
      */
     private function getInstalledPackagesVersion($versions)
     {
-        $output = $this->runCommandInContext('composer show --installed');
+        $output = $this->runCommandInContext($this->composerCmd . ' show --installed');
 
         $packages = explode(PHP_EOL, $output);
         //last index is always empty

--- a/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
+++ b/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
@@ -71,7 +71,7 @@ class VersionCompilerPass implements CompilerPassInterface
      */
     private function getContextVersion()
     {
-        $output = $this->runCommandInContext($this->composerCmd . ' show -s --no-ansi');
+        $output = $this->runComposerInContext('show -s --no-ansi');
         $lines = explode(PHP_EOL, $output);
         $wrapper = array();
         foreach ($lines as $line) {
@@ -93,7 +93,7 @@ class VersionCompilerPass implements CompilerPassInterface
      */
     private function getInstalledPackagesVersion($versions)
     {
-        $output = $this->runCommandInContext($this->composerCmd . ' show --installed');
+        $output = $this->runComposerInContext('show --installed');
 
         $packages = explode(PHP_EOL, $output);
         //last index is always empty
@@ -110,18 +110,20 @@ class VersionCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * runs a bash/shell command depending on the context
+     * runs a composer command depending on the context
      *
-     * @param string $command shell/bash command
+     * @param string $command composer args
      * @return string
      */
-    private function runCommandInContext($command)
+    private function runComposerInContext($command)
     {
         if ($this->isWrapperContext()) {
-            $process = new Process('cd ' . escapeshellarg($this->rootDir) . '/../../../../  && ' . $command);
+            $contextDir = escapeshellarg($this->rootDir).'/../../../../';
         } else {
-            $process = new Process('cd ' . escapeshellarg($this->rootDir) . '/../ && ' . $command);
+            $contextDir = escapeshellarg($this->rootDir).'/../';
         }
+
+        $process = new Process('cd '.$contextDir.' && '.escapeshellarg($this->composerCmd).' '.$command);
 
         try {
             $process->mustRun();


### PR DESCRIPTION
We need to override this on cloudfoundry so it uses the buildpacks composer installation by setting it to `php /tmp/staged/app/php/bin/composer.phar`.

This should make graviton deploy again after #260 broke it, but I'm having a hard time testing it due to most likely unrelated errors when pushing to my own instances :/