### PR TITLE
Fix escaping of args and cmd

### DIFF
--- a/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
+++ b/src/Graviton/CoreBundle/Compiler/VersionCompilerPass.php
@@ -118,12 +118,12 @@ class VersionCompilerPass implements CompilerPassInterface
     private function runComposerInContext($command)
     {
         if ($this->isWrapperContext()) {
-            $contextDir = escapeshellarg($this->rootDir).'/../../../../';
+            $contextDir = escapeshellarg($this->rootDir.'/../../../../');
         } else {
-            $contextDir = escapeshellarg($this->rootDir).'/../';
+            $contextDir = escapeshellarg($this->rootDir.'/../');
         }
 
-        $process = new Process('cd '.$contextDir.' && '.escapeshellarg($this->composerCmd).' '.$command);
+        $process = new Process('cd '.$contextDir.' && '.escapeshellcmd($this->composerCmd).' '.$command);
 
         try {
             $process->mustRun();


### PR DESCRIPTION
Given a multi part `composerCmd` we were calling `cd '/path/to/root'/../ && 'php composer.phar' show ...`. But we need to have the multi-part `composerCmd` with a bit less escaping if we want this not to bomb.