### PR TITLE
Dynamic key support in schemas and output

### DIFF
--- a/src/Graviton/DocumentBundle/Listener/ExtReferenceListener.php
+++ b/src/Graviton/DocumentBundle/Listener/ExtReferenceListener.php
@@ -131,6 +131,11 @@ class ExtReferenceListener
 
                 if (isset($item->$topLevel)) {
                     $item->$topLevel = $this->mapField($item->$topLevel, $subField);
+                } else {
+                    // map available things since we found nothing on $topLevel and there might be some refs deeper down
+                    foreach (get_object_vars($item) as $subLevel => $subItem) {
+                        $item->$subLevel = $this->mapField($subItem, $subField);
+                    }
                 }
             } elseif (isset($item->$field)) {
                 $item->$field = $this->convertToUrl($item->$field);

--- a/src/Graviton/DocumentBundle/Listener/ExtReferenceListener.php
+++ b/src/Graviton/DocumentBundle/Listener/ExtReferenceListener.php
@@ -133,7 +133,7 @@ class ExtReferenceListener
                     $item->$topLevel = $this->mapField($item->$topLevel, $subField);
                 } else {
                     // map available things since we found nothing on $topLevel and there might be some refs deeper down
-                    foreach (get_object_vars($item) as $subLevel => $subItem) {
+                    foreach ($item as $subLevel => $subItem) {
                         $item->$subLevel = $this->mapField($subItem, $subField);
                     }
                 }

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
@@ -101,6 +101,7 @@ class JsonDefinitionField implements DefinitionElementInterface
             'exposedName'       => $this->getExposedName(),
             'doctrineType'      => $this->getTypeDoctrine(),
             'serializerType'    => $this->getTypeSerializer(),
+            'xDynamicKey'       => $this->getXDynamicKey(),
             'relType'           => null,
             'isClassType'       => false,
             'constraints'       => array_map(
@@ -161,6 +162,17 @@ class JsonDefinitionField implements DefinitionElementInterface
 
         // our fallback default
         return self::$serializerTypeMap[self::TYPE_STRING];
+    }
+
+    /**
+     * @return array|void
+     */
+    public function getXDynamicKey()
+    {
+        $key = $this->definition->getXDynamicKey();
+        if ($key) {
+            return $key;
+        }
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
@@ -165,7 +165,7 @@ class JsonDefinitionField implements DefinitionElementInterface
     }
 
     /**
-     * @return array|void
+     * @return XDynamicKey|void
      */
     public function getXDynamicKey()
     {

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
@@ -1,6 +1,8 @@
 <?php
 namespace Graviton\GeneratorBundle\Definition;
 
+use Graviton\GeneratorBundle\Definition\Schema\XDynamicKey;
+
 /**
  * A single field as specified in the json definition
  *
@@ -170,7 +172,7 @@ class JsonDefinitionField implements DefinitionElementInterface
     public function getXDynamicKey()
     {
         $key = $this->definition->getXDynamicKey();
-        if ($key) {
+        if ($key instanceof XDynamicKey) {
             return $key;
         }
     }

--- a/src/Graviton/GeneratorBundle/Definition/Schema/Field.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/Field.php
@@ -4,6 +4,8 @@
  */
 namespace Graviton\GeneratorBundle\Definition\Schema;
 
+use Graviton\GeneratorBundle\Definition\Schema\XDynamicKey;
+
 /**
  * JSON definition "target.fields"
  *
@@ -58,6 +60,11 @@ class Field
      * @var array
      */
     private $collection = [];
+
+    /**
+     * @var XDynamicKey
+     */
+    private $xDynamicKey;
 
     /**
      * @return string
@@ -254,6 +261,24 @@ class Field
     public function setCollection(array $collection)
     {
         $this->collection = $collection;
+        return $this;
+    }
+
+    /**
+     * @return XDynamicKey
+     */
+    public function getXDynamicKey()
+    {
+        return $this->xDynamicKey;
+    }
+
+    /**
+     * @param XDynamicKey $xDynamicKey x-dynamic-key field value
+     * @return $this
+     */
+    public function setXDynamicKey(XDynamicKey $xDynamicKey)
+    {
+        $this->xDynamicKey = $xDynamicKey;
         return $this;
     }
 }

--- a/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
@@ -24,7 +24,7 @@ class XDynamicKey
     /**
      * @var string
      */
-    private $refField = '$ref';
+    private $refMethod = 'getRef';
 
     /**
      * @return string
@@ -65,18 +65,18 @@ class XDynamicKey
     /**
      * @return string
      */
-    public function getRefField()
+    public function getRefMethod()
     {
-        return $this->refField;
+        return $this->refMethod;
     }
 
     /**
-     * @param string $refField reference the dynamic field is resolved through
+     * @param string $refMethod reference the dynamic field is resolved through
      * @return $this
      */
-    public function setRefField($refField)
+    public function setRefMethod($refMethod)
     {
-        $this->refField = $refField;
+        $this->refMethod = $refMethod;
         return $this;
     }
 }

--- a/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Part of JSON definition: "target.fields.x-dynamic-key"
+ */
+namespace Graviton\GeneratorBundle\Definition\Schema;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class XDynamicKey
+{
+    /**
+     * @var string
+     */
+    private $documentId;
+
+    /**
+     * @var string
+     */
+    private $repositoryMethod;
+
+    /**
+     * @var string
+     */
+    private $recordGetter;
+
+    /**
+     * @return string
+     */
+    public function getDocumentId()
+    {
+        return $this->documentId;
+    }
+
+    /**
+     * @param string $documentId document-id field
+     * @return $this
+     */
+    public function setDocumentId($documentId)
+    {
+        $this->documentId = $documentId;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepositoryMethod()
+    {
+        return $this->repositoryMethod;
+    }
+
+    /**
+     * @param string $repositoryMethod repository-method field
+     * @return $this
+     */
+    public function setRepositoryMethod($repositoryMethod)
+    {
+        $this->repositoryMethod = $repositoryMethod;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecordGetter()
+    {
+        return $this->recordGetter;
+    }
+
+    /**
+     * @param string $recordGetter record-getter field
+     * @return $this
+     */
+    public function setRecordGetter($recordGetter)
+    {
+        $this->recordGetter = $recordGetter;
+        return $this;
+    }
+}

--- a/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/XDynamicKey.php
@@ -24,7 +24,7 @@ class XDynamicKey
     /**
      * @var string
      */
-    private $recordGetter;
+    private $refField = '$ref';
 
     /**
      * @return string
@@ -65,18 +65,18 @@ class XDynamicKey
     /**
      * @return string
      */
-    public function getRecordGetter()
+    public function getRefField()
     {
-        return $this->recordGetter;
+        return $this->refField;
     }
 
     /**
-     * @param string $recordGetter record-getter field
+     * @param string $refField reference the dynamic field is resolved through
      * @return $this
      */
-    public function setRecordGetter($recordGetter)
+    public function setRefField($refField)
     {
-        $this->recordGetter = $recordGetter;
+        $this->refField = $refField;
         return $this;
     }
 }

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Field.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Field.xml
@@ -34,5 +34,8 @@
         <property name="collection"
                   type="array&lt;string&gt;"
                   serialized-name="collection"/>
+        <property name="xDynamicKey"
+                  type="Graviton\GeneratorBundle\Definition\Schema\XDynamicKey"
+                  serialized-name="x-dynamic-key"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
@@ -7,8 +7,8 @@
         <property name="repositoryMethod"
                   type="string"
                   serialized-name="repository-method"/>
-        <property name="recordGetter"
+        <property name="refField"
                   type="string"
-                  serialized-name="record-getter"/>
+                  serialized-name="ref-field"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="Graviton\GeneratorBundle\Definition\Schema\XDynamicKey">
+        <property name="documentId"
+                  type="string"
+                  serialized-name="document-id"/>
+        <property name="repositoryMethod"
+                  type="string"
+                  serialized-name="repository-method"/>
+        <property name="recordGetter"
+                  type="string"
+                  serialized-name="record-getter"/>
+    </class>
+</serializer>

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.XDynamicKey.xml
@@ -7,8 +7,8 @@
         <property name="repositoryMethod"
                   type="string"
                   serialized-name="repository-method"/>
-        <property name="refField"
+        <property name="refMethod"
                   type="string"
-                  serialized-name="ref-field"/>
+                  serialized-name="ref-method"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
@@ -162,7 +162,15 @@ class {{ document }} implements TranslatableDocumentInterface{% if isrecordOrigi
     public function get{{ field.fieldName|capitalize }}()
 {% endif %}
     {
+{% if field.xDynamicKey is defined and field.xDynamicKey != null %}
+        $records = [];
+        foreach ($this->{{ field.fieldName }} as $record) {
+            $records[$record->{{ field.xDynamicKey.refMethod }}()->{'$id'}] = $record;
+        }
+        return $records;
+{% else %}
         return $this->{{ field.fieldName }};
+{% endif %}
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.php.twig
@@ -165,7 +165,8 @@ class {{ document }} implements TranslatableDocumentInterface{% if isrecordOrigi
 {% if field.xDynamicKey is defined and field.xDynamicKey != null %}
         $records = [];
         foreach ($this->{{ field.fieldName }} as $record) {
-            $records[$record->{{ field.xDynamicKey.refMethod }}()->{'$id'}] = $record;
+            $ref = json_decode($record->{{ field.xDynamicKey.refMethod }}());
+            $records[$ref->{'$id'}] = $record;
         }
         return $records;
 {% else %}

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
@@ -29,7 +29,7 @@
       "x-dynamic-key": {
           "document-id": "{{ field.xDynamicKey.documentId }}",
           "repository-method": "{{ field.xDynamicKey.repositoryMethod }}",
-          "record-getter": "{{ field.xDynamicKey.recordGetter }}"
+          "ref-field": "{{ field.xDynamicKey.refField }}"
       },
 {% endif %}
 

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
@@ -25,7 +25,15 @@
       "readOnly": {{ field.readOnly|json_encode() }},
 {% endif %}
 
-{% if field.description is defined %}
+{% if field.xDynamicKey is defined and field.xDynamicKey != null %}
+      "x-dynamic-key": {
+          "document-id": "{{ field.xDynamicKey.documentId }}",
+          "repository-method": "{{ field.xDynamicKey.repositoryMethod }}",
+          "record-getter": "{{ field.xDynamicKey.recordGetter }}"
+      },
+{% endif %}
+
+{% if field.description is defined and field.description != '' %}
       "description": {{ field.description|json_encode() }}
 {% else %}
       "description": "@todo replace me"

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
@@ -29,7 +29,7 @@
       "x-dynamic-key": {
           "document-id": "{{ field.xDynamicKey.documentId }}",
           "repository-method": "{{ field.xDynamicKey.repositoryMethod }}",
-          "ref-field": "{{ field.xDynamicKey.refField }}"
+          "ref-method": "{{ field.xDynamicKey.refMethod }}"
       },
 {% endif %}
 

--- a/src/Graviton/GeneratorBundle/Tests/Definition/BaseJsonDefinitionFieldTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/BaseJsonDefinitionFieldTest.php
@@ -76,6 +76,7 @@ abstract class BaseJsonDefinitionFieldTest extends \PHPUnit_Framework_TestCase
             'required'          => $field->getRequired(),
             'translatable'      => $field->getTranslatable(),
             'collection'        => $field->getCollection(),
+            'xDynamicKey'       => null,
             'constraints'       => array_map(
                 function (Schema\Constraint $constraint) {
                     return [

--- a/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionElementTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionElementTest.php
@@ -114,7 +114,8 @@ class DefinitionElementTest extends \PHPUnit_Framework_TestCase
             'relType' => null,
             'isClassType' => false,
             'constraints' => array(),
-            'collection' => array()
+            'collection' => array(),
+            'xDynamicKey' => null,
         );
 
         $this->assertEquals($def, $field->getDefAsArray());

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
@@ -164,6 +164,42 @@ class JsonDefinitionFieldTest extends BaseJsonDefinitionFieldTest
                     'serializerType'    => $field->getTypeSerializer(),
                     'relType'           => null,
                     'isClassType'       => false,
+                    'xDynamicKey'       => null,
+                ]
+            ),
+            $field->getDefAsArray()
+        );
+    }
+
+    /**
+     * Test JsonDefinitionField::getXDynamicKey()
+     *
+     * @return void
+     */
+    public function testGetXDynamicKey()
+    {
+        $key = (new Schema\XDynamicKey())
+            ->setDocumentId(__CLASS__)
+            ->setRepositoryMethod(__LINE__)
+            ->setRecordGetter(__FILE__);
+
+        $definition = (new Schema\Field())
+            ->setXDynamicKey($key);
+
+        $field = new JsonDefinitionField('name', $definition);
+
+        $this->assertEquals(
+            array_replace(
+                $this->getBaseDefAsArray($definition),
+                [
+                    'name'              => $field->getName(),
+                    'type'              => $field->getType(),
+                    'exposedName'       => $definition->getExposeAs(),
+                    'doctrineType'      => $field->getTypeDoctrine(),
+                    'serializerType'    => $field->getTypeSerializer(),
+                    'relType'           => null,
+                    'isClassType'       => false,
+                    'xDynamicKey'       => $key,
                 ]
             ),
             $field->getDefAsArray()

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
@@ -181,7 +181,7 @@ class JsonDefinitionFieldTest extends BaseJsonDefinitionFieldTest
         $key = (new Schema\XDynamicKey())
             ->setDocumentId(__CLASS__)
             ->setRepositoryMethod(__LINE__)
-            ->setRefField(__FILE__);
+            ->setRefMethod(__FILE__);
 
         $definition = (new Schema\Field())
             ->setXDynamicKey($key);

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
@@ -181,7 +181,7 @@ class JsonDefinitionFieldTest extends BaseJsonDefinitionFieldTest
         $key = (new Schema\XDynamicKey())
             ->setDocumentId(__CLASS__)
             ->setRepositoryMethod(__LINE__)
-            ->setRecordGetter(__FILE__);
+            ->setRefField(__FILE__);
 
         $definition = (new Schema\Field())
             ->setXDynamicKey($key);

--- a/src/Graviton/SchemaBundle/Document/Schema.php
+++ b/src/Graviton/SchemaBundle/Document/Schema.php
@@ -45,6 +45,11 @@ class Schema
     protected $properties = array();
 
     /**
+     * @var Schema
+     */
+    protected $additionalProperties;
+
+    /**
      * @var string[]
      */
     protected $required = array();
@@ -269,6 +274,28 @@ class Schema
         }
 
         return $properties;
+    }
+
+    /**
+     * set additionalProperties on schema
+     *
+     * @param Schema $schema schema to use for additionalProperties type
+     *
+     * @return void
+     */
+    public function setAdditionalProperties(Schema $schema)
+    {
+        $this->additionalProperties = $schema;
+    }
+
+    /**
+     * get addtionalProperties for schema
+     *
+     * @return Schema
+     */
+    public function getAdditionalProperties()
+    {
+        return $this->additionalProperties;
     }
 
     /**

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -167,6 +167,30 @@ class SchemaModel implements ContainerAwareInterface
     }
 
     /**
+     * tell us if a model what to be exposed using a key as field
+     *
+     * @param string $field field that we check for dynamic-key spec
+     *
+     * @return boolean
+     */
+    public function hasDynamicKey($field)
+    {
+        return $this->getSchemaField($field, 'x-dynamic-key', false) !== false;
+    }
+
+    /**
+     * Get field used for setting stringy key value
+     *
+     * @param string $field field that we get dynamic-key spec from
+     *
+     * @return object
+     */
+    public function getDynamicKeySpec($field)
+    {
+        return $this->getSchemaField($field, 'x-dynamic-key');
+    }
+
+    /**
      * get schema field value
      *
      * @param string $field         field name

--- a/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
+++ b/src/Graviton/SchemaBundle/Resources/config/schema/SchemaModel.json
@@ -36,6 +36,11 @@
       },
       "description": "Array of properties"
     },
+    "additionalProperties": {
+      "title": "Additional Properties",
+      "type": "object",
+      "description": "Definition of additional properties"
+    },
     "required": {
       "title": "Required",
       "type": "array",

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -13,6 +13,7 @@
     <property name="properties" accessor-getter="getProperties" expose="true">
       <type><![CDATA[array<string, Graviton\SchemaBundle\Document\Schema>]]></type>
     </property>
+    <property name="additionalProperties" accessor-getter="getAdditionalProperties" expose="true" type="Graviton\SchemaBundle\Document\Schema"/>
     <property name="required" accessor-getter="getRequired" accessor-setter="setRequired" expose="true">
       <type><![CDATA[array<string>]]></type>
     </property>

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameter key="graviton.schema.listener.canonicalschemaresponse.class">Graviton\SchemaBundle\Listener\CanonicalSchemaLinkResponseListener</parameter>
     <parameter key="graviton.schema.model.schemamodel.class">Graviton\SchemaBundle\Model\SchemaModel</parameter>
     <parameter key="graviton.schema.service.schemautils.class">Graviton\SchemaBundle\SchemaUtils</parameter>
+    <parameter key="graviton.schema.service.repositoryfactory.class">Graviton\SchemaBundle\Service\RepositoryFactory</parameter>
   </parameters>
   <services>
     <service id="graviton.schema.listener.schematyperesponse" class="%graviton.schema.listener.schematyperesponse.class%">
@@ -22,7 +23,11 @@
         <argument type="service" id="service_container"></argument>
       </call>
     </service>
+    <service id="graviton.schema.service.repositoryfactory" class="%graviton.schema.service.repositoryfactory.class%">
+      <argument type="service" id="doctrine_mongodb"/>
+    </service>
     <service id="graviton.schema.utils" class="%graviton.schema.service.schemautils.class%">
+      <argument type="service" id="graviton.schema.service.repositoryfactory"/>
       <argument type="service" id="graviton.i18n.repository.language"/>
       <argument type="service" id="router"/>
       <argument>%graviton.document.type.extref.mapping%</argument>

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -184,11 +184,10 @@ class SchemaUtils
 
                         $repositoryMethod = $dynamicKeySpec->{'repository-method'};
                         $records = $dynamicRepository->$repositoryMethod();
-                        $recordGetter = $dynamicKeySpec->{'record-getter'};
 
                         $dynamicProperties = array_map(
-                            function ($record) use ($recordGetter) {
-                                return $record->$recordGetter();
+                            function ($record) {
+                                return $record->getId();
                             },
                             $records
                         );

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -10,6 +10,7 @@ use Graviton\I18nBundle\Document\Language;
 use Graviton\I18nBundle\Repository\LanguageRepository;
 use Graviton\RestBundle\Model\DocumentModel;
 use Graviton\SchemaBundle\Document\Schema;
+use Graviton\SchemaBundle\Service\RepositoryFactory;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -54,8 +55,14 @@ class SchemaUtils
     private $defaultLocale;
 
     /**
+     * @var RepositoryFactory
+     */
+    private $repositoryFactory;
+
+    /**
      * Constructor
      *
+     * @param RepositoryFactory  $repositoryFactory    Create repos from model class names
      * @param LanguageRepository $languageRepository   repository
      * @param RouterInterface    $router               router
      * @param array              $extrefServiceMapping Extref service mapping
@@ -63,12 +70,14 @@ class SchemaUtils
      * @param string             $defaultLocale        Default Language
      */
     public function __construct(
+        RepositoryFactory $repositoryFactory,
         LanguageRepository $languageRepository,
         RouterInterface $router,
         array $extrefServiceMapping,
         array $documentFieldNames,
         $defaultLocale
     ) {
+        $this->repositoryFactory = $repositoryFactory;
         $this->languageRepository = $languageRepository;
         $this->router = $router;
         $this->extrefServiceMapping = $extrefServiceMapping;

--- a/src/Graviton/SchemaBundle/Service/RepositoryFactory.php
+++ b/src/Graviton/SchemaBundle/Service/RepositoryFactory.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * get a repository instance for a given class
+ */
+
+namespace Graviton\SchemaBundle\Service;
+
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RepositoryFactory
+{
+    /**
+     * @var ManagerRegistry
+     */
+    private $managerRegistry;
+
+    /**
+     * @param ManagerRegistry $managerRegistry registry used to fetch a repository
+     */
+    public function __construct(
+        ManagerRegistry $managerRegistry
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+    /**
+     * get a repository class for a given class name
+     *
+     * @param string $documentId class to instanciate
+     *
+     * @return \Doctrine\Common\Persistence\ObjectManager
+     */
+    public function get($documentId)
+    {
+        return $this->managerRegistry
+            ->getRepository($documentId);
+    }
+}

--- a/src/Graviton/SchemaBundle/Tests/Service/RepositoryFactoryTest.php
+++ b/src/Graviton/SchemaBundle/Tests/Service/RepositoryFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * validate RepositoryFactory
+ */
+
+namespace Graviton\SchemaBundle\Tests\Service;
+
+use Graviton\SchemaBundle\Service\RepositoryFactory;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     */
+    public function testGetMethod()
+    {
+        $managerRegistryMock = $this
+            ->getMockBuilder('Doctrine\Bundle\MongoDBBundle\ManagerRegistry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $managerRegistryMock
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with('BundleName:Document');
+
+        $sut = new RepositoryFactory(
+            $managerRegistryMock
+        );
+
+        $sut->get('BundleName:Document');
+    }
+}


### PR DESCRIPTION
This make it able to express that we need to expose an array as an object while using parts of the object as key. This takes part of schema and service output, making such stuff writable still needs taking care of.

Given the following (simplified) field definition:

```js
{
  "name": "field",
  "type": "class:AcmeBundle\\Document\\Field",
  "x-dynamic-key": {
    "document-id": "GravitonDynModuleBundle:Module",
    "repository-method": "findAll",
    "ref-method": "getRef"
  }
}
```

The schema it generates should contain a property for every record id from the result set of `GravitonDynModuleBundle:Module::findAll`.

The swagger-schema shall contain an `additionalProperties` property allowing any id to be used.

It should generate a `Document` class that returns the value of `field` as an associative array based on the id of the MongoDBRef in the `getRef` entry of `AcmeBundle\Document\Field`. It is assumed that the method will return an unprocessed `extref` entry.

Most of this PR is actually only extending the json-definition format to express the above. Since this mostly generates schema info for now, the actual changes to the non-schema parts of the runtime are rather small.

I already have a heap of follow-up stories prepared on this, but need to get this done till the end of the sprint. Most of those stories will pertain to making `x-dynamic-key` fields writable over REST. It looks like some refactoring will be needed to get that up and running which is why this code does not take care of edge cases as much as it could.

Since this has heaps of related PRs to it I'll try and list some here (sorry about some of them being on our internal repos):
* https://github.com/libgraviton/json-schema/pull/4
* [grv/graviton-service-bundle-financing#54](https://git.swisscom.ch/projects/GRV/repos/graviton-service-bundle-financing/pull-requests/54/overview)
* [grv/evoja-checklist-bundle@develop](https://git.swisscom.ch/projects/GRV/repos/graviton-evojachecklistbundle/browse)

If you want to have a go at this you will find a preview on the [`feature/EVO-705-preview`](https://git.swisscom.ch/projects/GRV) branch of our internal wrapper. Again, sorry for linking to closed stuff...

Since there are some customer names in the repos I wasn't able to link to all of them. Please refer to [EVO-705](https://issue.swisscom.ch/browse/EVO-705) for links to additional pull-requests pertaining to this.