### PR TITLE
Configure COMPOSER_CMD for cf push

### DIFF
--- a/app/config/deploy.yml.dist
+++ b/app/config/deploy.yml.dist
@@ -11,4 +11,4 @@ deploy-scripts:
   cf_services:
     mongodb: advanced
     atmoss3: free
-  cf_environment_vars: { "ERRBIT_API_KEY": null, "ERRBIT_HOST": "errbit.nova.scapp.io" }
+  cf_environment_vars: { "ERRBIT_API_KEY": null, "ERRBIT_HOST": "errbit.nova.scapp.io", "COMPOSER_CMD": "php /tmp/staged/app/php/bin/composer.phar" }


### PR DESCRIPTION
Short term fix for local graviton deploys (this was already in the cloud by way of jenkins).

Long term we should support deactivating the rewriting of `versions.yml` with `COMPOSER_CMD=false` or something.