### PR TITLE
Allow defining of mongo db collection a service maps to

### DIFF
--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
@@ -1,6 +1,8 @@
 <?php
 namespace Graviton\GeneratorBundle\Definition;
 
+use Graviton\GeneratorBundle\Definition\Schema\Service;
+
 /**
  * This class represents the json file that defines the structure
  * of a mongo collection that exists and serves as a base to generate
@@ -424,5 +426,21 @@ class JsonDefinition
         }
 
         return $retVal;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceCollection()
+    {
+        $collectionName = $this->getId();
+
+        if ($this->def->getService() instanceof Service
+            && $this->def->getService()->getCollectionName()) {
+
+            $collectionName = $this->def->getService()->getCollectionName();
+        }
+
+        return $collectionName;
     }
 }

--- a/src/Graviton/GeneratorBundle/Definition/Schema/Service.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/Service.php
@@ -45,6 +45,10 @@ class Service
      * @var array[]
      */
     private $fixtures = [];
+    /**
+     * @var string
+     */
+    private $collectionName;
 
     /**
      * @return string
@@ -188,6 +192,24 @@ class Service
     public function setFixtures(array $fixtures)
     {
         $this->fixtures = $fixtures;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCollectionName()
+    {
+        return $this->collectionName;
+    }
+
+    /**
+     * @param string $collectionName name of colleciton
+     * @return $this
+     */
+    public function setCollectionName($collectionName)
+    {
+        $this->collectionName = $collectionName;
         return $this;
     }
 }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -165,6 +165,7 @@ class ResourceGenerator extends AbstractGenerator
             ->setParameter('basename', $basename)
             ->setParameter('isrecordOriginFlagSet', $this->json->isRecordOriginFlagSet())
             ->setParameter('recordOriginModifiable', $this->json->isRecordOriginModifiable())
+            ->setParameter('collection', $this->json->getServiceCollection())
             ->getParameters();
 
         $this->generateDocument($parameters, $dir, $document, $withRepository);

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Service.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Service.xml
@@ -25,5 +25,8 @@
         <property name="fixtures"
                   type="array&lt;ArrayObject&gt;"
                   serialized-name="fixtures"/>
+        <property name="collectionName"
+                  type="string"
+                  serialized-name="collectionName"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -10,7 +10,7 @@
         {% set docType = "document" %}
     {%  endif %}
 
-  <{{ docType }} name="{{ base }}Document\{{ document }}" repository-class="{{ base }}Repository\{{ document}}Repository">
+  <{{ docType }} name="{{ base }}Document\{{ document }}" repository-class="{{ base }}Repository\{{ document}}Repository" collection="{{ collection }}">
 
   {% if idField is defined %}
       <field fieldName="id" type="{{ idField.doctrineType }}" id="true" strategy="UUID"/>


### PR DESCRIPTION
This allows us to define what collection a service takes its data from. This can be used if the same data need to be presented differently depending on the endpoint.

I plan on using it to keep an editable version of a service containing some dynamic keys available at a different path. While it won't be used in that way as soon as dynamic keys are writable I still think this might have it's merits later on.

It can also be used if we want to reference something from an existing collection in a readonly service so there's that as well.

Look no further than [here](https://git.swisscom.ch/projects/GRV/repos/graviton-evojachecklistbundle/pull-requests/1/overview) for where I want to use this (and while you're there, that one would like to get merged as well :pray:).