### PR TITLE
directory correction due to dockerize issue

### DIFF
--- a/src/Graviton/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Graviton/CoreBundle/Composer/ScriptHandler.php
@@ -29,7 +29,7 @@ class ScriptHandler extends ScriptHandlerBase
      */
     public static function generateVersionYml(CommandEvent $event)
     {
-        $baseDir = __DIR__.'/../../../..';
+        $baseDir = __DIR__;
         $rootDir = $baseDir.'/app';
 
         if (self::hasComposerCommandInEnvVars()) {


### PR DESCRIPTION
The path concat results in a string as follows:
"vendor/graviton/graviton/src/Graviton/CoreBundle/Composer/../../../../app/../../../../app/config/version_service.yml"
The wrong resolved real path is:
"app/config/version_service.yml"
The correct resolved real path must be:
"vendor/graviton/graviton/app/config/version_service.yml"

