### PR TITLE
fix correct _self link header part when request exceeds defaut pagelimit and no rql has been given..

### DIFF
--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -125,10 +125,14 @@ class SelfLinkResponseListener
         }
 
         if ($routeType == 'all' && $request->attributes->get('paging')) {
-            $parameters = array('page' => $request->get('page', 1));
-            if ($request->attributes->get('perPage')) {
-                $parameters['perPage'] = $request->attributes->get('perPage');
-            }
+            // no rql given, we can do our own limit
+            $limit = sprintf(
+                'limit(%s,%s)',
+                $request->attributes->get('startAt'),
+                $request->attributes->get('perPage')
+            );
+
+            $parameters = ['q' => $limit];
         }
 
         if ($routeType == 'all' && $request->attributes->get('hasRql')) {

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -154,6 +154,7 @@ class DocumentModel extends SchemaModel implements ModelInterface
             $request->attributes->set('paging', true);
             $request->attributes->set('page', $page);
             $request->attributes->set('numPages', $numPages);
+            $request->attributes->set('startAt', $startAt);
             $request->attributes->set('perPage', $numberPerPage);
             $request->attributes->set('totalCount', $totalCount);
         }


### PR DESCRIPTION
currently, if the amount of data of the *first* page of a response exceeds the "default pagination setting", we generate a wrong _self link header part as it's still "perPage" and "page" in there..

this can be demonstrated using curl in our develop instance (as long it will be not deployed) as we have more than 10 customers in there:

```bash
curl -vv 'http://evoja-szkb-bap-backend-develop.nova.scapp.io/person/customer/'
Link: <http://evoja-szkb-bap-backend-develop.nova.scapp.io/person/customer/?limit(10%2C10)>; rel="next",<http://evoja-szkb-bap-backend-develop.nova.scapp.io/person/customer/?limit(10%2C30)>; rel="last",<http://evoja-szkb-bap-backend-develop.nova.scapp.io/person/customer/?page=1&perPage=10>; rel="self"
```

please note the part ```<http://evoja-szkb-bap-backend-develop.nova.scapp.io/person/customer/?page=1&perPage=10>; rel="self"```

this PR changes this to generate a `limit(n,n)` clause in this case..