### PR TITLE
fix method requirement in version routing

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -6,12 +6,10 @@
   <route id="graviton.core.static.main.options" path="/" methods="OPTIONS">
     <default key="_controller">graviton.core.controller.main:optionsAction</default>
   </route>
-  <route id="graviton.core.static.version.get" path="/core/version">
+  <route id="graviton.core.static.version.get" path="/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsAction</default>
-    <requirement key="_method">GET</requirement>
   </route>
-  <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version">
+  <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsSchemaAction</default>
-    <requirement key="_method">GET</requirement>
   </route>
 </routes>


### PR DESCRIPTION
changes in the /core/version service introduced some deprecation warnings in the logs..

```
[2015-10-14 08:27:16] php.INFO: The "_method" requirement of route "graviton.core.static.version.get" in file "/home/dn/git/graviton2/src/Graviton/CoreBundle/Resources/config/routing.xml" is deprecated since version 2.2 and will be removed in 3.0. Use the "methods" attribute instead. {"type":16384,"file":"/home/dn/git
```

this PR changes the definition to the newer method..