### PR TITLE
fix HEAD handling

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -638,6 +638,27 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * requests on OPTIONS and HEAD shall not lead graviton to get any data from mongodb.
+     * if we page limit(1) this will lead to presence of the x-total-count header if
+     * data is generated (asserted by testGetAppPagingWithRql()). thus, if we don't
+     * have this header, we can safely assume that no data has been processed in RestController.
+     *
+     * @return void
+     */
+    public function testNoRecordsAreGeneratedOnPreRequests()
+    {
+        $client = static::createRestClient();
+        $client->request('OPTIONS', '/core/app/?limit(1)');
+        $response = $client->getResponse();
+        $this->assertArrayNotHasKey('x-total-count', $response->headers->all());
+
+        $client = static::createRestClient();
+        $client->request('HEAD', '/core/app/?limit(1)');
+        $response = $client->getResponse();
+        $this->assertArrayNotHasKey('x-total-count', $response->headers->all());
+    }
+
+    /**
      * test getting schema information from canonical url
      *
      * @return void

--- a/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
+++ b/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
@@ -58,7 +58,6 @@ class ActionUtils
         }
 
         $route = new Route($pattern, $defaults, $requirements);
-
         $route->setMethods($method);
 
         return $route;
@@ -162,7 +161,7 @@ class ActionUtils
      * @param string  $service       service id
      * @param array   $serviceConfig service configuration
      * @param array   $parameters    service params
-     * @param boolean $useIdPattern  geenrate route with id param
+     * @param boolean $useIdPattern  generate route with id param
      *
      * @return Route
      */
@@ -172,6 +171,24 @@ class ActionUtils
             $parameters['id'] = self::ID_PATTERN;
         }
         return self::getRoute($service, 'OPTIONS', 'optionsAction', $serviceConfig, $parameters);
+    }
+
+    /**
+     * Get route for HEAD requests
+     *
+     * @param string  $service       service id
+     * @param array   $serviceConfig service configuration
+     * @param array   $parameters    service params
+     * @param boolean $useIdPattern  generate route with id param
+     *
+     * @return Route
+     */
+    public static function getRouteHead($service, $serviceConfig, array $parameters = array(), $useIdPattern = false)
+    {
+        if ($useIdPattern) {
+            $parameters['id'] = self::ID_PATTERN;
+        }
+        return self::getRoute($service, 'HEAD', 'optionsAction', $serviceConfig, $parameters);
     }
 
     /**

--- a/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
+++ b/src/Graviton/RestBundle/Routing/Loader/BasicLoader.php
@@ -97,11 +97,6 @@ class BasicLoader extends Loader
      */
     public function loadReadOnlyRoutes($service, $resource, $serviceConfig)
     {
-        $actionGet = ActionUtils::getRouteGet($service, $serviceConfig);
-        $this->routes->add($resource . '.get', $actionGet);
-
-        $actionAll = ActionUtils::getRouteAll($service, $serviceConfig);
-        $this->routes->add($resource . '.all', $actionAll);
 
         $actionOptions = ActionUtils::getRouteOptions($service, $serviceConfig);
         $this->routes->add($resource . '.options', $actionOptions);
@@ -109,6 +104,18 @@ class BasicLoader extends Loader
         $actionOptionsNoSlash = ActionUtils::getRouteOptions($service, $serviceConfig);
         $actionOptionsNoSlash->setPath(substr($actionOptionsNoSlash->getPath(), 0, -1));
         $this->routes->add($resource . '.optionsNoSlash', $actionOptionsNoSlash);
+
+        $actionHead = ActionUtils::getRouteHead($service, $serviceConfig);
+        $this->routes->add($resource . '.head', $actionHead);
+
+        $actionHead = ActionUtils::getRouteHead($service, $serviceConfig, array(), true);
+        $this->routes->add($resource . '.idHead', $actionHead);
+
+        $actionGet = ActionUtils::getRouteGet($service, $serviceConfig);
+        $this->routes->add($resource . '.get', $actionGet);
+
+        $actionAll = ActionUtils::getRouteAll($service, $serviceConfig);
+        $this->routes->add($resource . '.all', $actionAll);
 
         $actionOptions = ActionUtils::getCanonicalSchemaRoute($service, $serviceConfig, 'collection');
         $this->routes->add($resource . '.canonicalSchema', $actionOptions);


### PR DESCRIPTION
i know, we all didn't want to support HEAD requests in the first place ;-/
but as it turns out, some browsers make them and there is no way to disable that.

Graviton currently handles them in a rather inconsistent way - it answers it with an 2** status code, but actually processes the data request in `allAction()` in `RestController` but then has an empty response body. I've seen that it gets data by the delayed answer, the presence of the `x-total-count` header in the response and dev.log output.

this PR handles HEAD the same as we handle OPTIONS. this suffices as the only thing the client (m$ie) is looking for in the HEAD response is the presence of a `Content-Type` header (afaik), which we provide in the OPTIONS request.