### PR TITLE
remove autoloader wtf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {"": "src/", "Graviton": "src/", "Graviton": "/app/htdocs/src"}
+        "psr-0": {"": "src/", "Graviton": "src/"}
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "59d95f70a0ebecdfd7c37c6f28dbbf03",
+    "hash": "9ef4e68ffc24c9233aba0486aaf4a46a",
     "content-hash": "e1e4e20ff8d6e7e0e8bf05398a7a5f52",
     "packages": [
         {


### PR DESCRIPTION
just something i've seen.. is this useful for anything? maybe an old cloud workaround? i think `/app/htdocs` does not exist anywhere, not even in the cloud (it's `/app/app/src`).. so can remove?