### PR TITLE
change the way we determine if it's a concerning request for EventStatus

### DIFF
--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -101,7 +101,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
         $queueEventMock = $this->getMockBuilder(
             '\Graviton\RabbitMqBundle\Document\QueueEvent'
         )->setMethods(['getEvent'])->getMock();
-        $queueEventMock->expects($this->exactly(3))->method('getEvent')->willReturn('document.dude.config.create');
+        $queueEventMock->expects($this->exactly(5))->method('getEvent')->willReturn('document.dude.config.create');
 
         $filterResponseEventMock = $this->getMockBuilder(
             '\Symfony\Component\HttpKernel\Event\FilterResponseEvent'


### PR DESCRIPTION
I've just seen that Graviton generated me an `EventStatus` resource on an `OPTIONS` request. that is obviously a wrong behavior..

So I cleaned up the messy part in `isNotConcerningRequest()` in the `EventStatusLinkResponseListener`  - this was prone to wrong behavior. It's way better to just see if we have a routing key - which can only be done if the current request has been mapped by our `CompilerPass`. this way, we have a whitelist approach as opposed to the blacklist based on before..

I also made sure we only go forward if we have an eventName in the `QueueEvent`. This always needs to be the case..
