### PR TITLE
EVO-949 - fix translation of non-existant translation domains at container build time

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -68,6 +68,7 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
+            new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
             new \Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),

--- a/app/bootstrap.tests.php
+++ b/app/bootstrap.tests.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * tests bootstrap file making sure the 'test' cache gets cleared before we execute tests.
+ */
+if (isset($_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'])) {
+    $fs = new \Symfony\Component\Filesystem\Filesystem();
+    $cacheDir = __DIR__.'/cache/'.$_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'];
+    if ($fs->exists($cacheDir)) {
+        $fs->remove($cacheDir);
+    }
+}
+
+require __DIR__.'/bootstrap.php.cache';

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -52,6 +52,13 @@ assetic:
         #yui_css:
         #    jar: "%kernel.root_dir%/Resources/java/yuicompressor-2.4.7.jar"
 
+# doctrine cache configuration
+doctrine_cache:
+    providers:
+        local:
+            file_system:
+                directory: "%kernel.cache_dir%/doctrine_cache"
+
 # Doctrine Configuration
 doctrine:
     dbal:

--- a/composer.lock
+++ b/composer.lock
@@ -4327,16 +4327,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.10.0",
+            "version": "v0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "94b56a1556324000b6f59edda1df1f54c873ede2"
+                "reference": "b5e1ddd4d91e63f7b6d88e65857534f57522d566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/94b56a1556324000b6f59edda1df1f54c873ede2",
-                "reference": "94b56a1556324000b6f59edda1df1f54c873ede2",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/b5e1ddd4d91e63f7b6d88e65857534f57522d566",
+                "reference": "b5e1ddd4d91e63f7b6d88e65857534f57522d566",
                 "shasum": ""
             },
             "type": "library",
@@ -4351,10 +4351,10 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.10.0",
+                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.11.0",
                 "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
             },
-            "time": "2015-10-05 08:09:36"
+            "time": "2015-10-15 11:35:22"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     processIsolation            = "false"
     stopOnFailure               = "false"
     syntaxCheck                 = "false"
-    bootstrap                   = "app/bootstrap.php.cache" >
+    bootstrap                   = "app/bootstrap.tests.php" >
   <testsuites>
     <testsuite name="integration">
       <directory>src/*/*Bundle/Tests/Controller</directory>
@@ -41,6 +41,7 @@
     <ini name="date.timezone" value="UTC"/>
     <ini name="xdebug.max_nesting_level" value="200"/>
     <ini name="memory_limit" value="-1"/>
+    <env name="BOOTSTRAP_CLEAR_CACHE_ENV" value="test"/>
   </php>
   <listeners>
     <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />

--- a/src/Graviton/I18nBundle/Event/TranslatablePersistEvent.php
+++ b/src/Graviton/I18nBundle/Event/TranslatablePersistEvent.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * event object for the translatable.persist event
+ */
+
+namespace Graviton\I18nBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+final class TranslatablePersistEvent extends Event
+{
+
+    /**
+     * our event name
+     *
+     * @var string
+     */
+    const EVENT_NAME = 'translatable.persist';
+
+    /**
+     * locale
+     *
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * domain
+     *
+     * @var string
+     */
+    private $domain;
+
+    /**
+     * constructor
+     *
+     * @param string $locale locale
+     * @param string $domain domain
+     */
+    public function __construct($locale, $domain)
+    {
+        $this->locale = $locale;
+        $this->domain = $domain;
+    }
+
+    /**
+     * get locale
+     *
+     * @return string locale
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * get domain
+     *
+     * @return string domain
+     */
+    public function getDomain()
+    {
+        return $this->domain;
+    }
+}

--- a/src/Graviton/I18nBundle/Listener/I18nCachingListener.php
+++ b/src/Graviton/I18nBundle/Listener/I18nCachingListener.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * eventlistener that reacts on translatable persisting and manages the i18ncache
+ */
+
+namespace Graviton\I18nBundle\Listener;
+
+use Graviton\I18nBundle\Event\TranslatablePersistEvent;
+use Graviton\I18nBundle\Service\I18nCacheUtils;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class I18nCachingListener
+{
+
+    /**
+     * cache utils
+     *
+     * @var I18nCacheUtils
+     */
+    private $cacheUtils;
+
+    /**
+     * constructor
+     *
+     * @param I18nCacheUtils $cacheUtils cache utils
+     */
+    public function __construct(I18nCacheUtils $cacheUtils)
+    {
+        $this->cacheUtils = $cacheUtils;
+    }
+
+    /**
+     * hooked to the 'translatable.persist' event - invalidates the given locale/domain pair
+     *
+     * @param TranslatablePersistEvent $event event
+     *
+     * @return void
+     */
+    public function onPersist(TranslatablePersistEvent $event)
+    {
+        $this->cacheUtils->invalidate($event->getLocale(), $event->getDomain());
+    }
+
+    /**
+     * hooked to the 'kernel.terminate' event - persists changes in the cache utils
+     *
+     * @param Event $event event
+     *
+     * @return void
+     */
+    public function onTerminate(Event $event)
+    {
+        $this->cacheUtils->processPending();
+    }
+}

--- a/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
+++ b/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
@@ -22,8 +22,16 @@ use Symfony\Component\Filesystem\Filesystem;
 class PostPersistTranslatableListener implements EventSubscriber
 {
 
+    /**
+     * i18n cache utils
+     *
+     * @var I18nCacheUtils
+     */
     private $cacheUtils;
 
+    /**
+     * @param I18nCacheUtils $cacheUtils cache utils
+     */
     public function __construct(I18nCacheUtils $cacheUtils)
     {
         $this->cacheUtils = $cacheUtils;
@@ -50,36 +58,7 @@ class PostPersistTranslatableListener implements EventSubscriber
     {
         $object = $event->getObject();
         if ($object instanceof Translatable) {
-
-            /*
-            $domain = $object->getDomain();
-            $locale = $object->getLocale();
-            */
-
             $this->cacheUtils->invalidate($object->getLocale(), $object->getDomain());
         }
-            /**
-            $triggerFile = __DIR__.'/../Resources/translations/'.$domain.'.'.$locale.'.odm';
-            $cacheDirMask = __DIR__.'/../../../../app/cache/translations';
-
-            $fs = new Filesystem();
-            if (!$fs->exists($triggerFile)) {
-                $fs->touch($triggerFile);
-            }
-
-            try {
-                $finder = new Finder();
-                $finder
-                    ->files()
-                    ->in($cacheDirMask)
-                    ->name('*.' . $locale . '.*');
-
-                foreach ($finder as $file) {
-                    $fs->remove($file->getRealPath());
-                }
-            } catch (\InvalidArgumentException $e) {
-            }
-            **/
-        //}
     }
 }

--- a/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
+++ b/src/Graviton/I18nBundle/Listener/PostPersistTranslatableListener.php
@@ -8,6 +8,7 @@ namespace Graviton\I18nBundle\Listener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Graviton\I18nBundle\Document\Translatable;
+use Graviton\I18nBundle\Service\I18nCacheUtils;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -20,6 +21,14 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class PostPersistTranslatableListener implements EventSubscriber
 {
+
+    private $cacheUtils;
+
+    public function __construct(I18nCacheUtils $cacheUtils)
+    {
+        $this->cacheUtils = $cacheUtils;
+    }
+
     /**
      * {@inheritDocs}
      *
@@ -41,10 +50,17 @@ class PostPersistTranslatableListener implements EventSubscriber
     {
         $object = $event->getObject();
         if ($object instanceof Translatable) {
+
+            /*
             $domain = $object->getDomain();
             $locale = $object->getLocale();
+            */
+
+            $this->cacheUtils->invalidate($object->getLocale(), $object->getDomain());
+        }
+            /**
             $triggerFile = __DIR__.'/../Resources/translations/'.$domain.'.'.$locale.'.odm';
-            $cacheDirMask = __DIR__.'/../../../../app/cache/*/translations';
+            $cacheDirMask = __DIR__.'/../../../../app/cache/translations';
 
             $fs = new Filesystem();
             if (!$fs->exists($triggerFile)) {
@@ -62,9 +78,8 @@ class PostPersistTranslatableListener implements EventSubscriber
                     $fs->remove($file->getRealPath());
                 }
             } catch (\InvalidArgumentException $e) {
-                // InvalidArgumentException gets thrown if the translation cache dir doesn't exist.
-                // we ignore it since it's normal under some circumstances (no cache warmup yet)
             }
-        }
+            **/
+        //}
     }
 }

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -23,6 +23,7 @@
     <parameter key="graviton.i18n.request.class">Symfony\Component\HttpFoundation\Request</parameter>
     <parameter key="graviton.i18n.listener.postpersisttranslatable.class">Graviton\I18nBundle\Listener\PostPersistTranslatableListener</parameter>
     <parameter key="graviton.i18n.utils.class">Graviton\I18nBundle\Service\I18nUtils</parameter>
+    <parameter key="graviton.i18n.cacheutils.class">Graviton\I18nBundle\Service\I18nCacheUtils</parameter>
     <parameter key="graviton.i18n.form.transformer.translatabletodefaultstring.class">Graviton\I18nBundle\Form\DataTransformer\TranslatableToDefaultStringTransformer</parameter>
     <parameter key="graviton.i18n.form.type.translatable.class">Graviton\I18nBundle\Form\Type\TranslatableType</parameter>
 
@@ -139,7 +140,14 @@
       <argument type="service" id="graviton.i18n.request"/>
     </service>
 
+    <service id="graviton.18n.cacheutils"
+             class="%graviton.i18n.cacheutils.class%">
+      <argument type="string">%kernel.cache_dir%</argument>
+      <argument type="string">odm</argument>
+    </service>
+
     <service id="graviton.i18n.listener.postpersisttranslatable" class="%graviton.i18n.listener.postpersisttranslatable.class%">
+      <argument type="service" id="graviton.18n.cacheutils"/>
       <tag name="doctrine_mongodb.odm.event_listener" event="postPersist" class="stdClass"/>
     </service>
     <service id="graviton.i18n.form.transformer.translatabletodefaultstring" class="%graviton.i18n.form.transformer.translatabletodefaultstring.class%">

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -144,10 +144,11 @@
              class="%graviton.i18n.cacheutils.class%">
       <argument type="string">%kernel.cache_dir%</argument>
       <argument type="string">odm</argument>
+      <tag name="kernel.event_subscriber"/>
     </service>
 
     <service id="graviton.i18n.listener.postpersisttranslatable" class="%graviton.i18n.listener.postpersisttranslatable.class%">
-      <argument type="service" id="graviton.18n.cacheutils"/>
+      <argument type="service" id="event_dispatcher"/>
       <tag name="doctrine_mongodb.odm.event_listener" event="postPersist" class="stdClass"/>
     </service>
     <service id="graviton.i18n.form.transformer.translatabletodefaultstring" class="%graviton.i18n.form.transformer.translatabletodefaultstring.class%">

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -25,6 +25,10 @@
     <parameter key="graviton.i18n.utils.class">Graviton\I18nBundle\Service\I18nUtils</parameter>
     <parameter key="graviton.i18n.form.transformer.translatabletodefaultstring.class">Graviton\I18nBundle\Form\DataTransformer\TranslatableToDefaultStringTransformer</parameter>
     <parameter key="graviton.i18n.form.type.translatable.class">Graviton\I18nBundle\Form\Type\TranslatableType</parameter>
+
+    <!-- should we move this to somewhere else? -->
+    <parameter key="translator.class">Graviton\I18nBundle\Translator\Translator</parameter>
+
   </parameters>
   <services>
     <service id="graviton.i18n.document.language" class="%graviton.i18n.document.language.class%"/>

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
     <parameter key="graviton.i18n.listener.i18nserializer.class">Graviton\I18nBundle\Listener\I18nSerializationListener</parameter>
     <parameter key="graviton.i18n.listener.i18ndeserializer.class">Graviton\I18nBundle\Listener\I18nDeserializationListener</parameter>
     <parameter key="graviton.i18n.listener.i18nrqlparsinglistener.class">Graviton\I18nBundle\Listener\I18nRqlParsingListener</parameter>
+    <parameter key="graviton.i18n.listener.i18ncachinglistener.class">Graviton\I18nBundle\Listener\I18nCachingListener</parameter>
     <parameter key="graviton.i18n.loader.doctrineodm.class">Graviton\I18nBundle\Translation\Loader\DoctrineODMLoader</parameter>
     <parameter key="graviton.i18n.request.class">Symfony\Component\HttpFoundation\Request</parameter>
     <parameter key="graviton.i18n.listener.postpersisttranslatable.class">Graviton\I18nBundle\Listener\PostPersistTranslatableListener</parameter>
@@ -101,6 +102,11 @@
       <argument type="string">%graviton.translator.default.locale%</argument>
       <tag name="kernel.event_listener" event="kernel.request" method="onkernelrequest"/>
     </service>
+    <service id="graviton.i18n.listener.i18ncaching" class="%graviton.i18n.listener.i18ncachinglistener.class%">
+      <argument type="service" id="graviton.18n.cacheutils"/>
+      <tag name="kernel.event_listener" event="translatable.persist" method="onPersist"/>
+      <tag name="kernel.event_listener" event="kernel.terminate" method="onTerminate"/>
+    </service>
     <service id="graviton.i18n.loader.doctrineodm" class="%graviton.i18n.loader.doctrineodm.class%">
       <call method="setRepository">
         <argument type="service" id="graviton.i18n.repository.translatable"/>
@@ -144,7 +150,6 @@
              class="%graviton.i18n.cacheutils.class%">
       <argument type="string">%kernel.cache_dir%</argument>
       <argument type="string">odm</argument>
-      <tag name="kernel.event_subscriber"/>
     </service>
 
     <service id="graviton.i18n.listener.postpersisttranslatable" class="%graviton.i18n.listener.postpersisttranslatable.class%">

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -146,8 +146,10 @@
       <argument type="service" id="graviton.i18n.request"/>
     </service>
 
+    <!-- I18nCacheUtils -->
     <service id="graviton.18n.cacheutils"
              class="%graviton.i18n.cacheutils.class%">
+      <argument type="service" id="doctrine_cache.providers.local"/>
       <argument type="string">%kernel.cache_dir%</argument>
       <argument type="string">odm</argument>
     </service>

--- a/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
@@ -219,9 +219,7 @@ class I18nCacheUtils
 
                     // make sure the file exists
                     $fs = new Filesystem();
-                    if (!$fs->exists($resourceFile)) {
-                        $fs->touch($resourceFile);
-                    }
+                    $fs->touch($resourceFile);
 
                     $resources[$locale][] = $resourceFile;
                 }
@@ -252,6 +250,10 @@ class I18nCacheUtils
      */
     private function processInvalidations()
     {
+        if (empty($this->invalidations)) {
+            return;
+        }
+
         $fs = new Filesystem();
         $localesToClean = array_keys($this->invalidations);
         $deleteRegex = '/^catalogue\.(['.implode('|', $localesToClean).'])/';
@@ -264,7 +266,7 @@ class I18nCacheUtils
                 ->name($deleteRegex);
 
             foreach ($finder as $file) {
-                $fs->remove($file->getRealPath());
+                //$fs->remove($file->getRealPath());
             }
         } catch (\InvalidArgumentException $e) {
             // happens when cache is non-existent

--- a/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
@@ -11,7 +11,7 @@
 
 namespace Graviton\I18nBundle\Service;
 
-use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\CacheProvider;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
@@ -22,19 +22,20 @@ use Symfony\Component\Finder\Finder;
  */
 class I18nCacheUtils
 {
+
+    /**
+     * doctrine cache
+     *
+     * @var CacheProvider
+     */
+    private $cache;
+
     /**
      * full path to translations cache
      *
      * @var string
      */
     private $cacheDirTranslations;
-
-    /**
-     * our cache file for doctrine cache
-     *
-     * @var string
-     */
-    private $cacheFile;
 
     /**
      * the cache key we use for our addition array
@@ -49,13 +50,6 @@ class I18nCacheUtils
      * @var string
      */
     private $cacheKeyFinalResource;
-
-    /**
-     * doctrine filesystemcache
-     *
-     * @var FilesystemCache
-     */
-    private $cache;
 
     /**
      * the loader id suffix (like 'odm')
@@ -96,21 +90,21 @@ class I18nCacheUtils
     /**
      * Constructor
      *
-     * @param string $cacheDir full path to cache dir
-     * @param string $loaderId loader id suffix
+     * @param CacheProvider $cache    cache
+     * @param string        $cacheDir full path to cache dir
+     * @param string        $loaderId loader id suffix
      */
     public function __construct(
+        CacheProvider $cache,
         $cacheDir,
         $loaderId
     ) {
-        // caching
+        $this->cache = $cache;
         $this->cacheDirTranslations = $cacheDir . '/translations';
-        $this->cacheFile = $cacheDir . '/addedI18nResources';
-        $this->cache = new FilesystemCache($this->cacheFile);
 
         // cache keys
-        $this->cacheKey = 'addedTranslations';
-        $this->cacheKeyFinalResource = 'finalResources';
+        $this->cacheKey = 'i18n.addedTranslations';
+        $this->cacheKeyFinalResource = 'i18n.finalResources';
 
         $this->loaderId = $loaderId;
         $this->resourceDir = __DIR__.'/../Resources/translations/';
@@ -124,11 +118,23 @@ class I18nCacheUtils
     /**
      * Gets the cache instance
      *
-     * @return FilesystemCache cache
+     * @return CacheProvider cache
      */
     public function getCache()
     {
         return $this->cache;
+    }
+
+    /**
+     * sets the resource dir
+     *
+     * @param string $dir resource dir
+     *
+     * @return void
+     */
+    public function setResourceDir($dir)
+    {
+        $this->resourceDir = $dir;
     }
 
     /**
@@ -194,18 +200,6 @@ class I18nCacheUtils
         }
 
         $this->invalidations[$locale] = '';
-    }
-
-    /**
-     * sets the resource dir
-     *
-     * @param string $dir resource dir
-     *
-     * @return void
-     */
-    public function setResourceDir($dir)
-    {
-        $this->resourceDir = $dir;
     }
 
     /**

--- a/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * service for i18n stuff
+ */
+
+namespace Graviton\I18nBundle\Service;
+
+use Doctrine\Common\Cache\FilesystemCache;
+
+/**
+ * A service (meaning symfony service) providing some convenience stuff when dealing with our RestController
+ * based services (meaning rest services).
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class I18nCacheUtils
+{
+
+    /**
+     * @var string
+     */
+    private $cacheFile;
+
+    /**
+     * @var string
+     */
+    private $cacheKey;
+
+    /**
+     * @var string
+     */
+    private $loaderId;
+
+    /**
+     * @var string
+     */
+    private $resourceDir;
+
+    /**
+     * @var FilesystemCache
+     */
+    private $cache;
+
+    private $addedResources = array();
+
+    private $isDirty = false;
+
+    /**
+     * Constructor
+     *
+     * @param string              $defaultLanguage    default language
+     */
+    public function __construct(
+        $cacheDir,
+        $loaderId
+    ) {
+        // caching
+        $this->cacheFile = $cacheDir . '/addedI18nResources';
+        $this->cache = new FilesystemCache($this->cacheFile);
+
+        // cache keys
+        $this->cacheKey = 'addedTranslations';
+        $this->cacheKeyFinalResource = 'finalResources';
+        $this->cacheKeyFinalResourceHash = 'finalResourceHash';
+
+        $this->loaderId = $loaderId;
+        $this->resourceDir = __DIR__.'/../Resources/translations/';
+
+        // do we have existing resources?
+        if ($this->cache->contains($this->cacheKey)) {
+            $this->addedResources = $this->cache->fetch($this->cacheKey);
+        }
+    }
+
+    public function invalidate($locale, $domain)
+    {
+        $filename = sprintf('%s.%s.%s', $domain, $locale, $this->loaderId);
+
+        if (!isset($this->addedResources[$locale]) || !in_array($filename, $this->addedResources[$locale])) {
+            $this->addedResources[$locale][] = $filename;
+            $this->isDirty = true;
+        }
+    }
+
+    public function setResourceDir($dir)
+    {
+        $this->resourceDir = $dir;
+    }
+
+    public function getResources($resources)
+    {
+        $resourceHash = sha1(serialize($resources));
+
+        $finalResources = null;
+        if ($this->resourceIsInCache($resourceHash)) {
+            $finalResources = $this->cache->fetch(cacheKeyResource);
+        }
+
+        if (!is_array($finalResources) && $this->cache->contains($this->cacheKey)) {
+            // merge the two together, always keep an eye to not duplicate (paths are different!)
+            $finalResources = $this->mergeResourcesWithAdditions($resources);
+
+            //echo "hans"; die;
+        }
+
+        /*
+        var_dump($resourceHash);
+        var_dump($resources);
+
+
+        $added = array();
+        if ($this->cache->contains($this->cacheKey)) {
+            $added = $this->cache->fetch($this->cacheKey);
+        }
+
+        var_dump($added); die;
+        */
+
+        return $resources;
+    }
+
+    /**
+     * Merges the cached additions with the one the Translator already has.
+     * I need to use preg_grep() here as I'm unable to compose an absolute path that is
+     * exactly like the one the Translator would have already as I have to deal with relative
+     * paths here (rightfully so). This shouldn't hurt too much as the end result is cache too
+     * and only redone if something changes.
+     *
+     * @param $resources
+     */
+    private function mergeResourcesWithAdditions($resources)
+    {
+        //var_dump($resources);
+        $this->addedResources['en'][] = 'core.en.odm';
+        foreach ($this->addedResources as $locale => $files) {
+            //var_dump($resources[$locale]); die;
+            foreach ($files as $file) {
+                //var_dump('/('.str_replace('.', '\\.', $file).')$/');
+                $hits =preg_grep('/$'.str_replace('.', '\\.', $file).'/', $resources[$locale]);
+                //var_dump($hits);
+            }
+        }
+
+        //die;
+    }
+
+    private function resourceIsInCache($resourcesHash)
+    {
+        $ret = false;
+
+        if ($this->cache->contains($this->cacheKeyFinalResourceHash) &&
+            $this->cache->fetch($this->cacheKeyFinalResourceHash) == $resourcesHash
+        ) {
+            $ret = true;
+        }
+
+        return $ret;
+    }
+
+    private function persistAdditions()
+    {
+        $this->cache->save($this->cacheKey, $this->addedResources);
+
+        // invalidate full map hash -> forces regeneration of the whole thing
+        $this->cache->delete($this->cacheKeyFinalResourceHash);
+    }
+
+    public function __destruct()
+    {
+        if ($this->isDirty === true) {
+            $this->persistAdditions();
+        }
+    }
+}

--- a/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
@@ -122,6 +122,16 @@ class I18nCacheUtils
     }
 
     /**
+     * Gets the cache instance
+     *
+     * @return FilesystemCache cache
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
      * this shall be called by a Translator.
      * it adds our additions to the already existent ones in the Translator and returns it.
      * as this is called quite often, we cache the final result (the full map including the translator resources)
@@ -213,8 +223,15 @@ class I18nCacheUtils
     {
         foreach ($this->addedResources as $locale => $files) {
             foreach ($files as $file) {
-                $hits = preg_grep('/\/'.str_replace('.', '\\.', $file).'$/', $resources[$locale]);
-                if (count($hits) === 0) {
+                $isExistent = false;
+                if (isset($resources[$locale])) {
+                    $hits = preg_grep('/\/'.str_replace('.', '\\.', $file).'$/', $resources[$locale]);
+                    if (count($hits) > 0) {
+                        $isExistent = true;
+                    }
+                }
+
+                if (!$isExistent) {
                     $resourceFile = $this->resourceDir.$file;
 
                     // make sure the file exists

--- a/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nCacheUtils.php
@@ -1,69 +1,116 @@
 <?php
 /**
- * service for i18n stuff
+ * service for i18n stuff relating to symfony translation loader and its caching.
+ *
+ * it basically receives the 'resource_files' array from a Translator (that is built statically in the Container)
+ * and adds runtime elements to it. behind the scenes, it invalidates translator caches and creates the resource files.
+ * all with the idea that new 'translation domains' get added at runtime without the need of a container rebuild.
+ * only then it will be actually loaded by the translation loaders and end up in the final catalogue.
+ * caches are in place to optimize the performance impact.
  */
 
 namespace Graviton\I18nBundle\Service;
 
 use Doctrine\Common\Cache\FilesystemCache;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 /**
- * A service (meaning symfony service) providing some convenience stuff when dealing with our RestController
- * based services (meaning rest services).
- *
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
 class I18nCacheUtils
 {
+    /**
+     * full path to translations cache
+     *
+     * @var string
+     */
+    private $cacheDirTranslations;
 
     /**
+     * our cache file for doctrien cache
+     *
      * @var string
      */
     private $cacheFile;
 
     /**
+     * the cache key we use for our addition array
+     *
      * @var string
      */
     private $cacheKey;
 
     /**
+     * the cache key we use for the full resource map
+     *
+     * @var string
+     */
+    private $cacheKeyFinalResource;
+
+    /**
+     * doctrine filesystemcache
+     *
+     * @var FilesystemCache
+     */
+    private $cache;
+
+    /**
+     * the loader id suffix (like 'odm')
+     *
      * @var string
      */
     private $loaderId;
 
     /**
+     * full path to the bundle resource dir
+     *
      * @var string
      */
     private $resourceDir;
 
     /**
-     * @var FilesystemCache
+     * this map contains all added resources (added to all translator knows already)
+     *
+     * @var array
      */
-    private $cache;
-
     private $addedResources = array();
 
+    /**
+     * if the postpersistListener invalidates something, it will be put here
+     *
+     * @var array
+     */
+    private $invalidations = array();
+
+    /**
+     * a boolean flag telling us if a new map persist is necessary
+     * (that is, when some new addition has been added that needs a resource map regeneration)
+     *
+     * @var boolean
+     */
     private $isDirty = false;
 
     /**
      * Constructor
      *
-     * @param string              $defaultLanguage    default language
+     * @param string $cacheDir full path to cache dir
+     * @param string $loaderId loader id suffix
      */
     public function __construct(
         $cacheDir,
         $loaderId
     ) {
         // caching
+        $this->cacheDirTranslations = $cacheDir . '/translations';
         $this->cacheFile = $cacheDir . '/addedI18nResources';
         $this->cache = new FilesystemCache($this->cacheFile);
 
         // cache keys
         $this->cacheKey = 'addedTranslations';
         $this->cacheKeyFinalResource = 'finalResources';
-        $this->cacheKeyFinalResourceHash = 'finalResourceHash';
 
         $this->loaderId = $loaderId;
         $this->resourceDir = __DIR__.'/../Resources/translations/';
@@ -74,6 +121,59 @@ class I18nCacheUtils
         }
     }
 
+    /**
+     * this shall be called by a Translator.
+     * it adds our additions to the already existent ones in the Translator and returns it.
+     * as this is called quite often, we cache the final result (the full map including the translator resources)
+     * and only regenerate that when a *new* domain has been added. basic invalidations by the PostPersistListener
+     * will *not* result in a rebuild here - only if a new domain has been added.
+     *
+     * @param array $resources the resources array of the translator
+     *
+     * @return array the finalized map containing translator resources and our additions
+     */
+    public function getResources($resources)
+    {
+        $finalResources = null;
+
+        // do we have a full resource map in the cache already? (full = translator + additions)
+        if ($this->cache->contains($this->cacheKeyFinalResource)) {
+            $finalResources = $this->cache->fetch($this->cacheKeyFinalResource);
+        }
+
+        // do we have cached additions?
+        if (!is_array($finalResources) && $this->cache->contains($this->cacheKey)) {
+            // merge the two together, always keep an eye to not duplicate (paths are different!)
+            $finalResources = $this->mergeResourcesWithAdditions($resources);
+
+            // cache it
+            $this->cache->save($this->cacheKeyFinalResource, $finalResources);
+        }
+
+        // so, did we got anything?
+        if (is_array($finalResources)) {
+            $resources = $finalResources;
+        }
+
+        return $resources;
+    }
+
+    /**
+     * shall be called by the PostPersistTranslatorListener (or other interested parties).
+     * if someone invalidates a locale & domain pair, this will lead to:
+     * - removal of the symfony translation cache files
+     * (if this pair has never been seen)
+     * - creation of the resource files ("trigger files")
+     * - a regeneration of the full resource map for the translator
+     *
+     * please note that calling invalidate() will do the above mentioned in a lazy way
+     * on __destruct() of this object.
+     *
+     * @param string $locale locale (de,en)
+     * @param string $domain the domain
+     *
+     * @return void
+     */
     public function invalidate($locale, $domain)
     {
         $filename = sprintf('%s.%s.%s', $domain, $locale, $this->loaderId);
@@ -82,93 +182,108 @@ class I18nCacheUtils
             $this->addedResources[$locale][] = $filename;
             $this->isDirty = true;
         }
+
+        $this->invalidations[$locale] = '';
     }
 
+    /**
+     * sets the resource dir
+     *
+     * @param string $dir resource dir
+     *
+     * @return void
+     */
     public function setResourceDir($dir)
     {
         $this->resourceDir = $dir;
     }
 
-    public function getResources($resources)
+    /**
+     * Merges the cached additions with the one the Translator already has.
+     * I need to use preg_grep() here as I'm unable to compose an absolute path that is
+     * identical to the one the Translator would have already as I have to deal with relative
+     * paths here (and rightfully so). This shouldn't hurt too much as the end result is cached
+     * and only redone if something changes.
+     *
+     * @param array $resources resources
+     *
+     * @return array finalized full map
+     */
+    private function mergeResourcesWithAdditions($resources)
     {
-        $resourceHash = sha1(serialize($resources));
+        foreach ($this->addedResources as $locale => $files) {
+            foreach ($files as $file) {
+                $hits = preg_grep('/\/'.str_replace('.', '\\.', $file).'$/', $resources[$locale]);
+                if (count($hits) === 0) {
+                    $resourceFile = $this->resourceDir.$file;
 
-        $finalResources = null;
-        if ($this->resourceIsInCache($resourceHash)) {
-            $finalResources = $this->cache->fetch(cacheKeyResource);
+                    // make sure the file exists
+                    $fs = new Filesystem();
+                    if (!$fs->exists($resourceFile)) {
+                        $fs->touch($resourceFile);
+                    }
+
+                    $resources[$locale][] = $resourceFile;
+                }
+            }
         }
-
-        if (!is_array($finalResources) && $this->cache->contains($this->cacheKey)) {
-            // merge the two together, always keep an eye to not duplicate (paths are different!)
-            $finalResources = $this->mergeResourcesWithAdditions($resources);
-
-            //echo "hans"; die;
-        }
-
-        /*
-        var_dump($resourceHash);
-        var_dump($resources);
-
-
-        $added = array();
-        if ($this->cache->contains($this->cacheKey)) {
-            $added = $this->cache->fetch($this->cacheKey);
-        }
-
-        var_dump($added); die;
-        */
-
         return $resources;
     }
 
     /**
-     * Merges the cached additions with the one the Translator already has.
-     * I need to use preg_grep() here as I'm unable to compose an absolute path that is
-     * exactly like the one the Translator would have already as I have to deal with relative
-     * paths here (rightfully so). This shouldn't hurt too much as the end result is cache too
-     * and only redone if something changes.
+     * saves our addition array to our cache and removes the full map from the cache
+     * leading to a regeneration of the map.
      *
-     * @param $resources
+     * @return void
      */
-    private function mergeResourcesWithAdditions($resources)
-    {
-        //var_dump($resources);
-        $this->addedResources['en'][] = 'core.en.odm';
-        foreach ($this->addedResources as $locale => $files) {
-            //var_dump($resources[$locale]); die;
-            foreach ($files as $file) {
-                //var_dump('/('.str_replace('.', '\\.', $file).')$/');
-                $hits =preg_grep('/$'.str_replace('.', '\\.', $file).'/', $resources[$locale]);
-                //var_dump($hits);
-            }
-        }
-
-        //die;
-    }
-
-    private function resourceIsInCache($resourcesHash)
-    {
-        $ret = false;
-
-        if ($this->cache->contains($this->cacheKeyFinalResourceHash) &&
-            $this->cache->fetch($this->cacheKeyFinalResourceHash) == $resourcesHash
-        ) {
-            $ret = true;
-        }
-
-        return $ret;
-    }
-
     private function persistAdditions()
     {
         $this->cache->save($this->cacheKey, $this->addedResources);
 
-        // invalidate full map hash -> forces regeneration of the whole thing
-        $this->cache->delete($this->cacheKeyFinalResourceHash);
+        // remove full map from cache
+        $this->cache->delete($this->cacheKeyFinalResource);
     }
 
+    /**
+     * processes all queued cache invalidations for the symfony translation cache.
+     * this is now only 1 Finder search for a single request.
+     *
+     * @return void
+     */
+    private function processInvalidations()
+    {
+        $fs = new Filesystem();
+        $localesToClean = array_keys($this->invalidations);
+        $deleteRegex = '/^catalogue\.(['.implode('|', $localesToClean).'])/';
+
+        try {
+            $finder = new Finder();
+            $finder
+                ->files()
+                ->in($this->cacheDirTranslations)
+                ->name($deleteRegex);
+
+            foreach ($finder as $file) {
+                $fs->remove($file->getRealPath());
+            }
+        } catch (\InvalidArgumentException $e) {
+            // happens when cache is non-existent
+        }
+    }
+
+    /**
+     * magic method that makes sure our file cleaning and persisting only
+     * happens near the end of the request, making it possible to only doing it once
+     * as opposed to everytime ;-)
+     * it's not necessary that it happens exactly at the end of the request as when this
+     * gets destructed all important things have already taken place.
+     *
+     * @return void
+     */
     public function __destruct()
     {
+        $this->processInvalidations();
+
         if ($this->isDirty === true) {
             $this->persistAdditions();
         }

--- a/src/Graviton/I18nBundle/Tests/Controller/ExternalTranslationDomainControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/ExternalTranslationDomainControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Functional test for cache handling for non-existent translatable domains on Container build time.
+ * On Container build time, only existent Translatable domains are added to the Translator map.
+ * So they will not be loaded until the Container is rebuild. We fixed that by creating our own
+ * Translator and I18nCacheUtils. This test ensures that this works as expected for the user.
+ *
+ * IMPORTANT: In order for this test to stay relevant, the service definition for
+ * /external/translatable MUST NOT contain ANY fixtures as this would produce the domain at Container
+ * build time!
+ */
+
+namespace Graviton\I18nBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ExternalTranslationDomainControllerTest extends RestTestCase
+{
+
+    /**
+     * setup function
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->loadFixtures(
+            array(
+                'Graviton\I18nBundle\DataFixtures\MongoDB\LoadLanguageData',
+                'Graviton\I18nBundle\DataFixtures\MongoDB\LoadMultiLanguageData',
+                'Graviton\I18nBundle\DataFixtures\MongoDB\LoadTranslatableData',
+            ),
+            null,
+            'doctrine_mongodb'
+        );
+
+        // make sure we have no resource files for domain 'external'
+        $fs = new Filesystem();
+        $finder = new Finder();
+        $finder
+            ->files()
+            ->in(__DIR__.'/../../Resources/translations')
+            ->name('external.*.*');
+
+        foreach ($finder as $file) {
+            $fs->remove($file->getRealPath());
+        }
+    }
+
+    /**
+     * see if a non existent domain gets translated correctly.
+     * it must invalidate the cache and trigger a reload of the translations in order for this to work.
+     *
+     * @return void
+     */
+    public function testCacheUtils()
+    {
+        $resource = new \stdClass;
+        $resource->id = 'test';
+        $resource->myString = new \stdClass;
+        $resource->myString->en = 'The John';
+        $resource->myString->de = 'Der Hans';
+        $resource->myString->fr = 'Le Jean';
+
+        $client = static::createRestClient();
+        $client->put(
+            '/external/translatable/test',
+            $resource,
+            array(),
+            array(),
+            array('HTTP_ACCEPT_LANGUAGE' => 'en,de,fr')
+        );
+
+        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request(
+            'GET',
+            '/external/translatable/test',
+            array(),
+            array(),
+            array('HTTP_ACCEPT_LANGUAGE' => 'en,de,fr')
+        );
+
+        $results = $client->getResults();
+
+        $this->assertEquals($resource->id, $results->id);
+        $this->assertEquals($resource->myString->en, $results->myString->en);
+        $this->assertEquals($resource->myString->de, $results->myString->de);
+        $this->assertEquals($resource->myString->fr, $results->myString->fr);
+    }
+}

--- a/src/Graviton/I18nBundle/Tests/Service/I18nCacheUtilsTest.php
+++ b/src/Graviton/I18nBundle/Tests/Service/I18nCacheUtilsTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * unit test for I18nCacheUtils
+ */
+
+namespace Graviton\I18nBundle\Tests\Service;
+
+use Graviton\I18nBundle\Service\I18nCacheUtils;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class I18nCacheUtilsTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * path to our local resources
+     *
+     * @var string
+     */
+    private $resourceDir;
+
+    /**
+     * cache utils
+     *
+     * @var I18nCacheUtils
+     */
+    private $cacheUtils;
+
+    /**
+     * setup function
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->resourceDir = __DIR__.'/resources/translations/';
+
+        $this->cacheUtils = new I18nCacheUtils(__DIR__.'/resources/cache', 'odm');
+        $this->cacheUtils->setResourceDir($this->resourceDir);
+    }
+
+    /**
+     * see if I18nCacheUtils does nothing when it has nothing
+     *
+     * @return void
+     */
+    public function testLeaveAloneIfNothing()
+    {
+        $resources = [
+            'de' => ['/hans.po']
+        ];
+
+        $this->assertEquals($resources, $this->cacheUtils->getResources($resources));
+    }
+
+    /**
+     * test the whole process
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $this->cacheUtils->invalidate('de', 'hans');
+        $this->cacheUtils->invalidate('fr', 'franz');
+
+        // we did invalidations.. resources files shall not be here yet! (test lazyness)
+        $this->assertFileNotExists($this->resourceDir.'hans.de.odm');
+        $this->assertFileNotExists($this->resourceDir.'franz.fr.odm');
+
+        $this->cacheUtils->processPending();
+
+        $resources = [
+            'de' => ['/hans.po']
+        ];
+
+        $finalResources = $this->cacheUtils->getResources($resources);
+
+        // see if our final resource is in the cache
+        $this->assertEquals($finalResources, $this->cacheUtils->getCache()->fetch('finalResources'));
+
+        // see if our files are in the arrays
+        $this->assertEquals('/hans.po', $finalResources['de'][0]);
+        $this->assertEquals($this->resourceDir.'hans.de.odm', $finalResources['de'][1]);
+        $this->assertEquals($this->resourceDir.'franz.fr.odm', $finalResources['fr'][0]);
+
+        // ok, now the files *need* to exist..
+        $this->assertFileExists($this->resourceDir.'hans.de.odm');
+        $this->assertFileExists($this->resourceDir.'franz.fr.odm');
+
+        // now, invalidate something more
+        $this->cacheUtils->invalidate('de', 'trudi');
+
+        // process
+        $this->cacheUtils->processPending();
+        $finalResources = $this->cacheUtils->getResources($resources);
+
+        // again put in cache?
+        $this->assertEquals($finalResources, $this->cacheUtils->getCache()->fetch('finalResources'));
+
+        // file exists?
+        $this->assertFileExists($this->resourceDir.'trudi.de.odm');
+
+        // new item in map?
+        $this->assertEquals($this->resourceDir.'trudi.de.odm', $finalResources['de'][2]);
+    }
+
+    /**
+     * clean up our mess
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        // remove resources
+        $fs = new Filesystem();
+        $finder = new Finder();
+        $finder
+            ->files()
+            ->ignoreDotFiles(true)
+            ->in(__DIR__ . '/resources/translations');
+
+        foreach ($finder as $file) {
+            $fs->remove($file->getRealPath());
+        }
+
+        // remove doctrine cache
+        $fs = new Filesystem();
+        $finder = new Finder();
+        $finder
+            ->directories()
+            ->in(__DIR__ . '/resources/cache')
+            ->depth(0)
+            ->name('addedI18nResources');
+
+        foreach ($finder as $file) {
+            $fs->remove($file->getRealPath());
+        }
+    }
+}

--- a/src/Graviton/I18nBundle/Translator/Translator.php
+++ b/src/Graviton/I18nBundle/Translator/Translator.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * a small child of the symfony Translator in order to load more dynamically
+ * a small child of the symfony Translator in order to load more dynamically.
+ * as we cannot inject more properties into this via DIC, our stuff is in I18nCacheUtils.
  */
 
 namespace Graviton\I18nBundle\Translator;
@@ -14,14 +15,33 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class Translator extends BaseTranslator {
+class Translator extends BaseTranslator
+{
 
-    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
-    {
+    /**
+     * Constructor.
+     *
+     * Available options:
+     *
+     *   * cache_dir: The cache directory (or null to disable caching)
+     *   * debug:     Whether to enable debugging or not (false by default)
+     *   * resource_files: List of translation resources available grouped by locale.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     * @param MessageSelector    $selector  The message selector for pluralization
+     * @param array              $loaderIds An array of loader Ids
+     * @param array              $options   An array of options
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(
+        ContainerInterface $container,
+        MessageSelector $selector,
+        $loaderIds = array(),
+        array $options = array()
+    ) {
         $cacheUtils = $container->get('graviton.18n.cacheutils');
         $options['resource_files'] = $cacheUtils->getResources($options['resource_files']);
-
         parent::__construct($container, $selector, $loaderIds, $options);
     }
-
 }

--- a/src/Graviton/I18nBundle/Translator/Translator.php
+++ b/src/Graviton/I18nBundle/Translator/Translator.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * a small child of the symfony Translator in order to load more dynamically
+ */
+
+namespace Graviton\I18nBundle\Translator;
+
+use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
+use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class Translator extends BaseTranslator {
+
+    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
+    {
+
+        print_r($options);
+        parent::__construct($container, $selector, $loaderIds, $options);
+        print_r($this->options);
+        die;
+
+    }
+
+    protected function initialize()
+    {
+        print_r($this->loaderIds);
+        die;
+        parent::initialize();
+    }
+
+}

--- a/src/Graviton/I18nBundle/Translator/Translator.php
+++ b/src/Graviton/I18nBundle/Translator/Translator.php
@@ -40,8 +40,11 @@ class Translator extends BaseTranslator
         $loaderIds = array(),
         array $options = array()
     ) {
-        $cacheUtils = $container->get('graviton.18n.cacheutils');
-        $options['resource_files'] = $cacheUtils->getResources($options['resource_files']);
+
+        $options['resource_files'] = $container
+            ->get('graviton.18n.cacheutils')
+            ->getResources($options['resource_files']);
+
         parent::__construct($container, $selector, $loaderIds, $options);
     }
 }

--- a/src/Graviton/I18nBundle/Translator/Translator.php
+++ b/src/Graviton/I18nBundle/Translator/Translator.php
@@ -18,19 +18,10 @@ class Translator extends BaseTranslator {
 
     public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
     {
+        $cacheUtils = $container->get('graviton.18n.cacheutils');
+        $options['resource_files'] = $cacheUtils->getResources($options['resource_files']);
 
-        print_r($options);
         parent::__construct($container, $selector, $loaderIds, $options);
-        print_r($this->options);
-        die;
-
-    }
-
-    protected function initialize()
-    {
-        print_r($this->loaderIds);
-        die;
-        parent::initialize();
     }
 
 }


### PR DESCRIPTION
this tries to solve the translation problems we observed mostly in the cloud. but it worked mostly locally.

**why did it not work in the cloud?**
at container build time, the translator resource files in the bundles that trigger the load (like `core.de.odm`) are searched and put as a *fixed* list in the *compiled* container.

as we added translations for new domains, they were never loaded as those files were never present at container build time. 

**why did it work locally (mostly)?**
locally, after we created some domains, it also created the trigger file (like `hans.de.odm`). as we develop, we often run a script like `dev-cleanstart.sh` - which rebuilds the container among other things. once we did that, translations for that domain did work.

so -> it never worked in the cloud because there, the container is never rebuilt after initial deployment.

**what this PR introduces**
* change the behavior of `PostPersistTranslatableListener`<br />instead of touching and/or removing files, this class now just dispatches an `Event` object.
* introduce the class `I18nUtilsCaching`<br />this class handles everything that concerns the handling of the cache as needed and feeds the `Translator` with the added files at runtime.
* introduce `I18nCachingListener`<br />Listens to the events from `PostPersistTranslatableListener` and calls the corresponding methods on `I18nUtilsCaching`.
* introduce a `Translator` that replaces the `FrameworkBundle\Translator`<br />It just adds one line where it calls `I18nUtilsCaching` as a away to inject the runtime added files into the Translation loader process.
* an integration test of the whole thing as well as a unit test just for the `I18nUtilsCaching` class.

**gains**
i really hope this change brings some performance improvements, also while running the unit tests. before, we touched and/or removed files at every doctrine persist event in `PostPersistTranslatableListener` and significant stuff has been done there.

now, all those `Event`s (and the resulting cache invalidations) are processed only once at the time the `Kernel` dispatches the `kernel.terminate` event. additionally, i remove the cached catalogue in just 1 `Finder` iteration.

**varia changes**
* the integration test of this feature *needs* to be on a *clean* cache. If we re-run the same test suite on an already existing cache, our runtime translation resources could already be picked up locally from the run before. so i introduced the cleaning of the `test` env in the phpunit bootstrap.
* i configured the `DoctrineCacheBundle` as I want to cache stuff I generate. If not, I must create the resulting array in every request. Note that this is the "Doctrine cache library", *not* the cache of doctrine that we use itself. 