### PR TITLE
47970 add elemmatch operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,10 @@
         {
             "type": "vcs",
             "url": "git@github.com:mrix/GravitonRqlParserBundle.git"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:mrix/GravitonTestServicesBundle.git"
         }
     ],
     "require": {
@@ -69,7 +73,7 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "dev-master",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "^0"
+        "graviton/test-services-bundle": "dev-47970-add-elemmatch-operator as 0.11.1"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,14 @@
         {
             "type": "composer",
             "url": "http://gravity-platform-packages.nova.scapp.io"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:mrix/php-rql-parser.git"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:mrix/GravitonRqlParserBundle.git"
         }
     ],
     "require": {
@@ -42,8 +50,8 @@
         "php-jsonpointer/php-jsonpointer": "~1.1@rc",
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
-        "graviton/php-rql-parser": "~2.0@alpha",
-        "graviton/rql-parser-bundle": "~0.9.0",
+        "graviton/php-rql-parser": "dev-47970-add-elemmatch-operator as 2.0.1",
+        "graviton/rql-parser-bundle": "dev-47970-add-elemmatch-operator as 0.9.1",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,6 @@
         {
             "type": "composer",
             "url": "http://gravity-platform-packages.nova.scapp.io"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:mrix/php-rql-parser.git"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:mrix/GravitonRqlParserBundle.git"
         }
     ],
     "require": {
@@ -50,8 +42,8 @@
         "php-jsonpointer/php-jsonpointer": "~1.1@rc",
         "exercise/htmlpurifier-bundle": "~0.1",
         "egulias/email-validator": "~1.2",
-        "graviton/php-rql-parser": "dev-47970-add-elemmatch-operator as 2.0.1",
-        "graviton/rql-parser-bundle": "dev-47970-add-elemmatch-operator as 0.9.1",
+        "graviton/php-rql-parser": ">=2.0.0-alpha15",
+        "graviton/rql-parser-bundle": "~0.10.0",
         "knplabs/knp-gaufrette-bundle": "^0.2@dev",
         "aws/aws-sdk-php": "~2.7",
         "eo/airbrake-bundle": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,6 @@
         {
             "type": "vcs",
             "url": "git@github.com:mrix/GravitonRqlParserBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:mrix/GravitonTestServicesBundle.git"
         }
     ],
     "require": {
@@ -73,7 +69,7 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "dev-master",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "dev-47970-add-elemmatch-operator as 0.11.1"
+        "graviton/test-services-bundle": "^0"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.lock
+++ b/composer.lock
@@ -1739,16 +1739,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "dev-47970-add-elemmatch-operator",
+            "version": "v2.0.0-alpha15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mrix/php-rql-parser.git",
-                "reference": "7289631e5ea3f6b738ee9f0794c9f47cac4b87aa"
+                "url": "https://github.com/libgraviton/php-rql-parser.git",
+                "reference": "5c5f4d18698e91d81b81ec1312a1d9abdf5b2925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/7289631e5ea3f6b738ee9f0794c9f47cac4b87aa",
-                "reference": "7289631e5ea3f6b738ee9f0794c9f47cac4b87aa",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/5c5f4d18698e91d81b81ec1312a1d9abdf5b2925",
+                "reference": "5c5f4d18698e91d81b81ec1312a1d9abdf5b2925",
                 "shasum": ""
             },
             "require": {
@@ -1770,19 +1770,7 @@
                     "Graviton\\Rql\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Graviton\\Rql\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards",
-                    "./vendor/bin/phpcs --standard=PSR1 --ignore='*.css' --ignore='*.js' src/ test/",
-                    "./vendor/bin/phpcs --standard=PSR2 --ignore='*.css' --ignore='*.js' src/ test/",
-                    "./vendor/bin/phpcs --standard=ENTB --ignore='*.css' --ignore='*.js' src/ test/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL"
             ],
@@ -1804,27 +1792,24 @@
                 "rest",
                 "rql"
             ],
-            "support": {
-                "source": "https://github.com/mrix/php-rql-parser/tree/47970-add-elemmatch-operator"
-            },
-            "time": "2015-10-19 09:43:02"
+            "time": "2015-10-20 10:09:06"
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "dev-47970-add-elemmatch-operator",
+            "version": "v0.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mrix/GravitonRqlParserBundle.git",
-                "reference": "d95c94c1a90d4f4852b8c412a918da05fc9feff5"
+                "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
+                "reference": "295f85880f0b54a632afc4a45ce21cd8dc482a2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/d95c94c1a90d4f4852b8c412a918da05fc9feff5",
-                "reference": "d95c94c1a90d4f4852b8c412a918da05fc9feff5",
+                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/295f85880f0b54a632afc4a45ce21cd8dc482a2a",
+                "reference": "295f85880f0b54a632afc4a45ce21cd8dc482a2a",
                 "shasum": ""
             },
             "require": {
-                "graviton/php-rql-parser": "dev-47970-add-elemmatch-operator",
+                "graviton/php-rql-parser": ">=2.0.0-alpha15",
                 "php": "~5.4",
                 "symfony/http-kernel": "~2.6"
             },
@@ -1841,19 +1826,7 @@
                     "Graviton\\RqlParserBundle\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Graviton\\RqlParserBundle\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards",
-                    "./vendor/bin/phpcs --standard=PSR1 --ignore='*.css' --ignore='*.js' src/ test/",
-                    "./vendor/bin/phpcs --standard=PSR2 --ignore='*.css' --ignore='*.js' src/ test/",
-                    "./vendor/bin/phpcs --standard=ENTB --ignore='*.css' --ignore='*.js' src/ test/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL"
             ],
@@ -1864,10 +1837,7 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "support": {
-                "source": "https://github.com/mrix/GravitonRqlParserBundle/tree/47970-add-elemmatch-operator"
-            },
-            "time": "2015-10-19 09:32:24"
+            "time": "2015-10-20 11:27:51"
         },
         {
             "name": "guzzle/guzzle",
@@ -5489,27 +5459,12 @@
             "time": "2015-09-09 00:18:50"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.0.1",
-            "alias_normalized": "2.0.1.0",
-            "version": "dev-47970-add-elemmatch-operator",
-            "package": "graviton/php-rql-parser"
-        },
-        {
-            "alias": "0.9.1",
-            "alias_normalized": "0.9.1.0",
-            "version": "dev-47970-add-elemmatch-operator",
-            "package": "graviton/rql-parser-bundle"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
         "doctrine/mongodb-odm": 10,
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
-        "graviton/php-rql-parser": 20,
-        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4357,16 +4357,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "dev-47970-add-elemmatch-operator",
+            "version": "v0.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mrix/GravitonTestServicesBundle.git",
-                "reference": "a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e"
+                "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
+                "reference": "51595263b0dbb49daf7f752318d62e11b7daa27d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonTestServicesBundle/zipball/a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e",
-                "reference": "a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/51595263b0dbb49daf7f752318d62e11b7daa27d",
+                "reference": "51595263b0dbb49daf7f752318d62e11b7daa27d",
                 "shasum": ""
             },
             "type": "library",
@@ -4381,9 +4381,10 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/mrix/GravitonTestServicesBundle/tree/47970-add-elemmatch-operator"
+                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/develop",
+                "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
             },
-            "time": "2015-10-19 05:41:42"
+            "time": "2015-10-19 08:05:16"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
@@ -5500,12 +5501,6 @@
             "alias_normalized": "0.9.1.0",
             "version": "dev-47970-add-elemmatch-operator",
             "package": "graviton/rql-parser-bundle"
-        },
-        {
-            "alias": "0.11.1",
-            "alias_normalized": "0.11.1.0",
-            "version": "dev-47970-add-elemmatch-operator",
-            "package": "graviton/test-services-bundle"
         }
     ],
     "minimum-stability": "dev",
@@ -5516,8 +5511,7 @@
         "graviton/php-rql-parser": 20,
         "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
-        "lapistano/proxy-object": 20,
-        "graviton/test-services-bundle": 20
+        "lapistano/proxy-object": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1743,12 +1743,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/php-rql-parser.git",
-                "reference": "844bc02bcf51670a7c63e8c75b01d6b5029c3db7"
+                "reference": "7289631e5ea3f6b738ee9f0794c9f47cac4b87aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/844bc02bcf51670a7c63e8c75b01d6b5029c3db7",
-                "reference": "844bc02bcf51670a7c63e8c75b01d6b5029c3db7",
+                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/7289631e5ea3f6b738ee9f0794c9f47cac4b87aa",
+                "reference": "7289631e5ea3f6b738ee9f0794c9f47cac4b87aa",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1807,7 @@
             "support": {
                 "source": "https://github.com/mrix/php-rql-parser/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-19 06:03:49"
+            "time": "2015-10-19 09:43:02"
         },
         {
             "name": "graviton/rql-parser-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4361,12 +4361,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/GravitonTestServicesBundle.git",
-                "reference": "5581019fbb79feef8ce60d5f33e3103bc1929a08"
+                "reference": "a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonTestServicesBundle/zipball/5581019fbb79feef8ce60d5f33e3103bc1929a08",
-                "reference": "5581019fbb79feef8ce60d5f33e3103bc1929a08",
+                "url": "https://api.github.com/repos/mrix/GravitonTestServicesBundle/zipball/a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e",
+                "reference": "a58cf55607e3b2259c2cfbc1e70a7d7b8c5d152e",
                 "shasum": ""
             },
             "type": "library",
@@ -4383,7 +4383,7 @@
             "support": {
                 "source": "https://github.com/mrix/GravitonTestServicesBundle/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-18 10:05:24"
+            "time": "2015-10-19 05:41:42"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/composer.lock
+++ b/composer.lock
@@ -1815,12 +1815,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/GravitonRqlParserBundle.git",
-                "reference": "c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c"
+                "reference": "d95c94c1a90d4f4852b8c412a918da05fc9feff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c",
-                "reference": "c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c",
+                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/d95c94c1a90d4f4852b8c412a918da05fc9feff5",
+                "reference": "d95c94c1a90d4f4852b8c412a918da05fc9feff5",
                 "shasum": ""
             },
             "require": {
@@ -1867,7 +1867,7 @@
             "support": {
                 "source": "https://github.com/mrix/GravitonRqlParserBundle/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-19 06:09:35"
+            "time": "2015-10-19 09:32:24"
         },
         {
             "name": "guzzle/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -1739,16 +1739,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "v2.0.0-alpha14",
+            "version": "dev-47970-add-elemmatch-operator",
             "source": {
                 "type": "git",
-                "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "31f551b3a8d55b43df115bed2cb8d51365cd9217"
+                "url": "https://github.com/mrix/php-rql-parser.git",
+                "reference": "fec7842798cde577fe5092b7f8630020b7fb0e7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/31f551b3a8d55b43df115bed2cb8d51365cd9217",
-                "reference": "31f551b3a8d55b43df115bed2cb8d51365cd9217",
+                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/fec7842798cde577fe5092b7f8630020b7fb0e7f",
+                "reference": "fec7842798cde577fe5092b7f8630020b7fb0e7f",
                 "shasum": ""
             },
             "require": {
@@ -1770,7 +1770,19 @@
                     "Graviton\\Rql\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Graviton\\Rql\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards",
+                    "./vendor/bin/phpcs --standard=PSR1 --ignore='*.css' --ignore='*.js' src/ test/",
+                    "./vendor/bin/phpcs --standard=PSR2 --ignore='*.css' --ignore='*.js' src/ test/",
+                    "./vendor/bin/phpcs --standard=ENTB --ignore='*.css' --ignore='*.js' src/ test/"
+                ]
+            },
             "license": [
                 "GPL"
             ],
@@ -1792,24 +1804,27 @@
                 "rest",
                 "rql"
             ],
-            "time": "2015-08-11 08:15:37"
+            "support": {
+                "source": "https://github.com/mrix/php-rql-parser/tree/47970-add-elemmatch-operator"
+            },
+            "time": "2015-10-16 09:33:06"
         },
         {
             "name": "graviton/rql-parser-bundle",
-            "version": "v0.9.0",
+            "version": "dev-47970-add-elemmatch-operator",
             "source": {
                 "type": "git",
-                "url": "https://github.com/libgraviton/GravitonRqlParserBundle.git",
-                "reference": "52212ada6a2d7ee970dccc839f8cb55ebbbfd929"
+                "url": "https://github.com/mrix/GravitonRqlParserBundle.git",
+                "reference": "db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonRqlParserBundle/zipball/52212ada6a2d7ee970dccc839f8cb55ebbbfd929",
-                "reference": "52212ada6a2d7ee970dccc839f8cb55ebbbfd929",
+                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f",
+                "reference": "db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f",
                 "shasum": ""
             },
             "require": {
-                "graviton/php-rql-parser": "~2.0@alpha",
+                "graviton/php-rql-parser": "dev-47970-add-elemmatch-operator",
                 "php": "~5.4",
                 "symfony/http-kernel": "~2.6"
             },
@@ -1826,7 +1841,19 @@
                     "Graviton\\RqlParserBundle\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Graviton\\RqlParserBundle\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "./vendor/bin/phpcs --config-set installed_paths ../../libgraviton/codesniffer/CodeSniffer/Standards",
+                    "./vendor/bin/phpcs --standard=PSR1 --ignore='*.css' --ignore='*.js' src/ test/",
+                    "./vendor/bin/phpcs --standard=PSR2 --ignore='*.css' --ignore='*.js' src/ test/",
+                    "./vendor/bin/phpcs --standard=ENTB --ignore='*.css' --ignore='*.js' src/ test/"
+                ]
+            },
             "license": [
                 "GPL"
             ],
@@ -1837,7 +1864,10 @@
                 }
             ],
             "description": "Port of the php-rql-parser into the world of Symfony 2.",
-            "time": "2015-08-13 10:45:35"
+            "support": {
+                "source": "https://github.com/mrix/GravitonRqlParserBundle/tree/47970-add-elemmatch-operator"
+            },
+            "time": "2015-10-16 10:15:40"
         },
         {
             "name": "guzzle/guzzle",
@@ -5459,13 +5489,27 @@
             "time": "2015-09-09 00:18:50"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.0.1",
+            "alias_normalized": "2.0.1.0",
+            "version": "dev-47970-add-elemmatch-operator",
+            "package": "graviton/php-rql-parser"
+        },
+        {
+            "alias": "0.9.1",
+            "alias_normalized": "0.9.1.0",
+            "version": "dev-47970-add-elemmatch-operator",
+            "package": "graviton/rql-parser-bundle"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "doctrine/mongodb-odm": 10,
         "doctrine/mongodb-odm-bundle": 10,
         "php-jsonpointer/php-jsonpointer": 5,
-        "graviton/php-rql-parser": 15,
+        "graviton/php-rql-parser": 20,
+        "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "lapistano/proxy-object": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4357,16 +4357,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.10.0",
+            "version": "dev-47970-add-elemmatch-operator",
             "source": {
                 "type": "git",
-                "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "94b56a1556324000b6f59edda1df1f54c873ede2"
+                "url": "https://github.com/mrix/GravitonTestServicesBundle.git",
+                "reference": "5581019fbb79feef8ce60d5f33e3103bc1929a08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/94b56a1556324000b6f59edda1df1f54c873ede2",
-                "reference": "94b56a1556324000b6f59edda1df1f54c873ede2",
+                "url": "https://api.github.com/repos/mrix/GravitonTestServicesBundle/zipball/5581019fbb79feef8ce60d5f33e3103bc1929a08",
+                "reference": "5581019fbb79feef8ce60d5f33e3103bc1929a08",
                 "shasum": ""
             },
             "type": "library",
@@ -4381,10 +4381,9 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.10.0",
-                "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
+                "source": "https://github.com/mrix/GravitonTestServicesBundle/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-05 08:09:36"
+            "time": "2015-10-18 10:05:24"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
@@ -5501,6 +5500,12 @@
             "alias_normalized": "0.9.1.0",
             "version": "dev-47970-add-elemmatch-operator",
             "package": "graviton/rql-parser-bundle"
+        },
+        {
+            "alias": "0.11.1",
+            "alias_normalized": "0.11.1.0",
+            "version": "dev-47970-add-elemmatch-operator",
+            "package": "graviton/test-services-bundle"
         }
     ],
     "minimum-stability": "dev",
@@ -5511,7 +5516,8 @@
         "graviton/php-rql-parser": 20,
         "graviton/rql-parser-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
-        "lapistano/proxy-object": 20
+        "lapistano/proxy-object": 20,
+        "graviton/test-services-bundle": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1743,12 +1743,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/php-rql-parser.git",
-                "reference": "5eb8c01f2e7afee5eaa81cd675a329e7aed7d037"
+                "reference": "844bc02bcf51670a7c63e8c75b01d6b5029c3db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/5eb8c01f2e7afee5eaa81cd675a329e7aed7d037",
-                "reference": "5eb8c01f2e7afee5eaa81cd675a329e7aed7d037",
+                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/844bc02bcf51670a7c63e8c75b01d6b5029c3db7",
+                "reference": "844bc02bcf51670a7c63e8c75b01d6b5029c3db7",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1807,7 @@
             "support": {
                 "source": "https://github.com/mrix/php-rql-parser/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-18 09:39:30"
+            "time": "2015-10-19 06:03:49"
         },
         {
             "name": "graviton/rql-parser-bundle",
@@ -1815,12 +1815,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/GravitonRqlParserBundle.git",
-                "reference": "92fccd395061e6252e558c60de75d022790b7bf1"
+                "reference": "c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/92fccd395061e6252e558c60de75d022790b7bf1",
-                "reference": "92fccd395061e6252e558c60de75d022790b7bf1",
+                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c",
+                "reference": "c78d6f1cd1f660e7cd5feb12f4b121896d2f7d7c",
                 "shasum": ""
             },
             "require": {
@@ -1867,7 +1867,7 @@
             "support": {
                 "source": "https://github.com/mrix/GravitonRqlParserBundle/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-18 07:19:46"
+            "time": "2015-10-19 06:09:35"
         },
         {
             "name": "guzzle/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -1743,12 +1743,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/php-rql-parser.git",
-                "reference": "fec7842798cde577fe5092b7f8630020b7fb0e7f"
+                "reference": "5eb8c01f2e7afee5eaa81cd675a329e7aed7d037"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/fec7842798cde577fe5092b7f8630020b7fb0e7f",
-                "reference": "fec7842798cde577fe5092b7f8630020b7fb0e7f",
+                "url": "https://api.github.com/repos/mrix/php-rql-parser/zipball/5eb8c01f2e7afee5eaa81cd675a329e7aed7d037",
+                "reference": "5eb8c01f2e7afee5eaa81cd675a329e7aed7d037",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1807,7 @@
             "support": {
                 "source": "https://github.com/mrix/php-rql-parser/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-16 09:33:06"
+            "time": "2015-10-18 09:39:30"
         },
         {
             "name": "graviton/rql-parser-bundle",
@@ -1815,12 +1815,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrix/GravitonRqlParserBundle.git",
-                "reference": "db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f"
+                "reference": "92fccd395061e6252e558c60de75d022790b7bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f",
-                "reference": "db09e9c21b91a5f5b1f11df2ee8bdc7c8123038f",
+                "url": "https://api.github.com/repos/mrix/GravitonRqlParserBundle/zipball/92fccd395061e6252e558c60de75d022790b7bf1",
+                "reference": "92fccd395061e6252e558c60de75d022790b7bf1",
                 "shasum": ""
             },
             "require": {
@@ -1867,7 +1867,7 @@
             "support": {
                 "source": "https://github.com/mrix/GravitonRqlParserBundle/tree/47970-add-elemmatch-operator"
             },
-            "time": "2015-10-16 10:15:40"
+            "time": "2015-10-18 07:19:46"
         },
         {
             "name": "guzzle/guzzle",

--- a/src/Graviton/CoreBundle/Tests/Controller/ElemMatchOperatorControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ElemMatchOperatorControllerTest.php
@@ -78,14 +78,18 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by simple field' => [
                 sprintf(
-                    'elemMatch(array,eq(type,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a')
                 ),
                 ['a'],
             ],
             'nothing by simple field' => [
                 sprintf(
-                    'elemMatch(array,eq(type,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('not-found')
                 ),
                 [],
@@ -93,7 +97,8 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by extref' => [
                 sprintf(
-                    'elemMatch(array,eq(%s,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$array'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/b')
                 ),
@@ -101,7 +106,8 @@ class ElemMatchOperatorControllerTest extends RestTestCase
             ],
             'nothing by extref' => [
                 sprintf(
-                    'elemMatch(array,eq(%s,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$array'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/not-found')
                 ),
@@ -110,16 +116,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by two condition' => [
                 sprintf(
-                    'elemMatch(array,and(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('A')
                 ),
                 ['a'],
             ],
             'nothing by two condition' => [
                 sprintf(
-                    'elemMatch(array,and(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('B')
                 ),
                 [],
@@ -127,7 +139,9 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by two condition with extref' => [
                 sprintf(
-                    'elemMatch(array,and(eq(type,%s),eq(%s,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/a')
@@ -136,7 +150,9 @@ class ElemMatchOperatorControllerTest extends RestTestCase
             ],
             'nothing by two condition with extref' => [
                 sprintf(
-                    'elemMatch(array,and(eq(type,%s),eq(%s,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/b')
@@ -146,16 +162,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by two array elements' => [
                 sprintf(
-                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('B')
                 ),
                 ['a'],
             ],
             'nothing by two array elements' => [
                 sprintf(
-                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('p'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('q')
                 ),
                 [],
@@ -163,16 +185,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by both documents' => [
                 sprintf(
-                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('X')
                 ),
                 ['a', 'x'],
             ],
             'nothing by both documents' => [
                 sprintf(
-                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('c'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('d')
                 ),
                 [],
@@ -180,14 +208,18 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by deep array' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,eq(type,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa')
                 ),
                 ['a'],
             ],
             'nothing by deep array' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,eq(type,%s))',
+                    'elemMatch(%s,eq(%s,%s))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('pp')
                 ),
                 [],
@@ -195,16 +227,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by deep and two condition' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('AA')
                 ),
                 ['a'],
             ],
             'nothing by deep and two condition' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('PP')
                 ),
                 [],
@@ -212,7 +250,9 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by deep and two condition with extref' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(%s,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/aa')
@@ -221,7 +261,9 @@ class ElemMatchOperatorControllerTest extends RestTestCase
             ],
             'nothing deep and by two condition with extref' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(%s,%s)))',
+                    'elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
                     $this->encodeRqlString('$ref'),
                     $this->encodeRqlString('http://localhost/core/module/bb')
@@ -231,16 +273,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by deep and two array elements' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('BB')
                 ),
                 ['a'],
             ],
             'nothing by deep and two array elements' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('pp'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('qq')
                 ),
                 [],
@@ -249,16 +297,22 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by deep and both documents' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('XX')
                 ),
                 ['a', 'x'],
             ],
             'nothing by deep and both documents' => [
                 sprintf(
-                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    'elemMatch(%s,or(eq(%s,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('$deep.$deep..$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('pp'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('QQ')
                 ),
                 [],
@@ -266,9 +320,14 @@ class ElemMatchOperatorControllerTest extends RestTestCase
 
             'by two elemMatch' => [
                 sprintf(
-                    'elemMatch(deep.deep,and(eq(name,%s),elemMatch(array,and(eq(type,%s),eq(name,%s)))))',
+                    'elemMatch(%s,and(eq(%s,%s),elemMatch(%s,and(eq(%s,%s),eq(%s,%s)))))',
+                    $this->encodeRqlString('$deep.$deep'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('A'),
+                    $this->encodeRqlString('$array'),
+                    $this->encodeRqlString('$type'),
                     $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$name'),
                     $this->encodeRqlString('AA')
                 ),
                 ['a'],

--- a/src/Graviton/CoreBundle/Tests/Controller/ElemMatchOperatorControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ElemMatchOperatorControllerTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * ElemMatchOperatorControllerTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use GravitonDyn\TestCaseElemMatchOperatorBundle\DataFixtures\MongoDB\LoadTestCaseElemMatchOperatorData;
+
+/**
+ * elemMatch() operator test
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ElemMatchOperatorControllerTest extends RestTestCase
+{
+    /**
+     * load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if (!class_exists(LoadTestCaseElemMatchOperatorData::class)) {
+            $this->markTestSkipped('TestCaseElemMatchOperator definition is not loaded');
+        }
+
+        $this->loadFixtures(
+            [LoadTestCaseElemMatchOperatorData::class],
+            null,
+            'doctrine_mongodb'
+        );
+    }
+
+    /**
+     * Test elemMatch() operator
+     *
+     * @param string $rqlQuery    RQL query
+     * @param array  $expectedIds Expected IDs
+     * @return void
+     *
+     * @dataProvider dataElemMatchOperator
+     */
+    public function testElemMatchOperator($rqlQuery, array $expectedIds)
+    {
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/elemmatch-operator/?'.$rqlQuery);
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $foundIds = array_map(
+            function ($item) {
+                return $item->id;
+            },
+            $client->getResults()
+        );
+
+        sort($expectedIds);
+        sort($foundIds);
+        $this->assertEquals($expectedIds, $foundIds);
+    }
+
+    /**
+     * Data for elemMatch() operator test
+     *
+     * @return array
+     */
+    public function dataElemMatchOperator()
+    {
+        return [
+            'all' => [
+                '',
+                ['a', 'x'],
+            ],
+
+            'by simple field' => [
+                sprintf(
+                    'elemMatch(array,eq(type,%s))',
+                    $this->encodeRqlString('a')
+                ),
+                ['a'],
+            ],
+            'nothing by simple field' => [
+                sprintf(
+                    'elemMatch(array,eq(type,%s))',
+                    $this->encodeRqlString('not-found')
+                ),
+                [],
+            ],
+
+            'by extref' => [
+                sprintf(
+                    'elemMatch(array,eq(%s,%s))',
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/b')
+                ),
+                ['a'],
+            ],
+            'nothing by extref' => [
+                sprintf(
+                    'elemMatch(array,eq(%s,%s))',
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/not-found')
+                ),
+                [],
+            ],
+
+            'by two condition' => [
+                sprintf(
+                    'elemMatch(array,and(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('A')
+                ),
+                ['a'],
+            ],
+            'nothing by two condition' => [
+                sprintf(
+                    'elemMatch(array,and(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('B')
+                ),
+                [],
+            ],
+
+            'by two condition with extref' => [
+                sprintf(
+                    'elemMatch(array,and(eq(type,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/a')
+                ),
+                ['a'],
+            ],
+            'nothing by two condition with extref' => [
+                sprintf(
+                    'elemMatch(array,and(eq(type,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/b')
+                ),
+                [],
+            ],
+
+            'by two array elements' => [
+                sprintf(
+                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('B')
+                ),
+                ['a'],
+            ],
+            'nothing by two array elements' => [
+                sprintf(
+                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('p'),
+                    $this->encodeRqlString('q')
+                ),
+                [],
+            ],
+
+            'by both documents' => [
+                sprintf(
+                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('a'),
+                    $this->encodeRqlString('X')
+                ),
+                ['a', 'x'],
+            ],
+            'nothing by both documents' => [
+                sprintf(
+                    'elemMatch(array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('c'),
+                    $this->encodeRqlString('d')
+                ),
+                [],
+            ],
+
+            'by deep array' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,eq(type,%s))',
+                    $this->encodeRqlString('aa')
+                ),
+                ['a'],
+            ],
+            'nothing by deep array' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,eq(type,%s))',
+                    $this->encodeRqlString('pp')
+                ),
+                [],
+            ],
+
+            'by deep and two condition' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('AA')
+                ),
+                ['a'],
+            ],
+            'nothing by deep and two condition' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('PP')
+                ),
+                [],
+            ],
+
+            'by deep and two condition with extref' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/aa')
+                ),
+                ['a'],
+            ],
+            'nothing deep and by two condition with extref' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,and(eq(type,%s),eq(%s,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('$ref'),
+                    $this->encodeRqlString('http://localhost/core/module/bb')
+                ),
+                [],
+            ],
+
+            'by deep and two array elements' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('BB')
+                ),
+                ['a'],
+            ],
+            'nothing by deep and two array elements' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('pp'),
+                    $this->encodeRqlString('qq')
+                ),
+                [],
+            ],
+
+
+            'by deep and both documents' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('XX')
+                ),
+                ['a', 'x'],
+            ],
+            'nothing by deep and both documents' => [
+                sprintf(
+                    'elemMatch(deep.deep..array,or(eq(type,%s),eq(name,%s)))',
+                    $this->encodeRqlString('pp'),
+                    $this->encodeRqlString('QQ')
+                ),
+                [],
+            ],
+
+            'by two elemMatch' => [
+                sprintf(
+                    'elemMatch(deep.deep,and(eq(name,%s),elemMatch(array,and(eq(type,%s),eq(name,%s)))))',
+                    $this->encodeRqlString('A'),
+                    $this->encodeRqlString('aa'),
+                    $this->encodeRqlString('AA')
+                ),
+                ['a'],
+            ],
+        ];
+    }
+
+    /**
+     * Encode RQL string
+     *
+     * @param string $string String
+     * @return string
+     */
+    private function encodeRqlString($string)
+    {
+        return strtr(
+            rawurlencode($string),
+            [
+                '-' => '%2D',
+                '_' => '%5F',
+                '.' => '%2E',
+                '~' => '%7E',
+            ]
+        );
+    }
+}

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RqlFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RqlFieldsCompilerPass.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * RqlFieldsCompilerPass class file
+ */
+
+namespace Graviton\DocumentBundle\DependencyInjection\Compiler;
+
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\Document;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\DocumentMap;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\ArrayField;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\EmbedMany;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\EmbedOne;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\Field;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RqlFieldsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @var DocumentMap
+     */
+    private $documentMap;
+
+    /**
+     * Constructor
+     *
+     * @param DocumentMap $documentMap Document map
+     */
+    public function __construct(DocumentMap $documentMap)
+    {
+        $this->documentMap = $documentMap;
+    }
+
+    /**
+     * Make extref fields map and set it to parameter
+     *
+     * @param ContainerBuilder $container container builder
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $map = [];
+
+        $services = array_keys($container->findTaggedServiceIds('graviton.rest'));
+        foreach ($services as $id) {
+            list($ns, $bundle, , $doc) = explode('.', $id);
+            if (empty($bundle) || empty($doc)) {
+                continue;
+            }
+
+            $className = $this->getServiceDocument(
+                $container->getDefinition($id),
+                $ns,
+                $bundle,
+                $doc
+            );
+            $rqlFields = $this->processDocument($this->documentMap->getDocument($className));
+            $routePrefix = strtolower($ns.'.'.$bundle.'.'.'rest'.'.'.$doc);
+
+            $map[$routePrefix.'.get'] = $rqlFields;
+            $map[$routePrefix.'.all'] = $rqlFields;
+        }
+
+        $container->setParameter('graviton.document.rql.fields', $map);
+    }
+
+    /**
+     * Get document class name from service
+     *
+     * @param Definition $service Service definition
+     * @param string     $ns      Bundle namespace
+     * @param string     $bundle  Bundle name
+     * @param string     $doc     Document name
+     * @return string
+     */
+    private function getServiceDocument(Definition $service, $ns, $bundle, $doc)
+    {
+        $tags = $service->getTag('graviton.rest');
+        if (!empty($tags[0]['collection'])) {
+            $doc = $tags[0]['collection'];
+            $bundle = $tags[0]['collection'];
+        }
+
+        if (strtolower($ns) === 'gravitondyn') {
+            $ns = 'GravitonDyn';
+        }
+
+        return sprintf(
+            '%s\\%s\\Document\\%s',
+            ucfirst($ns),
+            ucfirst($bundle).'Bundle',
+            ucfirst($doc)
+        );
+    }
+
+    /**
+     * Recursive doctrine document processing
+     *
+     * @param Document $document       Document
+     * @param string   $documentPrefix Document field prefix
+     * @param string   $exposedPrefix  Exposed field prefix
+     * @return array
+     */
+    private function processDocument(Document $document, $documentPrefix = '', $exposedPrefix = '')
+    {
+        $result = [];
+        foreach ($document->getFields() as $field) {
+            $result[$documentPrefix.$field->getFieldName()] = $exposedPrefix.$field->getExposedName();
+
+            if ($field instanceof ArrayField) {
+                $result[$documentPrefix.$field->getFieldName().'.0'] = $exposedPrefix.$field->getExposedName().'.0';
+            } elseif ($field instanceof EmbedOne) {
+                $result = array_merge(
+                    $result,
+                    $this->processDocument(
+                        $field->getDocument(),
+                        $documentPrefix.$field->getFieldName().'.',
+                        $exposedPrefix.$field->getExposedName().'.'
+                    )
+                );
+            } elseif ($field instanceof EmbedMany) {
+                $result[$documentPrefix.$field->getFieldName().'.0'] = $exposedPrefix.$field->getExposedName().'.0';
+                $result = array_merge(
+                    $result,
+                    $this->processDocument(
+                        $field->getDocument(),
+                        $documentPrefix.$field->getFieldName().'.0.',
+                        $exposedPrefix.$field->getExposedName().'.0.'
+                    )
+                );
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
+++ b/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
@@ -17,6 +17,7 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\ExtRefMappingCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\ExtRefFieldsCompilerPass;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\RqlFieldsCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\TranslatableFieldsCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\DocumentFieldNamesCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\DocumentFormFieldsCompilerPass;
@@ -85,6 +86,7 @@ class GravitonDocumentBundle extends Bundle implements GravitonBundleInterface
 
         $container->addCompilerPass(new ExtRefMappingCompilerPass());
         $container->addCompilerPass(new ExtRefFieldsCompilerPass($documentMap));
+        $container->addCompilerPass(new RqlFieldsCompilerPass($documentMap));
         $container->addCompilerPass(new TranslatableFieldsCompilerPass($documentMap));
         $container->addCompilerPass(new DocumentFormFieldsCompilerPass($documentMap));
         $container->addCompilerPass(new DocumentFormDataMapCompilerPass($documentMap));

--- a/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
+++ b/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
@@ -116,6 +116,10 @@ class ExtReferenceSearchListener
      */
     private function getDbRefValue($url)
     {
+        if ($url === null) {
+            return null;
+        }
+
         try {
             $extref = $this->converter->getExtReference($url);
             return \MongoDBRef::create($extref->getRef(), $extref->getId());

--- a/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
+++ b/src/Graviton/DocumentBundle/Listener/ExtReferenceSearchListener.php
@@ -12,10 +12,10 @@
 namespace Graviton\DocumentBundle\Listener;
 
 use Graviton\DocumentBundle\Service\ExtReferenceConverterInterface;
-use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Graviton\Rql\Event\VisitNodeEvent;
+use Graviton\Rql\Node\ElemMatchNode;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Graviton\Rql\Event\VisitNodeEvent;
 use Xiag\Rql\Parser\Node\Query\AbstractArrayOperatorNode;
 use Xiag\Rql\Parser\Node\Query\AbstractScalarOperatorNode;
 

--- a/src/Graviton/DocumentBundle/Listener/FieldNameSearchListener.php
+++ b/src/Graviton/DocumentBundle/Listener/FieldNameSearchListener.php
@@ -6,7 +6,7 @@
 namespace Graviton\DocumentBundle\Listener;
 
 use Graviton\Rql\Event\VisitNodeEvent;
-use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Graviton\Rql\Node\ElemMatchNode;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Xiag\Rql\Parser\Node\Query\AbstractComparisonOperatorNode;

--- a/src/Graviton/DocumentBundle/Listener/FieldNameSearchListener.php
+++ b/src/Graviton/DocumentBundle/Listener/FieldNameSearchListener.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * FieldNameSearchListener class file
+ */
+
+namespace Graviton\DocumentBundle\Listener;
+
+use Graviton\Rql\Event\VisitNodeEvent;
+use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Xiag\Rql\Parser\Node\Query\AbstractComparisonOperatorNode;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldNameSearchListener
+{
+    /**
+     * @var array
+     */
+    private $fields;
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * Constructor
+     *
+     * @param array        $fieldsMapping Fields mapping
+     * @param RequestStack $requestStack  Request stack
+     */
+    public function __construct(array $fieldsMapping, RequestStack $requestStack)
+    {
+        $this->fields = $fieldsMapping;
+        $this->request = $requestStack->getCurrentRequest();
+    }
+
+    /**
+     * @param VisitNodeEvent $event node event to visit
+     *
+     * @return VisitNodeEvent
+     */
+    public function onVisitNode(VisitNodeEvent $event)
+    {
+        $node = $event->getNode();
+        if (!$node instanceof AbstractComparisonOperatorNode) {
+            return $event;
+        }
+
+        $fieldName = $this->getDocumentFieldName($node->getField(), $event->getContext());
+        if ($fieldName === false) {
+            return $event;
+        }
+
+        $copy = clone $node;
+        $copy->setField(strtr($fieldName, ['.0.' => '.']));
+        $event->setNode($copy);
+        return $event;
+    }
+
+    /**
+     * Get document field name by query name
+     *
+     * @param string    $searchName  Exposed field name from RQL query
+     * @param \SplStack $nodeContext Current node context
+     * @return string|bool Field name or FALSE
+     */
+    private function getDocumentFieldName($searchName, \SplStack $nodeContext)
+    {
+        $route = $this->request->attributes->get('_route');
+        if (!isset($this->fields[$route])) {
+            throw new \LogicException(sprintf('No field mapping found for route "%s"', $route));
+        }
+
+        $fieldName = $searchName;
+        $fieldPrefix = '';
+        foreach ($nodeContext as $parentNode) {
+            if ($parentNode instanceof ElemMatchNode) {
+                $fieldName = $parentNode->getField().'.0.'.$fieldName;
+                $fieldPrefix = $parentNode->getField().'.0.'.$fieldPrefix;
+            }
+        }
+        $fieldName = strtr($fieldName, ['..' => '.0.']);
+        $fieldPrefix = strtr($fieldPrefix, ['..' => '.0.']);
+
+        $documentField = array_search($fieldName, $this->fields[$route], true);
+        if ($documentField === false) {
+            return false;
+        }
+        if ($fieldPrefix === '') {
+            return $documentField;
+        }
+
+        $documentPrefix = array_search(rtrim($fieldPrefix, '.'), $this->fields[$route], true);
+        if ($documentPrefix === false) {
+            return false;
+        }
+
+        $documentPrefix = $documentPrefix.'.';
+        if (strpos($documentField, $documentPrefix) !== 0) {
+            return false;
+        }
+
+        return substr($documentField, strlen($documentPrefix));
+    }
+}

--- a/src/Graviton/DocumentBundle/Resources/config/services.xml
+++ b/src/Graviton/DocumentBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
 
         <service id="graviton.document.listener.extreferencesearchlistener" class="%graviton.document.listener.extreferencesearchlistener.class%">
              <argument type="service" id="graviton.document.service.extrefconverter" />
-             <argument>%graviton.document.type.extref.fields%</argument>
+             <argument>%graviton.document.extref.fields%</argument>
              <argument type="service" id="request_stack"/>
              <tag name="kernel.event_listener" event="rql.visit.node" method="onVisitNode"/>
         </service>

--- a/src/Graviton/DocumentBundle/Resources/config/services.xml
+++ b/src/Graviton/DocumentBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="graviton.document.service.formdatamapper.class">Graviton\DocumentBundle\Service\FormDataMapper</parameter>
         <parameter key="graviton.document.service.extrefconverter.class">Graviton\DocumentBundle\Service\ExtReferenceConverter</parameter>
         <parameter key="graviton.document.listener.extreferencesearchlistener.class">Graviton\DocumentBundle\Listener\ExtReferenceSearchListener</parameter>
+        <parameter key="graviton.document.listener.fieldnamesearchlistener.class">Graviton\DocumentBundle\Listener\FieldNameSearchListener</parameter>
         <parameter key="graviton.document.form.datatransformer.extref.class">Graviton\DocumentBundle\Form\DataTransformer\ExtRefTransformer</parameter>
         <parameter key="graviton.document.form.type.extref.class">Graviton\DocumentBundle\Form\Type\ExtRefType</parameter>
         <parameter key="graviton.document.form.type.document.class">Graviton\DocumentBundle\Form\Type\DocumentType</parameter>
@@ -30,7 +31,12 @@
              <argument type="service" id="graviton.document.service.extrefconverter" />
              <argument>%graviton.document.extref.fields%</argument>
              <argument type="service" id="request_stack"/>
-             <tag name="kernel.event_listener" event="rql.visit.node" method="onVisitNode"/>
+             <tag name="kernel.event_listener" event="rql.visit.node" method="onVisitNode" priority="2"/>
+        </service>
+        <service id="graviton.document.listener.fieldnamesearchlistener" class="%graviton.document.listener.fieldnamesearchlistener.class%">
+            <argument>%graviton.document.rql.fields%</argument>
+            <argument type="service" id="request_stack"/>
+            <tag name="kernel.event_listener" event="rql.visit.node" method="onVisitNode" priority="1"/>
         </service>
         <service id="graviton.document.form.datatransformer.extref" class="%graviton.document.form.datatransformer.extref.class%">
             <argument type="service" id="graviton.document.service.extrefconverter"/>

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
@@ -50,41 +50,30 @@ class ExtRefFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('setParameter')
             ->with(
-                $this->equalTo('graviton.document.type.extref.fields'),
+                $this->equalTo('graviton.document.extref.fields'),
                 [
                     'gravitontest.document.rest.a.get' => [
-                        'ref'                         => '$exposedRefA',
+                        '$exposedRefA',
 
-                        'achild.ref'                  => 'achild.$exposedRefB',
-                        'achild.bchild.ref'           => 'achild.bchild.$exposedRefC',
-                        'achild.bchildren.0.ref'      => 'achild.bchildren.0.$exposedRefC',
+                        'achild.$exposedRefB',
+                        'achild.bchild.$exposedRefC',
+                        'achild.bchildren.0.$exposedRefC',
 
-                        'achildren.0.ref'             => 'achildren.0.$exposedRefB',
-                        'achildren.0.bchild.ref'      => 'achildren.0.bchild.$exposedRefC',
-                        'achildren.0.bchildren.0.ref' => 'achildren.0.bchildren.0.$exposedRefC',
+                        'achildren.0.$exposedRefB',
+                        'achildren.0.bchild.$exposedRefC',
+                        'achildren.0.bchildren.0.$exposedRefC',
                     ],
                     'gravitontest.document.rest.a.all' => [
-                        'ref'                         => '$exposedRefA',
+                        '$exposedRefA',
 
-                        'achild.ref'                  => 'achild.$exposedRefB',
-                        'achild.bchild.ref'           => 'achild.bchild.$exposedRefC',
-                        'achild.bchildren.0.ref'      => 'achild.bchildren.0.$exposedRefC',
+                        'achild.$exposedRefB',
+                        'achild.bchild.$exposedRefC',
+                        'achild.bchildren.0.$exposedRefC',
 
-                        'achildren.0.ref'             => 'achildren.0.$exposedRefB',
-                        'achildren.0.bchild.ref'      => 'achildren.0.bchild.$exposedRefC',
-                        'achildren.0.bchildren.0.ref' => 'achildren.0.bchildren.0.$exposedRefC',
+                        'achildren.0.$exposedRefB',
+                        'achildren.0.bchild.$exposedRefC',
+                        'achildren.0.bchildren.0.$exposedRefC',
                     ],
-                    'gravitontest.document.rest.a.patch' => [
-                        'ref'                         => '$exposedRefA',
-
-                        'achild.ref'                  => 'achild.$exposedRefB',
-                        'achild.bchild.ref'           => 'achild.bchild.$exposedRefC',
-                        'achild.bchildren.0.ref'      => 'achild.bchildren.0.$exposedRefC',
-
-                        'achildren.0.ref'             => 'achildren.0.$exposedRefB',
-                        'achildren.0.bchild.ref'      => 'achildren.0.bchild.$exposedRefC',
-                        'achildren.0.bchildren.0.ref' => 'achildren.0.bchildren.0.$exposedRefC',
-                    ]
                 ]
             );
 

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/RqlFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/RqlFieldsCompilerPassTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * RqlFieldsCompilerPassTest class file
+ */
+
+namespace Graviton\DocumentBundle\Tests\DependencyInjection\CompilerPass;
+
+use Graviton\DocumentBundle\DependencyInjection\Compiler\RqlFieldsCompilerPass;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\DocumentMap;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class RqlFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     */
+    public function testProcess()
+    {
+        $expectedReqult = [
+            'id'                            => 'id',
+            'key'                           => 'key',
+            'ref'                           => '$exposedRefA',
+
+            'achild'                        => 'achild',
+            'achild.id'                     => 'achild.id',
+            'achild.key'                    => 'achild.key',
+            'achild.ref'                    => 'achild.$exposedRefB',
+            'achild.bchild'                 => 'achild.bchild',
+            'achild.bchild.id'              => 'achild.bchild.id',
+            'achild.bchild.key'             => 'achild.bchild.key',
+            'achild.bchild.ref'             => 'achild.bchild.$exposedRefC',
+            'achild.bchildren'              => 'achild.bchildren',
+            'achild.bchildren.0'            => 'achild.bchildren.0',
+            'achild.bchildren.0.id'         => 'achild.bchildren.0.id',
+            'achild.bchildren.0.key'        => 'achild.bchildren.0.key',
+            'achild.bchildren.0.ref'        => 'achild.bchildren.0.$exposedRefC',
+
+            'achildren'                     => 'achildren',
+            'achildren.0'                   => 'achildren.0',
+            'achildren.0.id'                => 'achildren.0.id',
+            'achildren.0.key'               => 'achildren.0.key',
+            'achildren.0.ref'               => 'achildren.0.$exposedRefB',
+            'achildren.0.bchild'            => 'achildren.0.bchild',
+            'achildren.0.bchild.id'         => 'achildren.0.bchild.id',
+            'achildren.0.bchild.key'        => 'achildren.0.bchild.key',
+            'achildren.0.bchild.ref'        => 'achildren.0.bchild.$exposedRefC',
+            'achildren.0.bchildren'         => 'achildren.0.bchildren',
+            'achildren.0.bchildren.0'       => 'achildren.0.bchildren.0',
+            'achildren.0.bchildren.0.id'    => 'achildren.0.bchildren.0.id',
+            'achildren.0.bchildren.0.key'   => 'achildren.0.bchildren.0.key',
+            'achildren.0.bchildren.0.ref'   => 'achildren.0.bchildren.0.$exposedRefC',
+        ];
+
+        $serviceDouble = $this
+            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\Definition')
+            ->disableOriginalConstructor()
+            ->setMethods(['getTag'])
+            ->getMock();
+        $serviceDouble
+            ->expects($this->once())
+            ->method('getTag')
+            ->with('graviton.rest')
+            ->willReturn([]);
+
+        $containerDouble = $this
+            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('graviton.rest')
+            ->willReturn(['gravitonTest.document.controller.A' => []]);
+        $containerDouble
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with('gravitonTest.document.controller.A')
+            ->willReturn($serviceDouble);
+        $containerDouble
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                $this->equalTo('graviton.document.rql.fields'),
+                [
+                    'gravitontest.document.rest.a.get' => $expectedReqult,
+                    'gravitontest.document.rest.a.all' => $expectedReqult,
+                ]
+            );
+
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/extref')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/validation/extref')
+                ->name('*.xml')
+        );
+
+        $compilerPass = new RqlFieldsCompilerPass($documentMap);
+        $compilerPass->process($containerDouble);
+    }
+}

--- a/src/Graviton/DocumentBundle/Tests/Listener/ExtReferenceSearchListenerTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Listener/ExtReferenceSearchListenerTest.php
@@ -9,7 +9,7 @@ use Graviton\DocumentBundle\Entity\ExtReference;
 use Graviton\DocumentBundle\Listener\ExtReferenceSearchListener;
 use Graviton\DocumentBundle\Service\ExtReferenceConverterInterface;
 use Graviton\Rql\Event\VisitNodeEvent;
-use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Graviton\Rql\Node\ElemMatchNode;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Graviton/DocumentBundle/Tests/Listener/FieldNameSearchListenerTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Listener/FieldNameSearchListenerTest.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * FieldNameSearchListenerTest class file
+ */
+
+namespace Graviton\DocumentBundle\Tests\Listener;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Graviton\DocumentBundle\Listener\FieldNameSearchListener;
+use Graviton\Rql\Event\VisitNodeEvent;
+use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Xiag\Rql\Parser\AbstractNode;
+use Xiag\Rql\Parser\Node\Query\ScalarOperator\EqNode;
+use Xiag\Rql\Parser\Node\Query\AbstractComparisonOperatorNode;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class FieldNameSearchListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Request
+     */
+    private $request;
+    /**
+     * @var ParameterBag|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $requestAttrs;
+    /**
+     * @var RequestStack|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $requestStack;
+
+
+    /**
+     * Setup the test
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->requestAttrs = $this->getMockBuilder(ParameterBag::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
+
+        $this->request = new Request();
+        $this->request->attributes = $this->requestAttrs;
+
+        $this->requestStack = $this->getMockBuilder(RequestStack::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrentRequest'])
+            ->getMock();
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($this->request);
+
+        parent::setUp();
+    }
+
+    /**
+     * Create listener
+     *
+     * @param array $fields Field mapping
+     * @return FieldNameSearchListener
+     */
+    private function createListener(array $fields)
+    {
+        return new FieldNameSearchListener($fields, $this->requestStack);
+    }
+
+    /**
+     * Test FieldNameSearchListener::onVisitNode() with not query node
+     *
+     * @return void
+     */
+    public function testOnVisitNodeWithNotQueryNode()
+    {
+        $fieldMapping = [];
+
+        $this->requestAttrs->expects($this->never())
+            ->method('get');
+
+        $node = $this->getMockBuilder(AbstractNode::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new VisitNodeEvent($node, $builder, new \SplStack());
+        $listener = $this->createListener($fieldMapping);
+        $listener->onVisitNode($event);
+
+        $this->assertSame($node, $event->getNode());
+        $this->assertSame($builder, $event->getBuilder());
+    }
+
+    /**
+     * Test FieldNameSearchListener::onVisitNode() with not mapped route
+     *
+     * @return void
+     * @expectedException \LogicException
+     */
+    public function testOnVisitNodeWithNotMappedRoute()
+    {
+        $fieldMapping = [];
+
+        $this->requestAttrs->expects($this->once())
+            ->method('get')
+            ->with('_route')
+            ->willReturn('route.id');
+
+        $node = $this->getMockBuilder(AbstractComparisonOperatorNode::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node->expects($this->once())
+            ->method('getField')
+            ->willReturn('field');
+        $node->expects($this->never())
+            ->method('getValue');
+
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new VisitNodeEvent($node, $builder, new \SplStack());
+        $listener = $this->createListener($fieldMapping);
+        $listener->onVisitNode($event);
+    }
+
+    /**
+     * Test FieldNameSearchListener::onVisitNode() with not mapped field
+     *
+     * @return void
+     */
+    public function testOnVisitNodeWithNotMappedField()
+    {
+        $fieldMapping = ['route.id' => []];
+
+        $this->requestAttrs->expects($this->once())
+            ->method('get')
+            ->with('_route')
+            ->willReturn('route.id');
+
+        $node = $this->getMockBuilder(AbstractComparisonOperatorNode::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node->expects($this->once())
+            ->method('getField')
+            ->willReturn('field');
+        $node->expects($this->never())
+            ->method('getValue');
+
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new VisitNodeEvent($node, $builder, new \SplStack());
+        $listener = $this->createListener($fieldMapping);
+        $listener->onVisitNode($event);
+
+        $this->assertSame($node, $event->getNode());
+        $this->assertSame($builder, $event->getBuilder());
+    }
+
+    /**
+     * Test ExtReferenceSearchListener::onVisitNode() simple
+     *
+     * @return void
+     */
+    public function testOnVisitNodeSimple()
+    {
+        $fieldMapping = ['route.id' => ['field' => '$field']];
+        $fieldValue = 'field-value';
+
+        $this->requestAttrs->expects($this->once())
+            ->method('get')
+            ->with('_route')
+            ->willReturn('route.id');
+
+        $node = new EqNode('$field', $fieldValue);
+
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new VisitNodeEvent($node, $builder, new \SplStack());
+        $listener = $this->createListener($fieldMapping);
+        $listener->onVisitNode($event);
+
+        $this->assertNotSame($node, $event->getNode());
+        $this->assertSame($builder, $event->getBuilder());
+
+        $this->assertEquals(
+            new EqNode('field', $fieldValue),
+            $event->getNode()
+        );
+    }
+
+    /**
+     * Test FieldNameSearchListener::onVisitNode() with context
+     *
+     * @return void
+     */
+    public function testOnVisitNodeWithContext()
+    {
+        $fieldMapping = [
+            'route.id' => [
+                'array'             => '$array',
+                'array.0'           => '$array.0',
+                'array.0.field'     => '$array.0.$field',
+                'array.0.field.ref' => '$array.0.$field.$ref',
+            ],
+        ];
+        $fieldValue = 'field-value';
+
+        $this->requestAttrs->expects($this->once())
+            ->method('get')
+            ->with('_route')
+            ->willReturn('route.id');
+
+        $node = new EqNode('$field.$ref', $fieldValue);
+        $context = new \SplStack();
+        $context->push(new ElemMatchNode('$array', $node));
+
+
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new VisitNodeEvent($node, $builder, $context);
+        $listener = $this->createListener($fieldMapping);
+        $listener->onVisitNode($event);
+
+        $this->assertNotSame($node, $event->getNode());
+        $this->assertSame($builder, $event->getBuilder());
+
+        $this->assertEquals(
+            new EqNode('field.ref', $fieldValue),
+            $event->getNode()
+        );
+    }
+}

--- a/src/Graviton/DocumentBundle/Tests/Listener/FieldNameSearchListenerTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Listener/FieldNameSearchListenerTest.php
@@ -8,7 +8,7 @@ namespace Graviton\DocumentBundle\Tests\Listener;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Graviton\DocumentBundle\Listener\FieldNameSearchListener;
 use Graviton\Rql\Event\VisitNodeEvent;
-use Graviton\RqlParserBundle\Rql\Node\ElemMatchNode;
+use Graviton\Rql\Node\ElemMatchNode;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionHash.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionHash.php
@@ -153,10 +153,7 @@ class JsonDefinitionHash implements DefinitionElementInterface
     private function processFieldDefinitionsRecursive(DefinitionElementInterface $field)
     {
         if ($field instanceof JsonDefinitionField) {
-            $clone = clone $field->getDef();
-            $clone->setName(preg_replace('/^'.preg_quote($this->name, '/').'\.(\d+\.)*/', '', $clone->getName()));
-
-            return [$clone];
+            return [$this->cloneFieldDefinition($field->getDef())];
         } elseif ($field instanceof JsonDefinitionArray) {
             return $this->processFieldDefinitionsRecursive($field->getElement());
         } elseif ($field instanceof JsonDefinitionHash) {
@@ -165,11 +162,24 @@ class JsonDefinitionHash implements DefinitionElementInterface
                 function (array $subfields, DefinitionElementInterface $subfield) {
                     return array_merge($subfields, $this->processFieldDefinitionsRecursive($subfield));
                 },
-                []
+                $field->definition === null ? [] : [$this->cloneFieldDefinition($field->definition)]
             );
         }
 
         throw new \InvalidArgumentException(sprintf('Unknown field type "%s"', get_class($field)));
+    }
+
+    /**
+     * Clone field definition
+     *
+     * @param Schema\Field $field Field
+     * @return Schema\Field
+     */
+    private function cloneFieldDefinition(Schema\Field $field)
+    {
+        $clone = clone $field;
+        $clone->setName(preg_replace('/^'.preg_quote($this->name, '/').'\.(\d+\.)*/', '', $clone->getName()));
+        return $clone;
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
@@ -461,6 +461,14 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
                         (new Schema\Target())
                             ->addField(
                                 (new Schema\Field())
+                                    ->setName('b.0.c')
+                                    ->setType('hash')
+                                    ->setExposeAs('$c')
+                                    ->setDescription('description')
+                                    ->setRequired(false)
+                            )
+                            ->addField(
+                                (new Schema\Field())
                                     ->setName('b.0.c.d.e')
                                     ->setType('varchar')
                             )


### PR DESCRIPTION
This is a part of [EVO-623](https://issue.swisscom.ch/browse/EVO-623). This is needed for searching files by links using `elemMatch()` RQL operator:
* Added new functional test
* Added `RqlFieldsCompilerPass` to save `rql field <=> database field` mapping
* Added `FieldNameSearchListener` to map RQL field names to correct database names
* Fixed a small bug in JSON definition parsing

This depends on the following changes:
* [x] https://github.com/libgraviton/php-rql-parser/pull/54
* [x] https://github.com/libgraviton/GravitonRqlParserBundle/pull/28
* [x] https://github.com/libgraviton/GravitonTestServicesBundle/pull/19
* [x] docs update gravity-platform/doc#18
* [x] reference evo number in pr description
* [x] update local `composer.*` files

I will remove aliases from `composer.json` when they will be merged.