### PR TITLE
introduce means to change rendered urls by configuration

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,6 +8,10 @@ parameters:
     graviton.security.services.whitelist: {}
     graviton.rest.special_mimetypes: {}
 
+    graviton.router.host: null
+    graviton.router.port_http: null
+    graviton.router.port_https: null
+
     graviton.security.oauth.github.client_id: ~
     graviton.security.oauth.github.client_secret: ~
 

--- a/src/Graviton/CoreBundle/Listener/RequestHostListener.php
+++ b/src/Graviton/CoreBundle/Listener/RequestHostListener.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * A listener that globally modifies the Router Context if configured
+ */
+
+namespace Graviton\CoreBundle\Listener;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RequestHostListener
+{
+
+    /**
+     * router
+     *
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * host
+     *
+     * @var string
+     */
+    private $host;
+
+    /**
+     * configured port for http
+     *
+     * @var int
+     */
+    private $portHttp;
+
+    /**
+     * configured port for https
+     *
+     * @var int
+     */
+    private $portHttps;
+
+    /**
+     * constructor
+     *
+     * @param Router $router    router
+     * @param string $host      host
+     * @param int    $portHttp  port for http
+     * @param int    $portHttps port for https
+     */
+    public function __construct(Router $router, $host, $portHttp, $portHttps)
+    {
+        $this->router = $router;
+        $this->host = $host;
+        $this->portHttp = $portHttp;
+        $this->portHttps = $portHttps;
+    }
+
+    /**
+     * modify the router context params if configured
+     *
+     * @return void
+     */
+    public function onKernelRequest()
+    {
+        if (!is_null($this->host)) {
+            $this->router->getContext()->setHost($this->host);
+        }
+
+        if (!is_null($this->portHttp)) {
+            $this->router->getContext()->setHttpPort($this->portHttp);
+        }
+
+        if (!is_null($this->portHttps)) {
+            $this->router->getContext()->setHttpsPort($this->portHttps);
+        }
+    }
+}

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -12,6 +12,7 @@
         <parameter key="graviton.core.controller.product.class">Graviton\CoreBundle\Controller\ProductController</parameter>
         <parameter key="graviton.core.repository.product.class">Graviton\CoreBundle\Repository\ProductRepository</parameter>
         <parameter key="graviton.core.model.product.class">Graviton\CoreBundle\Model\Product</parameter>
+        <parameter key="graviton.core.listener.requesthost.class">Graviton\CoreBundle\Listener\RequestHostListener</parameter>
         <parameter key="graviton.core.document.product.class">Graviton\CoreBundle\Document\Product</parameter>
         <parameter key="graviton.core.service.coreutils.class">Graviton\CoreBundle\Service\CoreUtils</parameter>
         <parameter key="graviton.core.service.coreversionutils.class">Graviton\CoreBundle\Service\CoreVersionUtils</parameter>
@@ -82,6 +83,17 @@
             <argument type="string">%graviton.core.version.data%</argument>
         </service>
         <service id="graviton.core.model.version" class="%graviton.core.model.version.class%" parent="graviton.rest.model"/>
+
+        <!--request host listener -->
+        <service id="graviton.core.listener.requesthost"
+                 class="%graviton.core.listener.requesthost.class%">
+            <argument type="service" id="router"/>
+            <argument type="string">%graviton.router.host%</argument>
+            <argument type="string">%graviton.router.port_http%</argument>
+            <argument type="string">%graviton.router.port_https%</argument>
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
+        </service>
+
         <service id="graviton.core.controller.version"
                  class="Graviton\CoreBundle\Controller\VersionController" parent="graviton.rest.controller">
             <argument type="service" id="graviton.core.utils"/>


### PR DESCRIPTION
Graviton rightfully doesn't care what urls it generates (like `extref`s or self urls).. As long as it's resolvable by `Router` and the request actually hits us, we are fine..

In all future scenarios, Graviton will be proxyed by some component. Be it something like Tyk or Kong or some L-Backend - some component will be in front. This arises the need of content rewriting in the JSON. 

At our first client, it seems it goes to a point where we'll put L-Backend (a shrinked version of it only containing the `ProxyBundle` and `/api/auth`) on the same host as Graviton (= meaning same hostname). 
Under that scenario it would be optimal if Graviton generates the URL from the L-Backend - and as they are on the same host and L-Backend proxies the request) - no content and/or content rewriting is necessary anymore. Provided we can generate different URLs in the output - that is, that this PR introduces.

On a vanilla Graviton, there will be no changes nor will this be activated. But it facilitates proxying scenarios in the future massively..

