### PR TITLE
make PUT on /file *not* return a Location header

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -160,13 +160,7 @@ class FileController extends RestController
 
         $response->setStatusCode(Response::HTTP_NO_CONTENT);
 
-        // TODO: this not is correct for multiple uploaded files!!
-        // TODO: Probably use "Link" header to address this.
-        $locations = $this->determineRoutes($request->get('_route'), $files, ['put', 'putNoSlash']);
-        $response->headers->set(
-            'Location',
-            $locations[0]
-        );
+        // no service sends Location headers on PUT - /file shouldn't as well
 
         return $response;
     }

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -407,7 +407,7 @@ class FileControllerTest extends RestTestCase
         $response = $client->getResponse();
 
         $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertEquals('/file/myPersonalFile', $response->headers->get('location'));
+        $this->assertNotContains('location', $response->headers->all());
 
         // clean up
         $client = $this->createClient();


### PR DESCRIPTION
no service in Graviton returns a `Location` header on a `PUT` request. but `/file` does. this PR makes `/file` behave as any other service in this regard.

some clients wrongly try to follow present `Location` headers in all methods except `POST` - sending this will lead a browser like Chrome to try to make OPTIONS preflight request and/or directly GET the file - this is not what we want, especially with a service like `/file` that potentially serves big objects..