### PR TITLE
Added missing file id to request

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -84,6 +84,9 @@ class FileController extends RestController
         $fileData = $this->validateRequest($request, $response, $request->get('metadata'));
         $files = $this->fileManager->saveFiles($request, $this->getModel(), $fileData);
 
+        // store id of new record so we don't need to re-parse body later when needed
+        $request->attributes->set('id', $files[0]);
+
         // Set status code and content
         $response->setStatusCode(Response::HTTP_CREATED);
 

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -239,8 +239,10 @@ class FileControllerTest extends RestTestCase
         );
 
         $response = $client->getResponse();
+        $linkHeader = $response->headers->get('Link');
 
         $this->assertEquals(201, $response->getStatusCode());
+        $this->assertRegExp('@/file/[a-z0-9]{32}>; rel="self"@', $linkHeader);
     }
 
     /**
@@ -297,8 +299,11 @@ class FileControllerTest extends RestTestCase
             ['CONTENT_TYPE' => $contentType],
             false
         );
-        $this->assertEquals(201, $client->getResponse()->getStatusCode());
         $response = $client->getResponse();
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $linkHeader = $response->headers->get('Link');
+        $this->assertRegExp('@/file/[a-z0-9]{32}>; rel="self"@', $linkHeader);
 
         // re-fetch
         $client = static::createRestClient();
@@ -323,7 +328,9 @@ class FileControllerTest extends RestTestCase
         $client->request('GET', sprintf('/file/%s', $retData->id));
 
         $retData = $client->getResults();
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+
         $this->assertEquals(strlen($newData), $retData->metadata->size);
         $this->assertEquals($contentType, $retData->metadata->mime);
     }


### PR DESCRIPTION
fixes bug that _self link does not contain the id of the added document.