### PR TITLE
fix vanilla graviton deploy

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -2,7 +2,6 @@
   "ADMIN_EMAIL": "lucas.bickel@swisscom.com",
   "WEB_SERVER": "nginx",
   "PHP_VERSION": "{PHP_56_LATEST}",
-  "NGINX_VERSION": "{NGINX_17_LATEST}",
   "PHP_MODULES": ["cli", "fpm"],
   "PHP_EXTENSIONS": ["bz2", "zlib", "curl", "mcrypt", "mongo", "openssl"],
   "WEBDIR": "web",


### PR DESCRIPTION
this is needed to push vanilla graviton again, as the 'NGINX_17_LATEST' thingy is outdated in the php buildpack..