### PR TITLE
fix extref in hash

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -258,6 +258,52 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
+     * test if we can save & retrieve extrefs inside 'free form objects'
+     *
+     * @return void
+     */
+    public function testFreeFormExtRefs()
+    {
+        $minimalExample = $this->postCreationDataProvider()['minimal'][0];
+
+        $document = json_decode(
+            file_get_contents($minimalExample),
+            false
+        );
+
+        $document->id = 'dynextreftest';
+
+        // insert some refs!
+        $document->unstructuredObject = new \stdClass();
+        $document->unstructuredObject->testRef = new \stdClass();
+        $document->unstructuredObject->testRef->{'$ref'} = 'http://localhost/hans/showcase/500';
+
+        // let's go more deep..
+        $document->unstructuredObject->go = new \stdClass();
+        $document->unstructuredObject->go->more = new \stdClass();
+        $document->unstructuredObject->go->more->deep = new \stdClass();
+        $document->unstructuredObject->go->more->deep->{'$ref'} = 'http://localhost/hans/showcase/500';
+
+        // array?
+        $document->unstructuredObject->refArray = [];
+        $document->unstructuredObject->refArray[0] = new \stdClass();
+        $document->unstructuredObject->refArray[0]->{'$ref'} = 'http://localhost/core/app/dude';
+        $document->unstructuredObject->refArray[1] = new \stdClass();
+        $document->unstructuredObject->refArray[1]->{'$ref'} = 'http://localhost/core/app/dude2';
+
+        $client = static::createRestClient();
+        $client->put('/hans/showcase/'.$document->id, $document);
+
+        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request('GET', '/hans/showcase/'.$document->id);
+
+        // all still the same?
+        $this->assertEquals($document, $client->getResults());
+    }
+
+    /**
      * are extra fields denied?
      *
      * @return void

--- a/src/Graviton/DocumentBundle/Entity/ExtReference.php
+++ b/src/Graviton/DocumentBundle/Entity/ExtReference.php
@@ -42,7 +42,7 @@ class ExtReference implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        return ['$ref' => $this->ref, '$id' => $this->ref];
+        return ['$ref' => $this->ref, '$id' => $this->id];
     }
 
     /**

--- a/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
+++ b/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
@@ -71,15 +71,15 @@ class GravitonDocumentBundle extends Bundle implements GravitonBundleInterface
 
         $documentMap = new DocumentMap(
             (new Finder())
-                ->in(__DIR__.'/../..')
+                ->in(__DIR__ . '/../..')
                 ->path('Resources/config/doctrine')
                 ->name('*.mongodb.xml'),
             (new Finder())
-                ->in(__DIR__.'/../..')
+                ->in(__DIR__ . '/../..')
                 ->path('Resources/config/serializer')
                 ->name('*.xml'),
             (new Finder())
-                ->in(__DIR__.'/../..')
+                ->in(__DIR__ . '/../..')
                 ->path('Resources/config')
                 ->name('validation.xml')
         );
@@ -91,5 +91,17 @@ class GravitonDocumentBundle extends Bundle implements GravitonBundleInterface
         $container->addCompilerPass(new DocumentFormFieldsCompilerPass($documentMap));
         $container->addCompilerPass(new DocumentFormDataMapCompilerPass($documentMap));
         $container->addCompilerPass(new DocumentFieldNamesCompilerPass($documentMap));
+    }
+
+    /**
+     * boot bundle function
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $extRefConverter = $this->container->get('graviton.document.service.extrefconverter');
+        $customType = Type::getType('hash');
+        $customType->setExtRefConverter($extRefConverter);
     }
 }

--- a/src/Graviton/DocumentBundle/Types/HashType.php
+++ b/src/Graviton/DocumentBundle/Types/HashType.php
@@ -6,7 +6,9 @@
 namespace Graviton\DocumentBundle\Types;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use Graviton\DocumentBundle\Entity\ExtReference;
 use Graviton\DocumentBundle\Entity\Hash;
+use Graviton\DocumentBundle\Service\ExtReferenceConverterInterface;
 
 /**
  * Hash type
@@ -17,6 +19,26 @@ use Graviton\DocumentBundle\Entity\Hash;
  */
 class HashType extends Type
 {
+
+    /**
+     * extref converter
+     *
+     * @var ExtReferenceConverterInterface
+     */
+    private static $extRefConverter;
+
+    /**
+     * sets the converter
+     *
+     * @param ExtReferenceConverterInterface $converter converter
+     *
+     * @return void
+     */
+    public function setExtRefConverter(ExtReferenceConverterInterface $converter)
+    {
+        self::$extRefConverter = $converter;
+    }
+
     /**
      * Convert DB value to PHP representation
      *
@@ -25,7 +47,7 @@ class HashType extends Type
      */
     public static function convertToPhp($value)
     {
-        return is_array($value) ? new Hash($value) : null;
+        return is_array($value) ? new Hash(self::processDynExtRefs($value)) : null;
     }
 
     /**
@@ -36,15 +58,65 @@ class HashType extends Type
      */
     public static function convertToDb($value)
     {
+        $dbValue = null;
+
         if (is_array($value)) {
-            return (object) $value;
+            $dbValue = (object) $value;
         } elseif ($value instanceof \ArrayObject) {
-            return (object) $value->getArrayCopy();
+            $dbValue = (object) $value->getArrayCopy();
         } elseif (is_object($value)) {
-            return (object) get_object_vars($value);
-        } else {
-            return null;
+            $dbValue = (object) get_object_vars($value);
         }
+
+        if (!is_null($dbValue)) {
+            $dbValue = (object) self::processDynExtRefs($dbValue);
+        }
+
+        return $dbValue;
+    }
+
+    /**
+     * loops our structure recursively to find all $ref objects that need to be converted
+     * either from that or to that..
+     *
+     * @param mixed $input input structure
+     *
+     * @return array altered structure with replaced $ref objects
+     */
+    public static function processDynExtRefs($input)
+    {
+        if ($input instanceof \stdClass) {
+            if (!empty(get_object_vars($input))) {
+                $input = self::processDynExtRefs(get_object_vars($input));
+            }
+            return $input;
+        }
+
+        $externalRefFieldName = '$ref';
+        $internalRefFieldName = '_dynExtRef';
+
+        if (is_array($input)) {
+            foreach ($input as $key => $value) {
+                if ($key === $internalRefFieldName) {
+                    if (is_array($value) && isset($value['$ref']) && isset($value['$id'])) {
+                        $extRef = ExtReference::create($value['$ref'], $value['$id']);
+                        $input[$externalRefFieldName] = self::$extRefConverter->getUrl($extRef);
+                        unset($input[$internalRefFieldName]);
+                    }
+                } elseif ($key === $externalRefFieldName) {
+                    $extRef = self::$extRefConverter->getExtReference($value);
+                    $input[$internalRefFieldName] = $extRef->jsonSerialize();
+                    unset($input[$externalRefFieldName]);
+                } else {
+                    if (is_array($value)) {
+                        $value = self::processDynExtRefs($value);
+                    }
+                    $input[$key] = $value;
+                }
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Graviton/DocumentBundle/Types/HashType.php
+++ b/src/Graviton/DocumentBundle/Types/HashType.php
@@ -93,7 +93,7 @@ class HashType extends Type
         }
 
         $externalRefFieldName = '$ref';
-        $internalRefFieldName = '_dynExtRef';
+        $internalRefFieldName = 'ref';
 
         if (is_array($input)) {
             foreach ($input as $key => $value) {


### PR DESCRIPTION
so.. this one adds the ability to save and display extrefs inside hashes ('free form objects')
obviously, we have no idea where they can be.. so we need to recurse that hash..

**what it does**
* recurse the hash (**important:** remember, that we *only* recurse the current hash! so in a big service like *consultation*, only a subset of objects are hashes - and there, we iterate that one smaller subhash)
* if we find an `$ref` field, transform it to a mongodb ref and save it like that under a new name (it needs to be a new name as `$ref` would need an `$id` field on the *same level!*)
* on output, transform it back to `$ref` - we can spot our fields by the unique keyword fieldname
* for all extref stuff, we use the in-place `ExtRefConverter`

**drawbacks**
remember: this is a workaround. ~~but a bad one actually. once we get `consultations` saved like this, we need to manually migrate them to the newer format of *real* extrefs (because the presence of the `_dynExtRef` fieldname!)~~
*update*: i renamed the field we save to internally to `ref` - the same way it would be saved if it would be a real extref. this way, we don't need to migrate as long as the references will be named `$ref` in the service.

i thought about it and it should be fairly safe to do that. *only drawback now*: you *cannot* have a field named "ref" anywhere in the service or it'll try to convert it to a `$ref` - so if it doesn't contain a valid url, it will fail.. but we don't have this anyway..

**testing**
showcasecontroller test has been enhanced to test this..