### PR TITLE
EVO-1281 - make /core/version urls the same as all others (having / at the end)

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -6,7 +6,7 @@
   <route id="graviton.core.static.main.options" path="/" methods="OPTIONS">
     <default key="_controller">graviton.core.controller.main:optionsAction</default>
   </route>
-  <route id="graviton.core.static.version.get" path="/core/version" methods="GET">
+  <route id="graviton.core.static.version.get" path="/core/version/" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsAction</default>
   </route>
   <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version" methods="GET">

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
             <parameter>graviton.core.static.version.get</parameter>
         </parameter>
         <parameter key="graviton.core.main.path.whitelist" type="collection">
-            <parameter>/core/version</parameter>
+            <parameter>/core/version/</parameter>
         </parameter>
     </parameters>
     <services>

--- a/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
@@ -25,7 +25,7 @@ class VersionControllerTest extends RestTestCase
     public function testGetAllAction()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/version');
+        $client->request('GET', '/core/version/');
         $response = $client->getResponse();
 
         $this->assertContains('"self":', $response->getContent());


### PR DESCRIPTION
as said.. /core/version should be /core/version/ (with trailing slash) so it's consistent with all other services)