### PR TITLE
Wrong self-version in core/version

### DIFF
--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -211,16 +211,12 @@ class CoreVersionUtils
      * @param string $versionString SemVer version string
      * @return string
      */
-    private function checkVersionNumber($versionString)
+    public function checkVersionNumber($versionString)
     {
         try {
             $version = $this->semVerMatcher($versionString);
         } catch (InvalidArgumentException $e) {
-            if (substr_count($versionString, '.') === 3) {
-                $version = $this->cutVersionString($versionString);
-            } else {
-                $version = $versionString;
-            }
+            $version = $this->cutVersionString($versionString);
         }
 
         return $version;
@@ -265,12 +261,21 @@ class CoreVersionUtils
     private function cutVersionString($versionString)
     {
         $versionParts = explode('.', $versionString);
-        $versionString= sprintf(
-            'v%d.%d.%d',
-            $versionParts[0],
-            $versionParts[1],
-            $versionParts[2]
-        );
+
+        if (substr_count($versionString, '.') === 3) {
+            $versionString = sprintf(
+                'v%d.%d.%d',
+                $versionParts[0],
+                $versionParts[1],
+                $versionParts[2]
+            );
+        } elseif (substr_count($versionString, '.') === 1) {
+            $versionString = sprintf(
+                'v%d.%d.0',
+                $versionParts[0],
+                $versionParts[1]
+            );
+        }
 
         return $versionString;
     }

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -250,7 +250,7 @@ class CoreVersionUtils
             );
         }
 
-        return isset($matches['version']) ? $matches['version'] : $matches['branch'];
+        return !empty($matches['version']) ? $matches['version'] : $matches['branch'];
     }
 
     /**

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -235,17 +235,22 @@ class CoreVersionUtils
     private function semVerMatcher($versionString)
     {
         $matches = array();
-        $regex = '/^(?<version>[v]?[0-9]+\.[0-9]+\.[0-9]+)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?$/';
+
+        // Regular expression for root package ('self') on a tagged version
+        $tag = '^(?<version>[v]?[0-9]+\.[0-9]+\.[0-9]+)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?$';
+        // Regular expression for root package on a git branch
+        $branch = '^(?<branch>(dev\-){1}[0-9a-zA-Z\.\/\-\_]+)$';
+        $regex = sprintf('/%s|%s/', $tag, $branch);
 
         $matched = preg_match($regex, $versionString, $matches);
 
         if (!$matched) {
             throw new InvalidArgumentException(
-                '"' . $versionString . '" is not a valid SemVer'
+                sprintf('"%s" is not a valid SemVer', $versionString)
             );
         }
 
-        return $matches['version'];
+        return isset($matches['version']) ? $matches['version'] : $matches['branch'];
     }
 
     /**

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -73,10 +73,10 @@ class CoreVersionUtils
         $lines = explode(PHP_EOL, $output);
         $wrapper = array();
         foreach ($lines as $line) {
-            if (strpos($line, 'versions') !== false) {
-                list(, $wrapperVersion) = explode(':', $line, 2);
+            if (strpos($line, 'versions : *') !== false) {
+                list(, $wrapperVersion) = explode(': *', $line, 2);
                 $wrapper['id'] = 'self';
-                $wrapper['version'] = $this->getVersionNumber(trim(str_replace('*', '', $wrapperVersion)));
+                $wrapper['version'] = $this->getVersionNumber(trim($wrapperVersion));
                 break;
             }
         }

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -71,7 +71,7 @@ class CoreVersionUtils
     {
         $output = $this->runComposerInContext('show -s --no-ansi');
         $lines = explode(PHP_EOL, $output);
-        $wrapper = [];
+        $wrapper = array();
         foreach ($lines as $line) {
             if (strpos($line, 'versions') !== false) {
                 list(, $wrapperVersion) = explode(': *', $line, 2);
@@ -251,13 +251,10 @@ class CoreVersionUtils
      */
     private function normalizeVersionString($versionString, $prefix = 'v')
     {
-        $versionArray = explode('.', $versionString);
-        array_pop($versionArray);
-
         return sprintf(
             '%s%s',
             $prefix,
-            implode('.', $versionArray)
+            implode('.', explode('.', $versionString, -1))
         );
     }
 }

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -74,9 +74,9 @@ class CoreVersionUtils
         $wrapper = array();
         foreach ($lines as $line) {
             if (strpos($line, 'versions') !== false) {
-                list(, $wrapperVersion) = explode(': *', $line, 2);
+                list(, $wrapperVersion) = explode(':', $line, 2);
                 $wrapper['id'] = 'self';
-                $wrapper['version'] = $this->getVersionNumber(trim($wrapperVersion));
+                $wrapper['version'] = $this->getVersionNumber(trim(str_replace('*', '', $wrapperVersion)));
                 break;
             }
         }

--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -105,7 +105,7 @@ class CoreVersionUtils
                     $versions,
                     array(
                         'id' => $content[0],
-                        'version' => $this->checkVersionNumber($content[1])
+                        'version' => $content[1]
                     )
                 );
             }
@@ -250,6 +250,9 @@ class CoreVersionUtils
 
     /**
      * Changing the incorrect SemVer string to a valid one
+     *
+     * At the moment, we are getting the version of the root package ('self') using the
+     * 'composer show -s'-command. Unfortunately Composer is adding an unnecessary ending.
      *
      * @param string $versionString SemVer version string
      * @return string

--- a/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
@@ -22,7 +22,7 @@ class VersionControllerTest extends RestTestCase
      *
      * @return void
      */
-    public function testGetAllAction()
+    public function testVersionsAction()
     {
         $client = static::createRestClient();
         $client->request('GET', '/core/version');
@@ -30,6 +30,15 @@ class VersionControllerTest extends RestTestCase
 
         $this->assertContains('"self":', $response->getContent());
         $this->assertInternalType('string', $response->getContent());
+
+        $tagRegExp = '^([v]?[0-9]+\.[0-9]+\.[0-9]+)(-[0-9a-zA-Z.]+)?(\+[0-9a-zA-Z.]+)?$';
+        $branchRegExp = '^((dev\-){1}[0-9a-zA-Z\.\/\-\_]+)$';
+        $regExp = sprintf('/%s|%s/', $tagRegExp, $branchRegExp);
+
+        $content = json_decode($response->getContent());
+        foreach ($content->versions as $packageId => $packageVersion) {
+            $this->assertRegExp($regExp, $packageVersion);
+        }
     }
 
     /**

--- a/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
+++ b/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
@@ -31,10 +31,14 @@ class CoreVersionUtilsTest extends RestTestCase
      */
     public function testGetVersionNumber($versionString, $expectedVersion)
     {
-        $this->coreVersionUtils = $this->getMockBuilder('Graviton\CoreBundle\Service\CoreVersionUtils')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
+        $yamlDumper = $this->getMockBuilder('Symfony\Component\Yaml\Dumper')
             ->getMock();
+
+        $this->coreVersionUtils = new CoreVersionUtils(
+            'composer',
+            $this->getContainer()->getParameter('kernel.root_dir'),
+            $yamlDumper
+        );
 
         $returnedVersion = $this->coreVersionUtils->getVersionNumber($versionString);
         $this->assertEquals($expectedVersion, $returnedVersion);

--- a/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
+++ b/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
@@ -23,37 +23,35 @@ class CoreVersionUtilsTest extends RestTestCase
     private $coreVersionUtils;
 
     /**
-     * @dataProvider provideVersionNumberForCheck
+     * @dataProvider provideVersionStringForGet
      *
-     * @param string $versionToCheck  String which should be checked
+     * @param string $versionString   String which should be checked
      * @param string $expectedVersion Expected Version string
      * @return void
      */
-    public function testCheckVersionNumber($versionToCheck, $expectedVersion)
+    public function testGetVersionNumber($versionString, $expectedVersion)
     {
         $this->coreVersionUtils = $this->getMockBuilder('Graviton\CoreBundle\Service\CoreVersionUtils')
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
-        $returnedVersion = $this->coreVersionUtils->checkVersionNumber($versionToCheck);
+        $returnedVersion = $this->coreVersionUtils->getVersionNumber($versionString);
         $this->assertEquals($expectedVersion, $returnedVersion);
     }
 
     /**
-     * Data provider for testCheckVersionNumber
+     * Data provider for testGetVersionNumber
      *
      * @return array
      */
-    public function provideVersionNumberForCheck()
+    public function provideVersionStringForGet()
     {
         return array(
             array('1.2.3.4', 'v1.2.3'),
             array('1.2.3', '1.2.3'),
-            array('1.2','v1.2.0'),
             array('v1.2.3', 'v1.2.3'),
             array('v1.2.3-alpha1', 'v1.2.3'),
-            array('dev-master', 'dev-master'),
             array('dev-feature/test_branch', 'dev-feature/test_branch'),
             array('dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75', 'dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75')
         );

--- a/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
+++ b/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Basic functional test for CoreVersionUtils class
+ */
+
+namespace Graviton\CoreBundle\Tests\Service;
+
+use Graviton\CoreBundle\Service\CoreVersionUtils;
+use Graviton\TestBundle\Test\RestTestCase;
+
+/**
+ * @category GravitonCoreBundle
+ * @package  Graviton
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class CoreVersionUtilsTest extends RestTestCase
+{
+    /**l
+     * @var CoreVersionUtils
+     */
+    private $coreVersionUtils;
+
+    /**
+     * @dataProvider provideVersionNumberForCheck
+     *
+     * @param string $versionToCheck  String which should be checked
+     * @param string $expectedVersion Expected Version string
+     * @return void
+     */
+    public function testCheckVersionNumber($versionToCheck, $expectedVersion)
+    {
+        $this->coreVersionUtils = $this->getMockBuilder('Graviton\CoreBundle\Service\CoreVersionUtils')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $returnedVersion = $this->coreVersionUtils->checkVersionNumber($versionToCheck);
+        $this->assertEquals($expectedVersion, $returnedVersion);
+    }
+
+    /**
+     * Data provider for testCheckVersionNumber
+     *
+     * @return array
+     */
+    public function provideVersionNumberForCheck()
+    {
+        return array(
+            array('1.2.3.4', 'v1.2.3'),
+            array('1.2.3', '1.2.3'),
+            array('1.2','v1.2.0'),
+            array('v1.2.3', 'v1.2.3'),
+            array('v1.2.3-alpha1', 'v1.2.3'),
+            array('dev-master', 'dev-master'),
+            array('dev-feature/test_branch', 'dev-feature/test_branch'),
+            array('dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75', 'dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75')
+        );
+    }
+}


### PR DESCRIPTION
The core/version service returns the wrong version of the root package ('self'). We are reading the self-version out of a composer show command. Since there is no ('handwritten') version tag in the composer.json file anymore, composer gets the information from somewhere else. Composer adds a 4th version after the patch version for a reason that i could not figure out. Nevertheless, this 4th identifier adds no further information and is not SemVer-valid, so it has to be removed.