### PR TITLE
EVO-1280: fix normalizing strings

### DIFF
--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -251,10 +251,13 @@ class CoreVersionUtils
      */
     private function normalizeVersionString($versionString, $prefix = 'v')
     {
-        return sprintf(
-            '%s%s',
-            $prefix,
-            implode('.', explode('.', $versionString, -1))
-        );
+        if (substr_count($versionString, '.') === 3) {
+            return sprintf(
+                '%s%s',
+                $prefix,
+                implode('.', explode('.', $versionString, -1))
+            );
+        }
+        return $versionString;
     }
 }

--- a/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
+++ b/src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php
@@ -57,7 +57,8 @@ class CoreVersionUtilsTest extends RestTestCase
             array('v1.2.3', 'v1.2.3'),
             array('v1.2.3-alpha1', 'v1.2.3'),
             array('dev-feature/test_branch', 'dev-feature/test_branch'),
-            array('dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75', 'dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75')
+            array('dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75', 'dev-9d0b8cf7c7a607684e978a2777ebdd36e348ba75'),
+            array('No version set (parsed as 1.0.0)', 'No version set (parsed as 1.0.0)')
         );
     }
 }


### PR DESCRIPTION
The string normalizer implemented in #326 should only cut strings with 4 version parts. Version strings like "No version set (parsed as 1.0.0)" should be ignored.