### PR TITLE
Revert /core/version changes introduced in #325

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -6,7 +6,7 @@
   <route id="graviton.core.static.main.options" path="/" methods="OPTIONS">
     <default key="_controller">graviton.core.controller.main:optionsAction</default>
   </route>
-  <route id="graviton.core.static.version.get" path="/core/version/" methods="GET">
+  <route id="graviton.core.static.version.get" path="/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsAction</default>
   </route>
   <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version" methods="GET">

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
             <parameter>graviton.core.static.version.get</parameter>
         </parameter>
         <parameter key="graviton.core.main.path.whitelist" type="collection">
-            <parameter>/core/version/</parameter>
+            <parameter>/core/version</parameter>
         </parameter>
     </parameters>
     <services>

--- a/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/VersionControllerTest.php
@@ -25,7 +25,7 @@ class VersionControllerTest extends RestTestCase
     public function testVersionsAction()
     {
         $client = static::createRestClient();
-        $client->request('GET', '/core/version/');
+        $client->request('GET', '/core/version');
         $response = $client->getResponse();
 
         $this->assertContains('"self":', $response->getContent());


### PR DESCRIPTION
As it has been stated in #325, `/core/version` is indeed a resource, not a collection, so it should not have a trailing slash..

Was a mistake on my side, let's revert my changes