### PR TITLE
EVO-1389 Add PATCH method to "Access-Control-Allow-Methods" header

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -671,7 +671,7 @@ class AppControllerTest extends RestTestCase
 
         $response = $client->getResponse();
 
-        $this->assertCorsHeaders('GET, POST, PUT, DELETE, OPTIONS', $response);
+        $this->assertCorsHeaders('GET, POST, PUT, PATCH, DELETE, OPTIONS', $response);
     }
 
     /**
@@ -731,8 +731,7 @@ class AppControllerTest extends RestTestCase
         $this->assertIsAppSchema($results->items);
         $this->assertEquals('en', $results->items->properties->name->required[0]);
 
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals('GET, POST, PUT, DELETE, OPTIONS', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertCorsHeaders('GET, POST, PUT, PATCH, DELETE, OPTIONS', $response);
         $this->assertContains(
             'Link',
             explode(',', $response->headers->get('Access-Control-Expose-Headers'))

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -338,8 +338,7 @@ class FileControllerTest extends RestTestCase
         $this->assertEquals('array', $results->type);
         $this->assertIsFileSchema($results->items);
 
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals('GET, POST, PUT, DELETE, OPTIONS', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertCorsHeaders('GET, POST, PUT, PATCH, DELETE, OPTIONS', $response);
         $this->assertContains(
             'Link',
             explode(',', $response->headers->get('Access-Control-Expose-Headers'))

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -26,7 +26,7 @@ class TranslatableControllerTest extends RestTestCase
         $client = static::createRestClient();
 
         $client->request('OPTIONS', '/i18n/translatable/i18n-de-German');
-        $this->assertCorsHeaders('GET, POST, PUT, DELETE, OPTIONS', $client->getResponse());
+        $this->assertCorsHeaders('GET, POST, PUT, PATCH, DELETE, OPTIONS', $client->getResponse());
 
         $this->assertEmpty($client->getResults());
     }

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -582,7 +582,7 @@ class RestController
         $response->setStatusCode(Response::HTTP_OK);
 
         // enabled methods for CorsListener
-        $corsMethods = 'GET, POST, PUT, DELETE, OPTIONS';
+        $corsMethods = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
         try {
             $router = $this->getRouter();
             // if post route is available we assume everything is readable
@@ -623,7 +623,7 @@ class RestController
         }
 
         // enabled methods for CorsListener
-        $corsMethods = 'GET, POST, PUT, DELETE, OPTIONS';
+        $corsMethods = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
         try {
             $router = $this->getRouter();
             // if post route is available we assume everything is readable


### PR DESCRIPTION
This adds `PATCH` method to `Access-Control-Allow-Methods` header to prevent the error `XMLHttpRequest cannot load https://<url>. Method PATCH is not allowed by Access-Control-Allow-Methods` with enabled CORS checking.