### PR TITLE
Use full path when calling command

### DIFF
--- a/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
+++ b/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
@@ -70,7 +70,7 @@ class MongodbMigrateCommand extends Command
 
             $arguments = $input->getArguments();
             $arguments['command'] = 'mongodb:migrations:migrate';
-            $arguments['--configuration'] = $file->getRelativePathname();
+            $arguments['--configuration'] = $file->getPathname();
 
             $migrateInput = new ArrayInput($arguments);
             $returnCode = $command->run($migrateInput, $output);


### PR DESCRIPTION
The command fails miserably when it gets passed a path that does not start with /.