### PR TITLE
fixe like() searches on identifier fields

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/doctrine/App.mongodb.xml
+++ b/src/Graviton/CoreBundle/Resources/config/doctrine/App.mongodb.xml
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
   <document name="Graviton\CoreBundle\Document\App" repository-class="Graviton\CoreBundle\Repository\AppRepository">
-    <field fieldName="id" type="string" id="true" strategy="UUID"/>
+    <field fieldName="id" id="true" strategy="UUID"/>
     <field fieldName="name" type="string"/>
     <field fieldName="showInMenu" type="boolean"/>
     <field fieldName="order" type="int"/>

--- a/src/Graviton/CoreBundle/Resources/config/doctrine/Product.mongodb.xml
+++ b/src/Graviton/CoreBundle/Resources/config/doctrine/Product.mongodb.xml
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
   <document name="Graviton\CoreBundle\Document\Product" repository-class="Graviton\CoreBundle\Repository\ProductRepository">
-    <field fieldName="id" type="string" id="true" strategy="UUID"/>
+    <field fieldName="id" id="true" strategy="UUID"/>
     <field fieldName="name" type="hash"/>
   </document>
 </doctrine-mongo-mapping>

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -387,6 +387,33 @@ class ShowcaseControllerTest extends RestTestCase
     }
 
     /**
+     * Test to see if we can do like() searches on identifier fields
+     *
+     * @return void
+     */
+    public function testLikeSearchOnIdentifierField()
+    {
+        // Load fixtures
+        $this->loadFixtures(
+            ['GravitonDyn\ShowCaseBundle\DataFixtures\MongoDB\LoadShowCaseData'],
+            null,
+            'doctrine_mongodb'
+        );
+
+        $client = static::createRestClient();
+        $client->request('GET', '/hans/showcase/?like(id,5*)');
+
+        // we should only get 1 ;-)
+        $this->assertEquals(1, count($client->getResults()));
+
+        $client = static::createRestClient();
+        $client->request('GET', '/hans/showcase/?like(id,*0)');
+
+        // this should get both
+        $this->assertEquals(2, count($client->getResults()));
+    }
+
+    /**
      * Test PATCH for deep nested attribute
      *
      * @return void

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -21,7 +21,7 @@
 
   {% if idField is defined %}
       {% if hideIdField == false %}
-          <field fieldName="id" type="{{ idField.doctrineType }}" id="true" strategy="UUID" />
+          <field fieldName="id" id="true" strategy="UUID" />
       {% else %}
           <field fieldName="id" type="{{ idField.doctrineType }}" id="false"/>
           <field fieldName="realId" type="{{ idField.doctrineType }}" id="true" strategy="AUTO" />


### PR DESCRIPTION
i took a look at EVO-1782. this led me first to believe it's not that trivial.

after digging deeper and creating [this issue on the mongo-odm project](https://github.com/doctrine/mongodb-odm/issues/1294), it seems that there is an easy fix in our context.

as it turns out, we *wrongly* specify `type='string'` on identifier fields. this makes `mongo-odm` to use the `StringType` instead of the `CustomidType` what would be used otherwise and *also results in a string based ID in MongoDB*.

This is important as `StringType` casts everything to `string` (obviously) for ID based searches - `CustomidType` doesn't do that, it preserves the `\MongoRegex` instance.

So, removing `type='string'` from our generated services indeed allows the user to issue `like()` RQL expression on the `id` field! And it doesn't change anything in the DB, our IDs are still normal `String` fields.