### PR TITLE
Remove antimattr/mongodb-migrations-bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -80,7 +80,6 @@ class AppKernel extends Kernel
             new \HadesArchitect\JsonSchemaBundle\JsonSchemaBundle(),
             new \Graviton\JsonSchemaBundle\GravitonJsonSchemaBundle(),
             new \OldSound\RabbitMqBundle\OldSoundRabbitMqBundle(),
-            new \AntiMattr\Bundle\MongoDBMigrationsBundle\MongoDBMigrationsBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test', 'oauth_dev'))) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -196,10 +196,3 @@ old_sound_rabbit_mq:
                 routing_keys: %graviton.rabbitmq.consumer.dump.routingkeys%
             callback: graviton.rabbitmq.consumer.dump
 
-mongo_db_migrations:
-    collection_name: "migration_versions"
-    database_name: "%mongodb.default.server.db%"
-    dir_name: "%kernel.root_dir%/../src/Graviton/MigrationBundle/Migrations/MongoDB"
-    script_dir_name: "%kernel.root_dir%/scripts"
-    name: "MongoDB Migrations"
-    namespace: "Graviton\MigrationBundle\Migrations\MongoDB"

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "graviton/json-schema": "~0.4",
         "hadesarchitect/json-schema-bundle": "~0.1.0",
         "php-jsonpatch/php-jsonpatch": "1.2.2",
-        "antimattr/mongodb-migrations-bundle": ">=1.0.1",
         "antimattr/mongodb-migrations": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "518a602d40fe5c59488ebea8757162b1",
-    "content-hash": "49a32934ba14b9ac665de098c6d586b3",
+    "hash": "2cf467d9ada485ec46a3b07945be6965",
+    "content-hash": "5740822c227cdf97ac65b5bf7c26112c",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -68,22 +68,6 @@
                 "mongodb"
             ],
             "time": "2014-09-26 17:18:36"
-        },
-        {
-            "name": "antimattr/mongodb-migrations-bundle",
-            "version": "v1.0.1",
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/mongodb-migrations-bundle/zipball/150abde99715673908b6a81be4f8826a4d222c46",
-                "reference": null,
-                "shasum": null
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AntiMattr\\Bundle\\MongoDBMigrationsBundle\\": ""
-                }
-            }
         },
         {
             "name": "aws/aws-sdk-php",

--- a/src/Graviton/MigrationBundle/Command/Helper/DocumentManager.php
+++ b/src/Graviton/MigrationBundle/Command/Helper/DocumentManager.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * helper to access document manager in commands
+ */
+
+namespace Graviton\MigrationBundle\Command\Helper;
+
+use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Helper\Helper;
+use Doctrine\ODM\MongoDB\DocumentManager as DoctrineDocumentManager;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class DocumentManager extends Helper implements HelperInterface
+{
+    /**
+     * @var DoctrineDocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @param DoctrineDocumentManager $documentManager document manager for console apps
+     */
+    public function __construct(DoctrineDocumentManager $documentManager)
+    {
+        $this->documentManager = $documentManager;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'dm';
+    }
+
+    /**
+     * @return DoctrineDocumentManager
+     */
+    public function getDocumentManager()
+    {
+        return $this->documentManager;
+    }
+}

--- a/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
+++ b/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
@@ -84,8 +84,9 @@ class MongodbMigrateCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $base = strpos(getcwd(), 'vendor/') === false ? getcwd() :  getcwd() . '/../../../../';
-        $this->finder->in($base)->path('Resources/config')->name('/migrations.(xml|yml)/')->files();
+        $this->finder->in(
+            strpos(getcwd(), 'vendor/') === false ? getcwd() :  getcwd() . '/../../../../'
+        )->path('Resources/config')->name('/migrations.(xml|yml)/')->files();
 
         foreach ($this->finder as $file) {
             if (!$file->isFile()) {

--- a/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
+++ b/src/Graviton/MigrationBundle/Command/MongodbMigrateCommand.php
@@ -87,11 +87,11 @@ class MongodbMigrateCommand extends Command
             $helperSet->set($this->documentManager, 'dm');
             $command->setHelperSet($helperSet);
 
+            $command->setMigrationConfiguration($this->getConfiguration($file->getPathname(), $output));
+
             $arguments = $input->getArguments();
             $arguments['command'] = 'mongodb:migrations:migrate';
             $arguments['--configuration'] = $file->getPathname();
-
-            $command->setMigrationConfiguration($this->getConfiguration($file->getPathname(), $output));
 
             $migrateInput = new ArrayInput($arguments);
             $returnCode = $command->run($migrateInput, $output);
@@ -129,9 +129,12 @@ class MongodbMigrateCommand extends Command
         $class = $info['extension'] === 'xml' ? 'XmlConfiguration' : 'YamlConfiguration';
         $class = sprintf('%s\%s', $namespace, $class);
         $configuration = new $class($this->documentManager->getDocumentManager()->getConnection(), $outputWriter);
-        $configuration->load($filepath);
 
+        // register databsae name before loading to ensure that loading does not fail
         $configuration->setMigrationsDatabaseName($this->databaseName);
+
+        // load additional config from migrations.(yml|xml)
+        $configuration->load($filepath);
 
         return $configuration;
     }

--- a/src/Graviton/MigrationBundle/Resources/config/services.xml
+++ b/src/Graviton/MigrationBundle/Resources/config/services.xml
@@ -3,15 +3,40 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <parameters>
-    <parameter key="graviton.migrate.command.mongodb_migrate.class">Graviton\MigrationBundle\Command\MongodbMigrateCommand</parameter>
+    <parameter key="graviton.migrate.command.graviton_migrate.class">Graviton\MigrationBundle\Command\MongodbMigrateCommand</parameter>
     <parameter key="graviton.migrate.config_finder.class">Symfony\Component\Finder\Finder</parameter>
+    <parameter key="graviton.migrate.document_manager_helper.class">Graviton\MigrationBundle\Command\Helper\DocumentManager</parameter>
+    <parameter key="graviton.migrate.command.execute.class">AntiMattr\MongoDB\Migrations\Tools\Console\Command\ExecuteCommand</parameter>
+    <parameter key="graviton.migrate.command.generate.class">AntiMattr\MongoDB\Migrations\Tools\Console\Command\GenerateCommand</parameter>
+    <parameter key="graviton.migrate.command.migrate.class">AntiMattr\MongoDB\Migrations\Tools\Console\Command\MigrateCommand</parameter>
+    <parameter key="graviton.migrate.command.status.class">AntiMattr\MongoDB\Migrations\Tools\Console\Command\StatusCommand</parameter>
+    <parameter key="graviton.migrate.command.version.class">AntiMattr\MongoDB\Migrations\Tools\Console\Command\VersionCommand</parameter>
   </parameters>
   <services>
-    <service id="graviton.migrate.config_finder" class="%graviton.migrate.config_finder.class%">
+    <service id="graviton.migrate.config_finder" class="%graviton.migrate.config_finder.class%"/>
+    <service id="graviton.migrate.document_manager_helper" class="%graviton.migrate.document_manager_helper.class%">
+      <argument type="service" id="doctrine_mongodb.odm.default_document_manager"/>
     </service>
-    <service id="graviton.migrate.command.mongodb_migrate" class="%graviton.migrate.command.mongodb_migrate.class%">
-      <argument  type="service" id="graviton.migrate.config_finder"/>
+    <service id="graviton.migrate.command.graviton_migrate" class="%graviton.migrate.command.graviton_migrate.class%">
+      <argument type="service" id="graviton.migrate.config_finder"/>
+      <argument type="service" id="graviton.migrate.document_manager_helper"/>
+      <argument>%mongodb.default.server.db%</argument>
       <tag name="console.command"/>
+    </service>
+    <service id="graviton.migrate.command.execute" class="%graviton.migrate.command.execute.class%">
+      <tag name="console.command" />
+    </service>
+    <service id="graviton.migrate.command.generate" class="%graviton.migrate.command.generate.class%">
+      <tag name="console.command" />
+    </service>
+    <service id="graviton.migrate.command.migrate" class="%graviton.migrate.command.migrate.class%">
+      <tag name="console.command" />
+    </service>
+    <service id="graviton.migrate.command.status" class="%graviton.migrate.command.status.class%">
+      <tag name="console.command" />
+    </service>
+    <service id="graviton.migrate.command.version" class="%graviton.migrate.command.version.class%">
+      <tag name="console.command" />
     </service>
   </services>
 </container>

--- a/src/Graviton/MigrationBundle/Resources/config/services.xml
+++ b/src/Graviton/MigrationBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
       <argument type="service" id="doctrine_mongodb.odm.default_document_manager"/>
     </service>
     <service id="graviton.migrate.command.graviton_migrate" class="%graviton.migrate.command.graviton_migrate.class%">
+      <argument type="service" id="service_container"/>
       <argument type="service" id="graviton.migrate.config_finder"/>
       <argument type="service" id="graviton.migrate.document_manager_helper"/>
       <argument>%mongodb.default.server.db%</argument>


### PR DESCRIPTION
This replaced the bundle with some code under our own control. For the most part I needed to do this since it was rather hard to override some of the internals of the commands in the bundle.

This PR uses the symfony dic to configure the *raw* command from antimattr/mongodb-migrations in the simplest possible fashion. When calling the commands using ``graviton:mongodb:migrate`` it injects the needed config as a helper and makes sure to do so early enough.