### PR TITLE
EVO-1383 fix datetime deserialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git"
+            "url": "https://github.com/mrix/GravitonTestServicesBundle.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
         {
             "type": "composer",
             "url": "https://gravity-platform-packages.scapp.io"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git"
         }
     ],
     "require": {
@@ -62,7 +66,7 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "dev-master",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "*"
+        "graviton/test-services-bundle": "dev-EVO-1383-fix-datetime-deserialization"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8134a19dce03d8457b957294e47b33ce",
-    "content-hash": "4e8c5031963f91bf0910c8893863e21c",
+    "hash": "46ad07ee45785eb235fc20b24f9dfe1b",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -4422,19 +4421,18 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.14.0",
+            "version": "dev-EVO-1383-fix-datetime-deserialization",
             "source": {
                 "type": "git",
-                "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "a4e11103f9e1478db2b685bf24d67641f4d0cdd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/a4e11103f9e1478db2b685bf24d67641f4d0cdd2",
-                "reference": "a4e11103f9e1478db2b685bf24d67641f4d0cdd2",
-                "shasum": ""
+                "url": "/sync/GravitonTestServicesBundle",
+                "reference": "59b4c0aedeae491573921b5d014ebed12ab074c7"
             },
             "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Graviton\\TestServiceBundle\\": "src/"
+                }
+            },
             "license": [
                 "GPL"
             ],
@@ -4445,11 +4443,7 @@
                 }
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
-            "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.14.0",
-                "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
-            },
-            "time": "2015-11-06 11:00:33"
+            "time": "2015-12-10 05:54:42"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
@@ -5560,7 +5554,8 @@
     "stability-flags": {
         "php-jsonpointer/php-jsonpointer": 5,
         "knplabs/knp-gaufrette-bundle": 20,
-        "lapistano/proxy-object": 20
+        "lapistano/proxy-object": 20,
+        "graviton/test-services-bundle": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "46ad07ee45785eb235fc20b24f9dfe1b",
+    "hash": "6a257b4688400065b56765fce1f7f2f0",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -4424,13 +4424,19 @@
             "version": "dev-EVO-1383-fix-datetime-deserialization",
             "source": {
                 "type": "git",
-                "url": "/sync/GravitonTestServicesBundle",
-                "reference": "59b4c0aedeae491573921b5d014ebed12ab074c7"
+                "url": "https://github.com/mrix/GravitonTestServicesBundle.git",
+                "reference": "16376a98c8b60dacf8b35994492aa613b15c66cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mrix/GravitonTestServicesBundle/zipball/16376a98c8b60dacf8b35994492aa613b15c66cd",
+                "reference": "16376a98c8b60dacf8b35994492aa613b15c66cd",
+                "shasum": ""
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Graviton\\TestServiceBundle\\": "src/"
+                    "Graviton\\TestServicesBundle\\": "src/"
                 }
             },
             "license": [
@@ -4443,7 +4449,10 @@
                 }
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
-            "time": "2015-12-10 05:54:42"
+            "support": {
+                "source": "https://github.com/mrix/GravitonTestServicesBundle/tree/EVO-1383-fix-datetime-deserialization"
+            },
+            "time": "2015-12-10 11:56:55"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/src/Graviton/CoreBundle/Tests/Controller/DatetimeDeserializationControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/DatetimeDeserializationControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * DatetimeDeserializationControllerTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use GravitonDyn\TestCaseDatetimeDeserializationBundle\Document\TestCaseDatetimeDeserialization;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class DatetimeDeserializationControllerTest extends RestTestCase
+{
+    /**
+     * Set up the test
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if (!class_exists(TestCaseDatetimeDeserialization::class)) {
+            $this->markTestSkipped(sprintf('%s definition is not loaded', TestCaseDatetimeDeserialization::class));
+        }
+    }
+
+    /**
+     * Test datetime deserialization and serialization
+     *
+     * @return void
+     */
+    public function testDateDesrialization()
+    {
+        $data = (object) [
+            'datetime'  => '2015-12-10T12:02:16+0000',
+            'datetimes' => [
+                '2015-12-10T10:02:16+0000',
+                '2015-12-11T11:02:16+0000',
+                '2015-12-12T12:02:16+0000',
+            ],
+        ];
+
+        $client = static::createRestClient();
+        $client->post('/testcase/datetime-deserialization/', $data);
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertEquals($data, $client->getResults());
+    }
+}

--- a/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/DateArrayFieldBuilder.php
+++ b/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/DateArrayFieldBuilder.php
@@ -51,7 +51,7 @@ class DateArrayFieldBuilder implements FieldBuilderInterface
 
         $options['type'] = 'datetime';
         $options['options']['widget'] = 'single_text';
-        $options['options']['input'] = 'string';
+        $options['options']['input'] = 'datetime';
 
         $form->add($name, 'collection', $options);
     }

--- a/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/DateFieldBuilder.php
+++ b/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/DateFieldBuilder.php
@@ -47,7 +47,7 @@ class DateFieldBuilder implements FieldBuilderInterface
         $submittedData = null
     ) {
         $options['widget'] = 'single_text';
-        $options['input'] = 'string';
+        $options['input'] = 'datetime';
 
         $form->add($name, $type, $options);
     }

--- a/src/Graviton/DocumentBundle/Tests/Form/Type/FieldBuilder/DateArrayFieldBuilderTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Form/Type/FieldBuilder/DateArrayFieldBuilderTest.php
@@ -79,7 +79,7 @@ class DateArrayFieldBuilderTest extends \PHPUnit_Framework_TestCase
                         'type' => 'datetime',
                         'allow_add' => true,
                         'allow_delete' => true,
-                        'options' => ['widget' => 'single_text', 'input' => 'string'],
+                        'options' => ['widget' => 'single_text', 'input' => 'datetime'],
                     ]
                 )
             );

--- a/src/Graviton/DocumentBundle/Tests/Form/Type/FieldBuilder/DateFieldBuilderTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Form/Type/FieldBuilder/DateFieldBuilderTest.php
@@ -68,7 +68,7 @@ class DateFieldBuilderTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $form->expects($this->once())
             ->method('add')
-            ->with($name, $type, array_merge($options, ['widget' => 'single_text', 'input' => 'string']));
+            ->with($name, $type, array_merge($options, ['widget' => 'single_text', 'input' => 'datetime']));
 
         $sut = new DateFieldBuilder();
         $sut->buildField($document, $form, $name, $type, $options, $data);

--- a/src/Graviton/RestBundle/Validator/Constraints/ReadOnly/ReadOnlyValidator.php
+++ b/src/Graviton/RestBundle/Validator/Constraints/ReadOnly/ReadOnlyValidator.php
@@ -8,6 +8,7 @@ namespace Graviton\RestBundle\Validator\Constraints\ReadOnly;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
 
 /**
  * Validator for read only
@@ -52,7 +53,6 @@ class ReadOnlyValidator extends ConstraintValidator
             $storedValue = $this->getStoredValueByPath($this->context->getPropertyPath(), $record);
 
             if ($storedValue instanceof \DateTime) {
-                $value = new \DateTime($value);
                 $isEqual = ($storedValue == $value);
             } else {
                 $isEqual = ($value === $storedValue);


### PR DESCRIPTION
This fixes the input format of date fields (see http://symfony.com/doc/current/reference/forms/types/datetime.html#input).
Current implementation returns date values as strings in `$form->getData()`.
Such behavior doesn't allow to implement services like calculators, where we have to respond immediately with given data.


I added the new test. Without my changes the test throws the exception:
```
DatetimeDeserializationTestController.php on line 41:
Graviton\ExceptionBundle\Exception\SerializationException {#2283
  -statusCode: 500
  -headers: []
  #message: """
    exception 'JMS\Serializer\Exception\LogicException' with message 'Expected object but got string. Do you have the wrong @Type mapping or could this be a Doctrine many-to-many relation?' in /sync/graviton/vendor/jms/serializer/src/JMS/Serializer/SerializationContext.php:68\n
    Stack trace:\n
    #0 /sync/graviton/vendor/jms/serializer/src/JMS/Serializer/GraphNavigator.php(143): JMS\Serializer\SerializationContext->isVisiting('2015-12-10 12:0...')\n
    #1 /sync/graviton/vendor/jms/serializer/src/JMS/Serializer/GenericSerializationVisitor.php(140): JMS\Serializer\GraphNavigator->accept('2015-12-10 12:0...', Array, Object(JMS\Serializer\SerializationContext))\n
```
