### PR TITLE
Fix mongofill install and remove php7 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
     fi
 - >
     if [ $(phpenv version-name) = "hhvm" ] || [ $(phpenv version-name) = "7.0" ]; then
-        composer require mongofill/mongofill --ignore-platform-reqs --no-update;
+        composer require mongofill/mongofill --ignore-platform-reqs;
     fi
 - composer install --no-interaction  --ignore-platform-reqs --no-scripts
 - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
     env: COMPOSER_CHECK=true PHPUNIT=false
   allow_failures:
   - php: hhvm
-  - php: 7.0
 script:
 - >
     if [ "$PHPUNIT" = "true" ]; then


### PR DESCRIPTION
This is so we can get ready for php7. Before supporting php7 as a deploy target we still need to wait on ext-mongodb (and thus on doctrine/mongodb and doctrine/mongodb-odm).

By using mongofill we can ensure we don't break php7 stuff in any unrelated places while waiting for that.