### PR TITLE
Bring back upsert with custom id for file service

### DIFF
--- a/src/Graviton/FileBundle/FileManager.php
+++ b/src/Graviton/FileBundle/FileManager.php
@@ -208,7 +208,7 @@ class FileManager
             // if it is settable on the document, let's set it and move on.. if not, inform the user..
             if ($record->getId() != $id) {
                 // try to set it..
-                if (is_callable(array($fileData, 'setId'))) {
+                if (is_callable(array($record, 'setId'))) {
                     $record->setId($id);
                 } else {
                     throw new MalformedInputException('No ID was supplied in the request payload.');
@@ -218,15 +218,13 @@ class FileManager
             return $model->updateRecord($id, $record);
         }
 
-        if (!empty($fileData)) {
-            $fId = $fileData->getId();
-            if (empty($fId) && !empty($id)) {
-                $fileData->setId($id);
-            }
-            $record = $fileData;
-        } else {
+        $record = $fileData;
+        if (empty($record)) {
             $entityClass = $model->getEntityClass();
             $record = new $entityClass();
+        }
+        if (empty($record->getId()) && !empty($id)) {
+            $record->setId($id);
         }
 
         return $model->insertRecord($record);

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -249,6 +249,26 @@ class FileControllerTest extends RestTestCase
         $this->assertRegExp('@/file/[a-z0-9]{32}>; rel="self"@', $linkHeader);
     }
 
+    public function testPutNewFile()
+    {
+        $client = static::createRestClient();
+
+        $client->put(
+            '/file/testPutNewFile',
+            file_get_contents(__DIR__ . '/fixtures/test.txt'),
+            [],
+            [],
+            ['CONTENT_TYPE' => 'text/plain'],
+            false
+        );
+
+        $response = $client->getResponse();
+        $linkHeader = $response->headers->get('Link');
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertContains('file/testPutNewFile>; rel="self"', $linkHeader);
+    }
+
     /**
      * validate that we can delete a file
      *

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -249,6 +249,11 @@ class FileControllerTest extends RestTestCase
         $this->assertRegExp('@/file/[a-z0-9]{32}>; rel="self"@', $linkHeader);
     }
 
+    /**
+     * validate that we can put a new file with a custom id
+     *
+     * @return void
+     */
     public function testPutNewFile()
     {
         $client = static::createRestClient();


### PR DESCRIPTION
This PR brings the functionality of `PUT`ting new files with custom `id`s back to the file service. Moreover, it adds a test which ensures that this feature doesn't get lost anymore.