### PR TITLE
Fix filename multipart/form-data bug, refactor FileManager

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -11,8 +11,6 @@ use Graviton\RestBundle\Service\RestUtilsInterface;
 use Graviton\SchemaBundle\SchemaUtils;
 use GravitonDyn\FileBundle\Document\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\FileBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -404,7 +404,8 @@ class FileControllerTest extends RestTestCase
           ],
           "metadata": {
             "action":[{"command":"print"},{"command":"archive"}],
-            "additionalInformation": "someInfo"
+            "additionalInformation": "someInfo",
+            "filename": "customFileName"
           }
         }';
 
@@ -438,6 +439,7 @@ class FileControllerTest extends RestTestCase
             $metaData['metadata']['additionalInformation'],
             $returnData['metadata']['additionalInformation']
         );
+        $this->assertEquals($metaData['metadata']['filename'], $returnData['metadata']['filename']);
 
         // clean up
         $client = $this->createClient();


### PR DESCRIPTION
This PR does the following:
* fix a bug where the `metadata.filename` of a file does not get set to the filename provided in the `metadata` filed on `multipart/form-data` requests
* extends a test for the above case
* refactors the `FileManager`