### PR TITLE
add additional field to the file service

### DIFF
--- a/src/Graviton/FileBundle/FileDocumentFactory.php
+++ b/src/Graviton/FileBundle/FileDocumentFactory.php
@@ -39,17 +39,25 @@ class FileDocumentFactory
     /**
      * Provides an instance of FileMetadata
      *
-     * @param string $id             Identifier of the file.
-     * @param int    $size           Size of the file.
-     * @param string $filename       Name of the file.
-     * @param string $mimetype       Mime-Type of the file.
-     * @param array  $actions        List of actions to be executed.
-     * @param string $additionalInfo Additional file information.
+     * @param string $id              Identifier of the file.
+     * @param int    $size            Size of the file.
+     * @param string $filename        Name of the file.
+     * @param string $mimetype        Mime-Type of the file.
+     * @param array  $actions         List of actions to be executed.
+     * @param string $additionalInfo  Additional file information.
+     * @param array  $additionalProps Additional file properties for example for printing
      *
      * @return FileMetadata
      */
-    public function initiateFileMataData($id, $size, $filename, $mimetype, array $actions = [], $additionalInfo = '')
-    {
+    public function initiateFileMataData(
+        $id,
+        $size,
+        $filename,
+        $mimetype,
+        array $actions = [],
+        $additionalInfo = '',
+        $additionalProps = []
+    ) {
         $now = new \DateTime();
         $meta = $this->createFileMataData();
         $meta->setId($id);
@@ -60,7 +68,8 @@ class FileDocumentFactory
             ->setCreatedate($now)
             ->setModificationdate($now)
             ->setAction($actions)
-            ->setAdditionalInformation($additionalInfo);
+            ->setAdditionalInformation($additionalInfo)
+            ->setAdditionalProperties($additionalProps);
 
         return $meta;
     }

--- a/src/Graviton/FileBundle/Resources/definition/File.json
+++ b/src/Graviton/FileBundle/Resources/definition/File.json
@@ -78,6 +78,22 @@
         "type": "string",
         "title": "Additional Information",
         "description": "Additional information for this file."
+      },
+      {
+        "name": "metadata.additionalProperties.0.name",
+        "type": "string",
+        "title": "property name",
+        "description": "additional property name",
+        "required": true,
+        "translatable": false
+      },
+      {
+        "name": "metadata.additionalProperties.0.value",
+        "type": "string",
+        "title": "property value",
+        "description": "additional property value",
+        "required": true,
+        "translatable": false
       }
     ]
   }

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -405,6 +405,10 @@ class FileControllerTest extends RestTestCase
           "metadata": {
             "action":[{"command":"print"},{"command":"archive"}],
             "additionalInformation": "someInfo",
+            "additionalProperties": [
+                {"name": "testName", "value": "testValue"},
+                {"name": "testName2", "value": "testValue2"}
+            ],
             "filename": "customFileName"
           }
         }';
@@ -439,6 +443,11 @@ class FileControllerTest extends RestTestCase
             $metaData['metadata']['additionalInformation'],
             $returnData['metadata']['additionalInformation']
         );
+        $this->assertEquals(
+            $metaData['metadata']['additionalProperties'],
+            $returnData['metadata']['additionalProperties']
+        );
+        $this->assertCount(2, $returnData['metadata']['additionalProperties']);
         $this->assertEquals($metaData['metadata']['filename'], $returnData['metadata']['filename']);
 
         // clean up
@@ -540,6 +549,15 @@ class FileControllerTest extends RestTestCase
             'readOnly',
             $schema->properties->metadata->properties->additionalInformation
         );
+
+        // metadata additionalProperties
+        $additionalPropertiesSchema = $schema->properties->metadata->properties->additionalProperties;
+        $this->assertEquals('array', $additionalPropertiesSchema->type);
+        $this->assertEquals('object', $additionalPropertiesSchema->items->type);
+        $this->assertEquals('string', $additionalPropertiesSchema->items->properties->name->type);
+        $this->assertEquals('property name', $additionalPropertiesSchema->items->properties->name->title);
+        $this->assertEquals('string', $additionalPropertiesSchema->items->properties->value->type);
+        $this->assertEquals('property value', $additionalPropertiesSchema->items->properties->value->title);
 
         // Links
         $this->assertEquals('array', $schema->properties->links->type);


### PR DESCRIPTION
With this PR we add an additional key/value store named additionalProperties to the metadata.
We need this new field, because we want print and archive PDF and other files. Our printing and archive system needs more information about which printer must be used and where can the file be stored for example.