### PR TITLE
Allow injected SYMFONY__ envs to contain json

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
@@ -43,17 +43,31 @@ class GravitonDocumentExtension extends GravitonBundleExtension
         parent::prepend($container);
 
         /** [nue]
-         * this is a workaround for a current symfony bug:
+         * this is a workaround for a new symfony feature:
          * https://github.com/symfony/symfony/issues/7555
          *
-         * we *want* to be able to override any param with our env variables..
+         * we *need* to be able to override any param with our env variables..
          * so we do again, what the kernel did already here.. ;-)
+         *
+         * Since fabpot seems to have said bye to this feature we are
+         * re-implementing it here. We are also adding some fancy json
+         * parsing for hashes and arrays while at it.
          *
          * @todo move this out of file bundle as it is much more global
          * @todo add proper documentation on this "feature" to a README
          */
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, 'SYMFONY__')) {
+
+                if (substr($value, 0, 1) == '[' || substr($value, 0, 1) == '{') {
+                    $value = json_decode($value, true);
+                    if (JSON_ERROR_NONE !== json_last_error()) {
+                        throw new \RuntimeException(
+                            sprintf('error "%s" in env variable "%s"', json_last_error_msg(), $key)
+                        );
+                    }
+                }
+
                 $container->setParameter(strtolower(str_replace('__', '.', substr($key, 9))), $value);
             }
         }


### PR DESCRIPTION
They are only interpreted as json if they start with either `{` or `[` as to not disturb the old behaviour where they where but simple strings.