### PR TITLE
add more envs to incenteev map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,14 @@
                     "graviton.rabbitmq.user": "RABBITMQ_USER",
                     "graviton.rabbitmq.password": "RABBITMQ_PASSWORD",
                     "graviton.rabbitmq.vhost": "RABBITMQ_VHOST",
-                    "graviton.proxy.swagger.sources": "PROXY_SWAGGER_SOURCES"
+                    "graviton.proxy.swagger.sources": "PROXY_SWAGGER_SOURCES",
+                    "graviton.security.authentication.header_required": "SECURITY_AUTHENTICATION_HEADER_REQUIRED",
+                    "graviton.security.authentication.test_username": "SECURITY_AUTHENTICATION_TEST_USERNAME",
+                    "graviton.security.authentication.allow_anonymous": "SECURITY_AUTHENTICATION_ALLOW_ANONYMOUS",
+                    "graviton.security.authentication.strategy": "SECURITY_AUTHENTICATION_STRATEGY",
+                    "graviton.security.authentication.strategy_key": "SECURITY_AUTHENTICATION_STRATEGY_KEY",
+                    "graviton.security.authentication.provider.model": "SECURITY_AUTHENTICATION_PROVIDER_MODEL",
+                    "graviton.security.authentication.provider.model.query_field": "SECURITY_AUTHENTICATION_MODEL_QUERY_FIELD"
                 }
             },
             {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ddf5c643a06e8893de7a8aa357b991d5",
-    "content-hash": "018e3254777ea41931160ba705244321",
+    "hash": "01ad0b9dd992f516cda15bef5f170952",
+    "content-hash": "391717ced6c13ebc0320576baca87e9d",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -225,7 +225,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dbtlr/php-airbrake/zipball/69fd4782219ba22fcfe4c278de1eebbbe38f0950",
+                "url": "https://api.github.com/repos/dbtlr/php-airbrake/zipball/999763ca1580d1fa7bffc0b6dfe1cf0152078e86",
                 "reference": "69fd4782219ba22fcfe4c278de1eebbbe38f0950",
                 "shasum": ""
             },

--- a/src/Graviton/ProxyBundle/Tests/Definition/Loader/DispersalStrategy/SwaggerStrategyTest.php
+++ b/src/Graviton/ProxyBundle/Tests/Definition/Loader/DispersalStrategy/SwaggerStrategyTest.php
@@ -156,7 +156,7 @@ class SwaggerStrategyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(['resolveReference'])
             ->getMock();
-        $schemaResolverMock->expects($this->exactly(2))
+        $schemaResolverMock->expects($this->exactly(1))
             ->method('resolveReference')
             ->withAnyParameters()
             ->willReturn($responseSchemaMock);


### PR DESCRIPTION
we need this to make the 'whoami' configurable for cloudfoundry environment.. I'll need to tag ASAP again (and bump..)..

I'm not sure about the current Docker environment.. we need to be able to always return a dummy consultant, *not* the string "anonymous". and as those params are directly written into the compiled container (not as getParameter() calls but 1:1), we **can also not** override them via the `SYMFONY__` envs.. so what to do there?

but first, let's merge this for CF..