### PR TITLE
env params via compiler pass

### DIFF
--- a/src/Graviton/CoreBundle/Compiler/EnvParametersCompilerPass.php
+++ b/src/Graviton/CoreBundle/Compiler/EnvParametersCompilerPass.php
@@ -1,0 +1,50 @@
+<?php
+/** A compiler pass that passes $_SERVER/$_ENV vars into the container parameters bag */
+
+namespace Graviton\CoreBundle\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class EnvParametersCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * this is a workaround for a new symfony feature:
+     * https://github.com/symfony/symfony/issues/7555
+     *
+     * we *need* to be able to override any param with our env variables..
+     * so we do again, what the kernel did already here.. ;-)
+     *
+     * Since fabpot seems to have said bye to this feature we are
+     * re-implementing it here. We are also adding some fancy json
+     * parsing for hashes and arrays while at it.
+     *
+     * @todo add proper documentation on this "feature" to a README
+     *
+     * @param ContainerBuilder $container Container
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach (array_merge($_SERVER, $_ENV) as $key => $value) {
+            if (0 === strpos($key, 'SYMFONY__')) {
+                if (substr($value, 0, 1) == '[' || substr($value, 0, 1) == '{') {
+                    $value = json_decode($value, true);
+                    if (JSON_ERROR_NONE !== json_last_error()) {
+                        throw new \RuntimeException(
+                            sprintf('error "%s" in env variable "%s"', json_last_error_msg(), $key)
+                        );
+                    }
+                }
+                $container->setParameter(strtolower(str_replace('__', '.', substr($key, 9))), $value);
+            }
+        }
+    }
+}

--- a/src/Graviton/CoreBundle/GravitonCoreBundle.php
+++ b/src/Graviton/CoreBundle/GravitonCoreBundle.php
@@ -7,6 +7,7 @@ namespace Graviton\CoreBundle;
 
 use Graviton\BundleBundle\GravitonBundleInterface;
 use Graviton\CacheBundle\GravitonCacheBundle;
+use Graviton\CoreBundle\Compiler\EnvParametersCompilerPass;
 use Graviton\DocumentBundle\GravitonDocumentBundle;
 use Graviton\ExceptionBundle\GravitonExceptionBundle;
 use Graviton\GeneratorBundle\GravitonGeneratorBundle;
@@ -78,5 +79,6 @@ class GravitonCoreBundle extends Bundle implements GravitonBundleInterface
         parent::build($container);
 
         $container->addCompilerPass(new VersionCompilerPass());
+        $container->addCompilerPass(new EnvParametersCompilerPass());
     }
 }

--- a/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
+++ b/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
@@ -27,9 +27,6 @@ class EnvParametersCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testParameterSetting($envName, $envValue, $paramName, $paramValue, $exception = null)
     {
-        // put $_SERVER on the side
-        $origServer = $_SERVER;
-
         $_SERVER[$envName] = $envValue;
 
         $containerDouble = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
@@ -51,8 +48,7 @@ class EnvParametersCompilerPassTest extends \PHPUnit_Framework_TestCase
         $compilerPass = new EnvParametersCompilerPass();
         $compilerPass->process($containerDouble);
 
-        // put $_SERVER back in place side
-        $_SERVER = $origServer;
+        unset($_SERVER[$envName]);
     }
 
     /**

--- a/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
+++ b/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * EnvParametersCompilerPassTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\DependencyInjection\CompilerPass;
+
+use Graviton\CoreBundle\Compiler\EnvParametersCompilerPass;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class EnvParametersCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider parameterSettingDataProvider
+     *
+     * @param string $envName    env name
+     * @param string $envValue   env value
+     * @param string $paramName  param name
+     * @param mixed  $paramValue param value
+     * @param string $exception  optional expected exception
+     *
+     * @return void
+     */
+    public function testParameterSetting($envName, $envValue, $paramName, $paramValue, $exception = null)
+    {
+        // put $_SERVER on the side
+        $origServer = $_SERVER;
+
+        $_SERVER[$envName] = $envValue;
+
+        $containerDouble = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+                                ->disableOriginalConstructor()
+                                ->getMock();
+
+        if (is_null($exception)) {
+            $containerDouble
+                ->expects($this->exactly(1))
+                ->method('setParameter')
+                ->with(
+                    $paramName,
+                    $paramValue
+                );
+        } else {
+            $this->setExpectedException($exception);
+        }
+
+        $compilerPass = new EnvParametersCompilerPass();
+        $compilerPass->process($containerDouble);
+
+        // put $_SERVER back in place side
+        $_SERVER = $origServer;
+    }
+
+    /**
+     * data provider for param settings
+     *
+     * @return array data
+     */
+    public function parameterSettingDataProvider()
+    {
+        return [
+            'simple' => [
+                'SYMFONY__test__parameter',
+                'test',
+                'test.parameter',
+                'test'
+            ],
+            'simple-underscore' => [
+                'SYMFONY__test__parameter_underscore',
+                'test_underscore',
+                'test.parameter_underscore',
+                'test_underscore'
+            ],
+            'json-arr' => [
+                'SYMFONY__test__parameter_json1',
+                '[{"test": "test"}, {"test": "test"}]',
+                'test.parameter_json1',
+                [['test' => 'test'], ['test' => 'test']]
+            ],
+            'json-object' => [
+                'SYMFONY__test__parameter_json2',
+                '{"test": "test"}',
+                'test.parameter_json2',
+                ['test' => 'test']
+            ],
+            'json-invalid' => [
+                'SYMFONY__test__parameter_json3',
+                '{"test": "test",,}',
+                null,
+                null,
+                '\RuntimeException'
+            ]
+        ];
+    }
+}

--- a/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
+++ b/src/Graviton/CoreBundle/Tests/DependencyInjection/CompilerPass/EnvParametersCompilerPassTest.php
@@ -45,10 +45,12 @@ class EnvParametersCompilerPassTest extends \PHPUnit_Framework_TestCase
             $this->setExpectedException($exception);
         }
 
-        $compilerPass = new EnvParametersCompilerPass();
-        $compilerPass->process($containerDouble);
-
-        unset($_SERVER[$envName]);
+        try {
+            $compilerPass = new EnvParametersCompilerPass();
+            $compilerPass->process($containerDouble);
+        } finally {
+            unset($_SERVER[$envName]);
+        }
     }
 
     /**

--- a/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/GravitonDocumentExtension.php
@@ -42,36 +42,6 @@ class GravitonDocumentExtension extends GravitonBundleExtension
     {
         parent::prepend($container);
 
-        /** [nue]
-         * this is a workaround for a new symfony feature:
-         * https://github.com/symfony/symfony/issues/7555
-         *
-         * we *need* to be able to override any param with our env variables..
-         * so we do again, what the kernel did already here.. ;-)
-         *
-         * Since fabpot seems to have said bye to this feature we are
-         * re-implementing it here. We are also adding some fancy json
-         * parsing for hashes and arrays while at it.
-         *
-         * @todo move this out of file bundle as it is much more global
-         * @todo add proper documentation on this "feature" to a README
-         */
-        foreach ($_SERVER as $key => $value) {
-            if (0 === strpos($key, 'SYMFONY__')) {
-
-                if (substr($value, 0, 1) == '[' || substr($value, 0, 1) == '{') {
-                    $value = json_decode($value, true);
-                    if (JSON_ERROR_NONE !== json_last_error()) {
-                        throw new \RuntimeException(
-                            sprintf('error "%s" in env variable "%s"', json_last_error_msg(), $key)
-                        );
-                    }
-                }
-
-                $container->setParameter(strtolower(str_replace('__', '.', substr($key, 9))), $value);
-            }
-        }
-
         // grab mongo config directly from vcap...
         $services = getenv('VCAP_SERVICES');
         if (!empty($services)) {


### PR DESCRIPTION
as mentioned in #357, we still have a major problem how to set params from `ENV` for docker based stuff during runtime.

*important:* we could override params before via `SYMFONY__` envs. but as soon as it concerns params that are referenced in a DIC definition (`%paramname%` in xml), this will not work. this concerns investment bundle stuff as also stuff in `SecurityBundle`.

this approach tries to solve it by:
* assume that we deploy the application without an existing compiled container (no `/app/cache/<env>`)
* once the app is running (with `ENV` set via recipe or any other way), the `CompilerPass` will write it to the `Container` - this time, they will land in the then compiled container.

the main point of this is that we must ensure the cache is built on runtime by not deploying a cache of the given `SYMFONY_ENV`. this combined with the fact that we read `ENV` on container compile via a `CompilerPass` should ensure that the `ENV` values actually end up in the compiled container (`resolved` correctly).

and yes, once the container is built, no more overrides can be done using this approach. but this would not have worked anyway, as the process would not be restarted anyway. At least not in CloudFoundy or Docker environments.