### PR TITLE
fix optional translatables

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -96,10 +96,6 @@ class ShowcaseControllerTest extends RestTestCase
         $client->post('/hans/showcase', $document);
 
         $expectedErrors = [];
-        $expectedError = new \stdClass();
-        $expectedError->propertyPath = 'children[someOtherField]';
-        $expectedError->message = 'This value is not valid.';
-        $expectedErrors[] = $expectedError;
         $notNullError = new \stdClass();
         $notNullError->propertyPath = 'data.aBoolean';
         $notNullError->message = 'The value "" is not a valid boolean.';
@@ -140,12 +136,9 @@ class ShowcaseControllerTest extends RestTestCase
             Response::HTTP_BAD_REQUEST,
             $client->getResponse()->getStatusCode()
         );
+
         $this->assertEquals(
             [
-                (object) [
-                    'propertyPath'  => 'children[someOtherField]',
-                    'message'       => 'This value is not valid.',
-                ],
                 (object) [
                     'propertyPath'  => 'data.aBoolean',
                     'message'       => 'The value "" is not a valid boolean.',
@@ -198,10 +191,6 @@ class ShowcaseControllerTest extends RestTestCase
         );
         $this->assertEquals(
             [
-                (object) [
-                    'propertyPath'  => 'children[someOtherField]',
-                    'message'       => 'This value is not valid.',
-                ],
                 (object) [
                     'propertyPath'  => 'data.contact.protocol',
                     'message'       => 'This value should not be blank.',

--- a/src/Graviton/CoreBundle/Tests/Controller/TranslatableRequiredTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/TranslatableRequiredTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * TranslatableRequiredTest class file
+ */
+
+namespace Graviton\CoreBundle\Tests\Controller;
+
+use Graviton\TestBundle\Test\RestTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class TranslatableRequiredTest extends RestTestCase
+{
+
+    /**
+     * test stuff that the backend should accept
+     *
+     * @dataProvider acceptableDataProvider
+     *
+     * @param array $data data to post
+     *
+     * @return void
+     */
+    public function testPutWithAcceptableTranslatableRequests($data)
+    {
+        $client = static::createRestClient();
+        $client->put('/testcase/translatable-required/testdata', $data);
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $this->assertEmpty($client->getResults());
+    }
+
+    /**
+     * test stuff that the backend should accept
+     *
+     * @dataProvider unacceptableDataProvider
+     *
+     * @param array  $data          data to post
+     * @param string $complainField field to complain about
+     *
+     * @return void
+     */
+    public function testPutMethodIncludeRequiredTranslatable($data, $complainField)
+    {
+        $client = static::createRestClient();
+        $client->put('/testcase/translatable-required/testdata', $data);
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $this->assertSame('children['.$complainField.']', $client->getResults()[0]->propertyPath);
+        $this->assertSame('This value is not valid.', $client->getResults()[0]->message);
+    }
+
+    /**
+     * Posts that the backend shall accept
+     *
+     * @return array data
+     */
+    public function acceptableDataProvider()
+    {
+        return [
+            'omit-optional' => [
+                'data' => [
+                    'id' => 'testdata',
+                    'required' => [
+                        'en' => 'Test'
+                    ]
+                ]
+            ],
+            'with-optional' => [
+                'data' => [
+                    'id' => 'testdata',
+                    'optional' => [
+                        'en' => 'Test'
+                    ]        ,
+                    'required' => [
+                        'en' => 'Test'
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Posts that the backend shall NOT accept
+     *
+     * @return array data
+     */
+    public function unacceptableDataProvider()
+    {
+        return [
+            'omit-required' => [
+                'data' => [
+                    'id' => 'testdata',
+                    'optional' => [
+                        'en' => 'Test'
+                    ]
+                ],
+                'complainField' => 'required'
+            ],
+            'empty-optional' => [
+                'data' => [
+                    'id' => 'testdata',
+                    'optional' => [],
+                    'required' => [
+                        'en' => 'Test'
+                    ]
+                ],
+                'complainField' => 'optional'
+            ],
+            'empty-no-default' => [
+                'data' => [
+                    'id' => 'testdata',
+                    'optional' => [
+                        'es' => 'Vamos a la playa'
+                    ],
+                    'required' => [
+                        'en' => 'Test'
+                    ]
+                ],
+                'complainField' => 'optional'
+            ]
+        ];
+    }
+}

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFormFieldsCompilerPass.php
@@ -86,13 +86,17 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface
                 list($type, $options) = $this->resolveFieldParams(
                     $translatableFields,
                     $field->getFieldName(),
-                    $field->getType()
+                    $field->getType(),
+                    $field
                 );
 
                 $result[] = [
                     $field->getFormName(),
                     $type,
-                    array_replace(['property_path' => $field->getFieldName()], $options),
+                    array_replace(
+                        ['property_path' => $field->getFieldName()],
+                        $options
+                    ),
                 ];
             } elseif ($field instanceof ArrayField) {
                 list($type, $options) = $this->resolveFieldParams(
@@ -141,28 +145,30 @@ class DocumentFormFieldsCompilerPass implements CompilerPassInterface
      * @param array  $translatable Translatable fields
      * @param string $fieldName    Field name
      * @param string $fieldType    Field type
+     * @param mixed  $field        optional field to pass
+     *
      * @return array Form type and options
      */
-    private function resolveFieldParams(array $translatable, $fieldName, $fieldType)
+    private function resolveFieldParams(array $translatable, $fieldName, $fieldType, $field = null)
     {
+        $options = [];
+
         if (in_array($fieldName, $translatable, true) || in_array($fieldName.'[]', $translatable, true)) {
             $type = 'translatable';
-            $options = [];
+            if ($field instanceof Field) {
+                $options['required'] = $field->isRequired();
+            }
         } elseif ($fieldType === 'hash') {
             $type = 'freeform';
-            $options = [];
         } elseif ($fieldType === 'hasharray') {
             $type = 'collection';
-            $options = ['type' => 'freeform'];
+            $options['type'] = 'freeform';
         } elseif ($fieldType === 'datearray') {
             $type = 'datearray';
-            $options = [];
         } elseif (isset($this->typeMap[$fieldType])) {
             $type = $this->typeMap[$fieldType];
-            $options = [];
         } else {
             $type = 'text';
-            $options = [];
         }
 
         return [$type, $options];

--- a/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/TranslatableFieldBuilder.php
+++ b/src/Graviton/DocumentBundle/Form/Type/FieldBuilder/TranslatableFieldBuilder.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * TranslatableFieldBuilder class file
+ */
+
+namespace Graviton\DocumentBundle\Form\Type\FieldBuilder;
+
+use Graviton\DocumentBundle\Form\Type\DocumentType;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class TranslatableFieldBuilder implements FieldBuilderInterface
+{
+    /**
+     * Is field type supported by this builder
+     *
+     * @param string $type    Field type
+     * @param array  $options Options
+     * @return bool
+     */
+    public function supportsField($type, array $options = [])
+    {
+        return $type === 'translatable';
+    }
+
+    /**
+     * Build form field
+     *
+     * @param DocumentType  $document      Document type
+     * @param FormInterface $form          Form
+     * @param string        $name          Field name
+     * @param string        $type          Field type
+     * @param array         $options       Options
+     * @param mixed         $submittedData Submitted data
+     * @return void
+     */
+    public function buildField(
+        DocumentType $document,
+        FormInterface $form,
+        $name,
+        $type,
+        array $options = [],
+        $submittedData = null
+    ) {
+
+        // don't add translatables that are not submitted and not required
+        if (is_null($submittedData) && $options['required'] !== true) {
+            return;
+        }
+
+        unset($options['required']);
+
+        $form->add($name, $type, $options);
+    }
+}

--- a/src/Graviton/DocumentBundle/Resources/config/services.xml
+++ b/src/Graviton/DocumentBundle/Resources/config/services.xml
@@ -82,6 +82,11 @@
             </call>
             <call method="addFormFieldBuilder">
                 <argument type="service">
+                    <service class="Graviton\DocumentBundle\Form\Type\FieldBuilder\TranslatableFieldBuilder"/>
+                </argument>
+            </call>
+            <call method="addFormFieldBuilder">
+                <argument type="service">
                     <service class="Graviton\DocumentBundle\Form\Type\FieldBuilder\DefaultFieldBuilder"/>
                 </argument>
             </call>

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFormFieldsCompilerPassTest.php
@@ -47,7 +47,7 @@ class DocumentFormFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
                         [
                             'titleA',
                             'translatable',
-                            ['property_path' => 'title'],
+                            ['property_path' => 'title', 'required' => false],
                         ],
                         [
                             'extrefA',


### PR DESCRIPTION
Graviton behaves wrongly when a service has a `translatable` that is **not** `required: true`. 

If the user omits it from the request, Graviton falsely complains with `[{"propertyPath":"children[field]","message":"This value is not valid."}]` and HTTP status `400`.

This PR fixes this.. I created this to replace #361 as it was quite cluttered..

*Why was ShowcaseControllerTest modified?*
That's a good question indeed.. In `ShowCase.json` we have `someOtherField`, an optional Translatable. And still, our ShowCaseControllerTest expected Graviton to complain when you omit this optional Translatable. So it tested wrong behavior. I removed this now..

*Required behavior*
If a translatable is not required, it shall not be required. 