### PR TITLE
lookup subscribed workers with subexpression, not character class

### DIFF
--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -265,7 +265,7 @@ class EventStatusLinkResponseListener
     private function getSubscribedWorkerIds(QueueEvent $queueEvent)
     {
         // compose our regex to match stars ;-)
-        // results in = /([\*|document]+)\.([\*|dude]+)\.([\*|config]+)\.([\*|update]+)/
+        // results in = /((\*|document)+)\.((\*|dude)+)\.((\*|config)+)\.((\*|update)+)/
         $routingArgs = explode('.', $queueEvent->getEvent());
         $regex =
             '/'.
@@ -273,7 +273,7 @@ class EventStatusLinkResponseListener
                 '\.',
                 array_map(
                     function ($arg) {
-                        return '([\*|'.$arg.']+)';
+                        return '((\*|'.$arg.')+)';
                     },
                     $routingArgs
                 )


### PR DESCRIPTION
If you check this -> http://api.dev-pub.zgkb.evoja.ch/event/status/?eq(eventName,document.financingcollateraltype.financingcollateraltype.update)

You'll see many `/event/status/` objects that *should not* exist. So I fiddled around with MongoRegex on the shell - and it turns out that I made a mistake in the current implementation. We need to search with a subexpression, not with a character class. 