### PR TITLE
EVO-2891: Add a ProxyBundle configuration for including / excluding the base path of thirdparty APIs

### DIFF
--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionArrayTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionArrayTest.php
@@ -8,7 +8,6 @@ namespace Graviton\GeneratorBundle\Tests\Definition;
 use Graviton\GeneratorBundle\Definition\DefinitionElementInterface;
 use Graviton\GeneratorBundle\Definition\JsonDefinitionArray;
 
-
 /**
  * JsonDefinitionArray test
  *

--- a/src/Graviton/ProxyBundle/Controller/ProxyController.php
+++ b/src/Graviton/ProxyBundle/Controller/ProxyController.php
@@ -153,8 +153,11 @@ class ProxyController
      * forwarding and should therefore not be delivered to the client.
      *
      * @param HeaderBag $headers The headerbag holding the thirdparty API's response headers
+     *
+     * @return void
      */
-    protected function cleanResponseHeaders(HeaderBag $headers) {
+    protected function cleanResponseHeaders(HeaderBag $headers)
+    {
         $headers->remove('transfer-encoding'); // Chunked responses get not automatically re-chunked by graviton
         $headers->remove('trailer'); // Only for chunked responses, graviton should re-set this when chunking
     }

--- a/src/Graviton/ProxyBundle/Controller/ProxyController.php
+++ b/src/Graviton/ProxyBundle/Controller/ProxyController.php
@@ -131,6 +131,8 @@ class ProxyController
             $psrRequest = $psrRequest->withUri($psrRequest->getUri()->withPort(parse_url($url, PHP_URL_PORT)));
             $psrResponse = $this->proxy->forward($psrRequest)->to($this->getHostWithScheme($url));
             $response = $this->httpFoundationFactory->createResponse($psrResponse);
+            // Since Graviton does not always use the same encoding as the thirdparty API, this header must be removed
+            $response->headers->remove('transfer-encoding');
             $this->transformationHandler->transformResponse(
                 $api['apiName'],
                 $api['endpoint'],
@@ -142,8 +144,7 @@ class ProxyController
         } catch (ServerException $serverException) {
             $response = $serverException->getResponse();
         }
-        // Since Graviton does not always use the same encoding as the thirdparty API, this header must be removed
-        $response->headers->remove('transfer-encoding');
+
         return $response;
     }
 

--- a/src/Graviton/ProxyBundle/Definition/ApiDefinition.php
+++ b/src/Graviton/ProxyBundle/Definition/ApiDefinition.php
@@ -52,6 +52,16 @@ class ApiDefinition
     }
 
     /**
+     * Gets the API's base path
+     *
+     * @return string The base path
+     */
+    public function getBasePath()
+    {
+        return $this->basePath;
+    }
+
+    /**
      * sets the FQDN of the API
      *
      * @param string $host FQDN
@@ -127,13 +137,14 @@ class ApiDefinition
     /**
      * get all defined API endpoints
      *
-     * @param boolean $withHost url with hostname
-     * @param string  $prefix   add a prefix to the url (blub/endpoint/url)
-     * @param string  $host     Host to be used instead of the host defined in the swagger json
+     * @param boolean $withHost     url with hostname
+     * @param string  $prefix       add a prefix to the url (blub/endpoint/url)
+     * @param string  $host         Host to be used instead of the host defined in the swagger json
+     * @param bool    $withBasePath Defines whether the API's base path should be included or not
      *
      * @return array
      */
-    public function getEndpoints($withHost = true, $prefix = null, $host = '')
+    public function getEndpoints($withHost = true, $prefix = null, $host = '', $withBasePath = true)
     {
         $endpoints = array();
         $basePath = "";
@@ -143,7 +154,7 @@ class ApiDefinition
         if (!empty($prefix)) {
             $basePath .= $prefix;
         }
-        if (isset($this->basePath)) {
+        if ($withBasePath && isset($this->basePath)) {
             $basePath .= $this->basePath;
         }
         foreach ($this->endpoints as $endpoint) {

--- a/src/Graviton/ProxyBundle/Definition/Loader/DispersalStrategy/SwaggerStrategy.php
+++ b/src/Graviton/ProxyBundle/Definition/Loader/DispersalStrategy/SwaggerStrategy.php
@@ -65,7 +65,7 @@ class SwaggerStrategy implements DispersalStrategyInterface
 
             $operations = $this->document->getOperationsById();
             foreach ($operations as $service) {
-                $path = $this->normalizePath($service->getPath());
+                $path = $service->getPath();
 
                 if (in_array(strtolower($service->getMethod()), ['delete', 'patch']) || $apiDef->hasEndpoint($path)) {
                     continue;
@@ -250,26 +250,5 @@ class SwaggerStrategy implements DispersalStrategyInterface
         }
 
         $this->fallbackData = $fallbackData;
-    }
-
-    /**
-     * Normalizes the provided path.
-     *
-     * The idea is to consolidate endpoints for GET requests.
-     *
-     * <code>
-     *   /my/path/      » /my/path
-     *   /my/path/{id}  » /my/path
-     * </code>
-     *
-     * @param string $path path to be normalized
-     *
-     * @return string
-     *
-     * @todo: determine how to treat endpoints with a variable within the path: /my/path/{id}/special
-     */
-    private function normalizePath($path)
-    {
-        return preg_replace('@\/(\{[a-zA-Z]*\})?$@', '', $path);
     }
 }

--- a/src/Graviton/ProxyBundle/DependencyInjection/Configuration.php
+++ b/src/Graviton/ProxyBundle/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('prefix')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('uri')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('host')->cannotBeEmpty()->end()
-                            ->booleanNode('removeBasePath')->defaultValue(true)->end()
+                            ->booleanNode('includeBasePath')->defaultValue(false)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Graviton/ProxyBundle/DependencyInjection/Configuration.php
+++ b/src/Graviton/ProxyBundle/DependencyInjection/Configuration.php
@@ -52,6 +52,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('prefix')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('uri')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('host')->cannotBeEmpty()->end()
+                            ->booleanNode('removeBasePath')->defaultValue(true)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Graviton/ProxyBundle/README.md
+++ b/src/Graviton/ProxyBundle/README.md
@@ -1,0 +1,37 @@
+# GravitonProxyBundle
+
+A bundle for proxying thirdparty APIs. At the moment, only APIs using swagger are supported.
+
+## Features
+The Bundle supports the following features for `swagger.json` based APIs:
+* Exposing all endpoints under `/3rdparty/{apiPrefix}/`
+* Forwarding complete requests to the thirdparty API
+* Generation of graviton JSON schemas based on the API schema
+
+
+## Configuration
+This bundle can be configured in `config.yml` as follows:
+
+```yml
+graviton_proxy:
+  sources:
+    swagger:
+      someApi:
+        prefix: someApi
+        uri: http://example.org/api/swagger.json
+        host: http://api.example.org/
+        includeBasePath: false
+      anotherApi:
+        prefix: anotherApi
+        uri: http://example.org/another/api/swagger.json
+
+```
+
+See the following table concerning the config nodes which CAN or MUST be set for each API:
+
+| Config Node         | Description                                                                       | Default Value / Behavior (empty if required) |
+|---------------------|-----------------------------------------------------------------------------------|----------------------------------------------|
+| **prefix**          |The graviton URL prefix where the API endpoints get exposed.                       |                                              |
+| **uri**             | The URL of the API schema (e.g `swagger.json`)                                    |                                              |
+| **host**            | Defines the host of the API. This overwrites any host defined in the API schema.  | Use the host defined by the API schema.      |
+| **includeBasePath** | Defines whether the APIs base path should be included in the graviton URL or not. | `false`                                      |

--- a/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
+++ b/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
@@ -111,7 +111,8 @@ class ApiDefinitionLoader
             $url = empty($this->options['host']) ? $this->definition->getHost() : $this->options['host'];
         }
 
-        $url .= ($this->options['removeBasePath'] ? $this->definition->getBasePath() : '') . $endpoint;
+        // If the base path is not already included, we need to add it.
+        $url .= ($this->options['includeBasePath'] ? '' : $this->definition->getBasePath()) . $endpoint;
 
         return $url;
     }
@@ -135,7 +136,7 @@ class ApiDefinitionLoader
         }
         $retVal = array();
         if (is_object($this->definition)) {
-            $retVal = $this->definition->getEndpoints($withHost, $prefix, $host, !$this->options['removeBasePath']);
+            $retVal = $this->definition->getEndpoints($withHost, $prefix, $host, $this->options['includeBasePath']);
         }
 
         return $retVal;

--- a/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
+++ b/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
@@ -112,7 +112,7 @@ class ApiDefinitionLoader
         }
 
         // If the base path is not already included, we need to add it.
-        $url .= ($this->options['includeBasePath'] ? '' : $this->definition->getBasePath()) . $endpoint;
+        $url .= (empty($this->options['includeBasePath']) ? $this->definition->getBasePath() : '') . $endpoint;
 
         return $url;
     }
@@ -134,12 +134,13 @@ class ApiDefinitionLoader
         if (isset($this->options['prefix'])) {
             $prefix .= "/".$this->options['prefix'];
         }
-        $retVal = array();
-        if (is_object($this->definition)) {
-            $retVal = $this->definition->getEndpoints($withHost, $prefix, $host, $this->options['includeBasePath']);
-        }
 
-        return $retVal;
+        return !is_object($this->definition) ? [] : $this->definition->getEndpoints(
+            $withHost,
+            $prefix,
+            $host,
+            !empty($this->options['includeBasePath'])
+        );
     }
 
     /**

--- a/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
+++ b/src/Graviton/ProxyBundle/Service/ApiDefinitionLoader.php
@@ -111,7 +111,7 @@ class ApiDefinitionLoader
             $url = empty($this->options['host']) ? $this->definition->getHost() : $this->options['host'];
         }
 
-        $url .= $endpoint;
+        $url .= ($this->options['removeBasePath'] ? $this->definition->getBasePath() : '') . $endpoint;
 
         return $url;
     }
@@ -135,7 +135,7 @@ class ApiDefinitionLoader
         }
         $retVal = array();
         if (is_object($this->definition)) {
-            $retVal = $this->definition->getEndpoints($withHost, $prefix, $host);
+            $retVal = $this->definition->getEndpoints($withHost, $prefix, $host, !$this->options['removeBasePath']);
         }
 
         return $retVal;

--- a/src/Graviton/ProxyBundle/Tests/Definition/ApiDefinitionTest.php
+++ b/src/Graviton/ProxyBundle/Tests/Definition/ApiDefinitionTest.php
@@ -35,12 +35,14 @@ class ApiDefinitionTest extends \PHPUnit_Framework_TestCase
         }
 
         $apiEndpoints = $sut->getEndpoints(false, null);
+        $apiEndpointsWithoutBase = $sut->getEndpoints(false, null, '', false);
 
         $this->assertEquals($host, $sut->getHost());
         $this->assertCount(3, $apiEndpoints);
         foreach ($endpoints as $id => $endpoint) {
             $this->assertTrue($sut->hasEndpoint($endpoint));
             $this->assertEquals($basePath.$endpoint, $apiEndpoints[$id]);
+            $this->assertEquals($endpoint, $apiEndpointsWithoutBase[$id]);
         }
     }
 

--- a/src/Graviton/RestBundle/Service/JsonPatchValidator.php
+++ b/src/Graviton/RestBundle/Service/JsonPatchValidator.php
@@ -25,15 +25,14 @@ class JsonPatchValidator
     {
         $operations = json_decode($jsonPatch, true);
         $pointer = new Pointer($targetDocument);
-        foreach($operations as $op)
-        {
+        foreach ($operations as $op) {
             try {
                 $pointer->get($op['path']);
-            } catch(InvalidPointerException $e) {
+            } catch (InvalidPointerException $e) {
                 // Basic validation failed
                 $this->setException($e);
                 return false;
-            } catch(NonexistentValueReferencedException $e) {
+            } catch (NonexistentValueReferencedException $e) {
                 $pathParts = explode('/', $op['path']);
                 $lastPart = end($pathParts);
 
@@ -52,7 +51,7 @@ class JsonPatchValidator
 
                     try {
                         $pointer->get(implode('/', $pathParts));
-                    } catch(NonexistentValueReferencedException $e) {
+                    } catch (NonexistentValueReferencedException $e) {
                         $this->setException($e);
                         return false;
                     }
@@ -78,5 +77,4 @@ class JsonPatchValidator
     {
         return $this->exception;
     }
-
 }


### PR DESCRIPTION
This PR adds a configuration which defines whether graviton should expose thirdparty endpoints with or without the thirdparty API's base path. Since exposing this base path does not make sense in most cases, the default behavior is removing it.

In addition, the following fixes are applied:
1. On `/3rdparty/{prefix}/{endpoint}` requests, use the thirdparty API defined by the prefix in the URL or throw a `NotFoundException` when no such prefix is defined (current behavior is always using the last configured thirdparty API by completely ignoring the prefix in the URL)
2. Path normalization (removing one path `{parameter}` at the end of the path for the endpoint overview) for swagger sources is removed (as discussed with @samsamann). Reason: Removing the `{parameters}` at the end of the exposed URL is confusing, since `{parameters}` in the middle of the path cannot be removed.
3. Always remove the `transfer-encoding` and `trailer` headers when forwarding thirdparty API responses, since graviton does not re-chunk chunked thridparty API responses.
4. Some ENTB phpcbf fixes