### PR TITLE
EVO-2938 - add ref to event status

### DIFF
--- a/src/Graviton/RabbitMqBundle/Resources/config/services.xml
+++ b/src/Graviton/RabbitMqBundle/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="graviton.rabbitmq.document.eventworker.class">GravitonDyn\EventWorkerBundle\Document\EventWorker</parameter>
         <parameter key="graviton.rabbitmq.document.eventstatus.class">GravitonDyn\EventStatusBundle\Document\EventStatus</parameter>
         <parameter key="graviton.rabbitmq.document.eventstatusstatus.class">GravitonDyn\EventStatusBundle\Document\EventStatusStatus</parameter>
+        <parameter key="graviton.rabbitmq.document.eventstatuseventresource.class">GravitonDyn\EventStatusBundle\Document\EventStatusEventResourceEmbedded</parameter>
         <parameter key="graviton.rabbitmq.validator.validinformationtype.class">Graviton\RabbitMqBundle\Validator\Constraints\ValidInformationTypeValidator</parameter>
         <parameter key="graviton.rabbitmq.validator.validstatus.class">Graviton\RabbitMqBundle\Validator\Constraints\ValidStatusValidator</parameter>
 
@@ -28,11 +29,13 @@
             <argument type="service" id="router" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="doctrine_mongodb.odm.default_document_manager" />
+            <argument type="service" id="graviton.document.service.extrefconverter" />
             <argument type="service" id="graviton.rabbitmq.document.queueevent" />
             <argument>%graviton.document.eventmap%</argument>
             <argument>%graviton.rabbitmq.document.eventworker.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatus.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatusstatus.class%</argument>
+            <argument>%graviton.rabbitmq.document.eventstatuseventresource.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatusstatus.route%</argument>
             <!-- the event 'graviton.rest.response.selfaware' will be dispatched by the SelfLinkResponseListener -->
             <tag name="kernel.event_listener" event="graviton.rest.response.selfaware" method="onKernelResponse"/>

--- a/src/Graviton/RabbitMqBundle/Resources/definition/EventStatus.json
+++ b/src/Graviton/RabbitMqBundle/Resources/definition/EventStatus.json
@@ -30,6 +30,15 @@
         "readOnly": true
       },
       {
+        "name": "eventResource.ref",
+        "type": "extref",
+        "exposeAs": "$ref",
+        "title": "Ref to event resource",
+        "collection": ["*"],
+        "description": "A $ref pointing to the resource that triggered this event. If the resource was deleted, it may not exist anymore.",
+        "required": false
+      },
+      {
         "name": "status.0.workerId",
         "type": "string",
         "title": "Worker ID",

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -121,7 +121,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
             '\Graviton\RabbitMqBundle\Document\QueueEvent'
         )->setMethods(['getEvent', 'getDocumenturl'])->getMock();
         $queueEventMock->expects($this->exactly(5))->method('getEvent')->willReturn('document.dude.config.create');
-        $queueEventMock->expects($this->exactly(3))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
+        $queueEventMock->expects($this->exactly(2))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
 
         $filterResponseEventMock = $this->getMockBuilder(
             '\Symfony\Component\HttpKernel\Event\FilterResponseEvent'


### PR DESCRIPTION
In talks it has been discussed that it would be nice to enable the user to lookup certain events by the originating REST resource that created a certain `/event/status`.

So this PR adds a `$ref` to every `/event/status/` record. It points to the exact document that was created/updated and allows for more precise RQL searches to find relevant status entries.

I also added more testing so the object that the `Listener` persists gets inspected more in detail.