### PR TITLE
Fix storing of language string for different domains

### DIFF
--- a/src/Graviton/I18nBundle/Resources/config/doctrine/Translatable.mongodb.xml
+++ b/src/Graviton/I18nBundle/Resources/config/doctrine/Translatable.mongodb.xml
@@ -15,7 +15,7 @@
       </cascade>
     </embed-one>
     <indexes>
-      <index unique="true">
+      <index unique="false">
         <key name="domain"/>
         <key name="locale"/>
         <key name="original"/>

--- a/src/Graviton/I18nBundle/Service/I18nUtils.php
+++ b/src/Graviton/I18nBundle/Service/I18nUtils.php
@@ -222,14 +222,15 @@ class I18nUtils
                 function ($locale) use ($original, $values) {
                     $isLocalized = false;
                     $translated = '';
+                    $domain = $this->getTranslatableDomain();
                     if (array_key_exists($locale, $values)) {
                         $translated = $values[$locale];
                         $isLocalized = true;
                     }
                     $translatable = new TranslatableDocument();
-                    $translatable->setId('i18n-' . $locale . '-' . $original);
+                    $translatable->setId($domain . '-' . $locale . '-' . $original);
                     $translatable->setLocale($locale);
-                    $translatable->setDomain($this->getTranslatableDomain());
+                    $translatable->setDomain($domain);
                     $translatable->setOriginal($original);
                     $translatable->setTranslated($translated);
                     $translatable->setIsLocalized($isLocalized);

--- a/src/Graviton/I18nBundle/Tests/Controller/LanguageControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/LanguageControllerTest.php
@@ -121,17 +121,19 @@ class LanguageControllerTest extends RestTestCase
         $this->assertEquals('Englisch', $results->name->de);
 
         $client = static::createRestClient();
-        $client->request('GET', '/i18n/translatable/i18n-en-German');
-        $this->assertEquals('i18n', $client->getResults()->domain);
-        $this->assertEquals('en', $client->getResults()->locale);
-        $this->assertEquals('German', $client->getResults()->original);
+        $client->request('GET', '/i18n/translatable/?locale=en&domain=i18n&original=German');
+
+        $this->assertCount(1, $client->getResults());
+        $this->assertEquals('i18n', $client->getResults()[0]->domain);
+        $this->assertEquals('en', $client->getResults()[0]->locale);
+        $this->assertEquals('German', $client->getResults()[0]->original);
 
         $client = static::createRestClient();
-        $client->request('GET', '/i18n/translatable/i18n-de-German');
-
-        $this->assertEquals('i18n', $client->getResults()->domain);
-        $this->assertEquals('de', $client->getResults()->locale);
-        $this->assertEquals('German', $client->getResults()->original);
+        $client->request('GET', '/i18n/translatable/?locale=de&domain=i18n&original=German');
+        $this->assertCount(1, $client->getResults());
+        $this->assertEquals('i18n', $client->getResults()[0]->domain);
+        $this->assertEquals('de', $client->getResults()[0]->locale);
+        $this->assertEquals('German', $client->getResults()[0]->original);
     }
 
     /**


### PR DESCRIPTION
Fixes [EVO-2923](https://issue.swisscom.ch/browse/EVO-2923) by storing the domain in the id properly. 

I also had to rewrite a translatable controller test so it works more like the actual reading of translatables.