### PR TITLE
set additional information field to non-requiered to keep versatility…

### DIFF
--- a/src/Graviton/FileBundle/Resources/definition/File.json
+++ b/src/Graviton/FileBundle/Resources/definition/File.json
@@ -84,7 +84,7 @@
         "type": "string",
         "title": "property name",
         "description": "additional property name",
-        "required": true,
+        "required": false,
         "translatable": false
       },
       {
@@ -92,7 +92,7 @@
         "type": "string",
         "title": "property value",
         "description": "additional property value",
-        "required": true,
+        "required": false,
         "translatable": false
       }
     ]


### PR DESCRIPTION
The availability must be ensured by the client. If not, the service will loose its generic state