### PR TITLE
Hide realId from schema output

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/RequiredHashControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/RequiredHashControllerTest.php
@@ -297,4 +297,20 @@ class RequiredHashControllerTest extends RestTestCase
             $client->getResults()
         );
     }
+
+    /**
+     * check that schema does not contain realId artefacts
+     *
+     * @return void
+     */
+    public function testCollectionHasNoRealId()
+    {
+        $client = static::createRestclient();
+        $client->request('GET', '/schema/testcase/requiredhash/collection');
+
+        $response = $client->getResponse();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertNotContains('realId', $response->getContent());
+    }
 }

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -191,6 +191,10 @@ class SchemaUtils
             if (!isset($documentFieldNames[$field])) {
                 continue;
             }
+            // hide realId field (I was aiming at a cleaner solution than the macig realId string initially)
+            if ($meta->getTypeOfField($field) == 'id' && $field == 'realId') {
+                continue;
+            }
 
             $property = new Schema();
             $property->setTitle($model->getTitleOfField($field));


### PR DESCRIPTION
This is a rather quick solution. I tried removing the realId earlier, but need to do it so late due so I don't break everywhere else this is used.

I'm also checking that the field is an id since that enables us to still use the name realId for other purposes if we need to.

This replaces #376 with something a bit more surgical but also a bit hacky...