### PR TITLE
Simple migration for translatable index

### DIFF
--- a/src/Graviton/I18nBundle/Migrations/MongoDB/Version20160303110805.php
+++ b/src/Graviton/I18nBundle/Migrations/MongoDB/Version20160303110805.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Index migration
+ */
+
+namespace Graviton\I18nBundle\Migrations\MongoDB;
+
+use AntiMattr\MongoDB\Migrations\AbstractMigration;
+use Doctrine\MongoDB\Database;
+use MongoDB;
+use MongoCollection;
+
+/**
+ * Migrate domain_1_locale_1_original_1 index
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/MIT MIT License
+ * @link     http://swisscom.ch
+ */
+class Version20160303110805 extends AbstractMigration
+{
+    /**
+     * @var string
+     */
+    private $collection = 'Translatable';
+
+    /**
+     * @var array
+     */
+    private $index = ['domain' => 1, 'locale' => 1, 'original' => 1];
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'drop the uniqueness of the domain_1_locale_1_original_1 index';
+    }
+
+    /**
+     * recreate index without unique flag
+     *
+     * @param Database $db database to migrate
+     *
+     * @return void
+     */
+    public function up(Database $db)
+    {
+        $db->createCollection($this->collection)->deleteIndex($this->index);
+        $db->createCollection($this->collection)->ensureIndex($this->index);
+    }
+
+    /**
+     * re-add unique flag to index
+     *
+     * @param Database $db database to migrate
+     *
+     * @return void
+     */
+    public function down(Database $db)
+    {
+        $db->createCollection($this->collection)->deleteIndex($this->index);
+        $db->createCollection($this->collection)->ensureIndex($this->index, ['unique' => true]);
+    }
+}

--- a/src/Graviton/I18nBundle/Resources/config/migrations.yml
+++ b/src/Graviton/I18nBundle/Resources/config/migrations.yml
@@ -1,0 +1,7 @@
+---
+name: graviton-i18n-bundle migrations
+collection_name: graviton-i18n-bundle-migrations
+migrations_namespace: Graviton\I18nBundle\Migrations\MongoDB
+migrations_directory: vendor/graviton/graviton/src/Graviton/I18nBundle/Migrations/MongoDB
+# use the next line if you need to migrate a bare graviton (rarely the case)
+#migrations_directory: src/Graviton/I18nBundle/Migrations/MongoDB


### PR DESCRIPTION
I prepared this so it will work in wrappers and you need to do some small changes if you want to test it without cloning it in a wrappe (as noted in migrations.yml). We should not really need this on bare graviton deploys anyhow since those are not getting a lot of action and have way less potential for conflicts.

I created a test branch on an internal wrapper to demonstrate how this works... Hit me up if you can't find it.