### PR TITLE
Optimize tests

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -11,6 +11,7 @@ framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
+        enabled: false
         collect: false
 
 web_profiler:


### PR DESCRIPTION
This starts doing what #378 tried to do as well. The two changes have been tried locally numerous times and they each make the integration testsuite several minutes faster.

Let me know if you know any other optimizations that might help. I'm still looking for a way to make fixture loading faster for one.