### PR TITLE
Fix cors headers for mock auth

### DIFF
--- a/src/Graviton/RestBundle/Listener/CorsResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/CorsResponseListener.php
@@ -20,12 +20,12 @@ class CorsResponseListener
     /**
      * @var string[]
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * @var string[]
      */
-    private $allowHeaders = array('Content-Type', 'Content-Language', 'If-None-Match');
+    private $allowHeaders = [];
 
     /**
      * add an allowed header
@@ -37,6 +37,18 @@ class CorsResponseListener
     public function addHeader($header)
     {
         $this->headers[] = $header;
+    }
+
+    /**
+     * add an allowed header
+     *
+     * @param string $header header to expose
+     *
+     * @return void
+     */
+    public function addAllowHeader($header)
+    {
+        $this->allowHeaders[] = $header;
     }
 
     /**

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -205,6 +205,15 @@
             <call method="addHeader">
                 <argument>X-Total-Count</argument>
             </call>
+            <call method="addAllowHeader">
+                <argument>Content-Type</argument>
+            </call>
+            <call method="addAllowHeader">
+                <argument>Content-Language</argument>
+            </call>
+            <call method="addAllowHeader">
+                <argument>If-None-Match</argument>
+            </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -214,6 +214,10 @@
             <call method="addAllowHeader">
                 <argument>If-None-Match</argument>
             </call>
+            <!-- we need to allow this header since clients routinely send it even though we want to replace it with something sane like OAuth2 -->
+            <call method="addAllowHeader">
+                <argument>X-REST-Token</argument>
+            </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 


### PR DESCRIPTION
I'm moving the Access-Control-Allow-Headers to the DIC for consistency. I'm also allowing the X-REST-Token header since most clients are sending that due to how they implemented against legacy.

This is a fix for some issues we are seeing on rel-pub...