### PR TITLE
flexibilize monolog log destination via incenteev

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -16,7 +16,7 @@ monolog:
     handlers:
         main:
             type:   stream
-            path:   "%kernel.logs_dir%/%kernel.environment%.log"
+            path:   "%graviton.log.path%"
             level:  debug
         console:
             type:   console

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -20,7 +20,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  "%kernel.logs_dir%/%kernel.environment%.log"
+            path:  "%graviton.log.path%"
             level: debug
         console:
             type:  console

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -3,6 +3,8 @@ parameters:
     graviton.mongodb.default.server.db: db
     graviton.mongodb.default.server.uri: ~
 
+    graviton.log.path: "%kernel.logs_dir%/%kernel.environment%.log"
+
     # Dependency injection in Security Bundle
     graviton.security.authentication.header_required: false
     graviton.security.authentication.test_username: false
@@ -62,7 +64,7 @@ parameters:
         - 'document.#'
     # pagination defaults
     graviton.rest.pagination.limit: 10
-    
+
     # how to call composer on this machine
     graviton.composer.cmd: composer
 

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
             {
                 "file": "app/config/parameters.yml",
                 "env-map": {
+                    "graviton.log.path": "LOG_PATH",
                     "graviton.mongodb.default.server.db": "MONGODB_DB",
                     "graviton.mongodb.default.server.uri": "MONGODB_URI",
                     "graviton.errbit.api_key": "ERRBIT_API_KEY",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "110d8543053f99ec79b298be65130dd9",
-    "content-hash": "f49ecf1aecb7cadb270d76e7de1e78fd",
+    "hash": "d65b1aad005a8635de059f4e1e22dbea",
+    "content-hash": "dab14af59055d37426430b4f3d3b826d",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",


### PR DESCRIPTION
We want to expose the log file destination for our Docker CD infrastructure..
Once tagged, I'll open PRs for the wrappers..

I tested this locally with a branch on a wrapper - setting the parameter to `php://stdout` indeed makes `ERROR`s pop up on the stdout of the `*-backend` docker container using `docker logs`

I guess we leave the loglevel on `error` on `prod` environment?
