### PR TITLE
add OPTIONS to /core/version and its schema

### DIFF
--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -15,7 +15,7 @@
   <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsSchemaAction</default>
   </route>
-  <route id="graviton.core.static.version.canonicalSchemaOptions" path="/schema/core/version" methods="OPTIONS">
+  <route id="graviton.core.static.version.canonicalSchema.options" path="/schema/core/version" methods="OPTIONS">
     <default key="_controller">graviton.core.controller.version:optionsAction</default>
   </route>
 </routes>

--- a/src/Graviton/CoreBundle/Resources/config/routing.xml
+++ b/src/Graviton/CoreBundle/Resources/config/routing.xml
@@ -9,7 +9,13 @@
   <route id="graviton.core.static.version.get" path="/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsAction</default>
   </route>
+  <route id="graviton.core.static.version.options" path="/core/version" methods="OPTIONS">
+    <default key="_controller">graviton.core.controller.version:optionsAction</default>
+  </route>
   <route id="graviton.core.static.version.canonicalSchema" path="/schema/core/version" methods="GET">
     <default key="_controller">graviton.core.controller.version:versionsSchemaAction</default>
+  </route>
+  <route id="graviton.core.static.version.canonicalSchemaOptions" path="/schema/core/version" methods="OPTIONS">
+    <default key="_controller">graviton.core.controller.version:optionsAction</default>
   </route>
 </routes>

--- a/src/Graviton/RestBundle/Service/RestUtils.php
+++ b/src/Graviton/RestBundle/Service/RestUtils.php
@@ -171,7 +171,7 @@ final class RestUtils implements RestUtilsInterface
                 if (strpos($route->getPath(), '/schema') === 0) {
                     return false;
                 }
-                if ($route->getPath() == '/') {
+                if ($route->getPath() == '/' || $route->getPath() == '/core/version') {
                     return false;
                 }
 


### PR DESCRIPTION
Currently, beco has this error when it tries to load `/core/version` via XHR (a.k.a "ajax") as the browser makes a preflight `OPTIONS`:

```
XMLHttpRequest cannot load http://api.dev-pub.szkb.evoja.ch/core/version. Response for preflight has invalid HTTP status code 405
```

This is, because somebody forgot to add `OPTIONS` method to `/core/version` - here we add it ;-)