### PR TITLE
ALIDA auth header

### DIFF
--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -218,6 +218,10 @@
             <call method="addAllowHeader">
                 <argument>X-REST-Token</argument>
             </call>
+            <!-- we need to allow this header since clients routinely send it even though we want to replace it with something sane like OAuth2 -->
+            <call method="addAllowHeader">
+                <argument>X-AUTH-Token</argument>
+            </call>
             <tag name="kernel.event_listener" event="graviton.rest.response" method="onKernelResponse"/>
         </service>
 


### PR DESCRIPTION
Due to the ALIDA auth a new header is needed. This will be later replaced with oauth2.