### PR TITLE
Feature/bigfix proxy httploader

### DIFF
--- a/src/Graviton/ProxyBundle/Definition/Loader/HttpLoader.php
+++ b/src/Graviton/ProxyBundle/Definition/Loader/HttpLoader.php
@@ -220,7 +220,7 @@ class HttpLoader implements LoaderInterface
      *
      * @return string
      */
-    protected function fetchFile(RequestInterface $request)
+    private function fetchFile(RequestInterface $request)
     {
         $content = "{}";
         try {

--- a/src/Graviton/ProxyBundle/Definition/Loader/HttpLoader.php
+++ b/src/Graviton/ProxyBundle/Definition/Loader/HttpLoader.php
@@ -181,7 +181,7 @@ class HttpLoader implements LoaderInterface
      */
     public function load($input)
     {
-        $retVal = null;
+        $retVal = new ApiDefinition();
         if (isset($this->strategy)) {
             $request = $this->client->get($input);
             $this->applyCurlOptions($request);
@@ -220,7 +220,7 @@ class HttpLoader implements LoaderInterface
      *
      * @return string
      */
-    private function fetchFile($request)
+    protected function fetchFile(RequestInterface $request)
     {
         $content = "{}";
         try {
@@ -229,8 +229,7 @@ class HttpLoader implements LoaderInterface
             if (isset($this->cache)) {
                 $this->cache->save($this->options['storeKey'], $content, $this->cacheLifetime);
             }
-        } catch (\Guzzle\Http\Exception\RequestException $e) {
-
+        } catch (\Guzzle\Http\Exception\HttpException $e) {
             $this->logger->info(
                 "Unable to fetch File!",
                 [

--- a/src/Graviton/ProxyBundle/Tests/Definition/Loader/HttpLoaderTest.php
+++ b/src/Graviton/ProxyBundle/Tests/Definition/Loader/HttpLoaderTest.php
@@ -97,10 +97,10 @@ class HttpLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @return HttpLoader
      */
-    public function testLoadReturnNull()
+    public function testLoadShallNotReturnNull()
     {
         $url = "http://localhost/test.json";
-        $this->assertNull($this->sut->load($url));
+        $this->assertNotNull($this->sut->load($url));
 
         $mock = $this->getMockBuilder('Graviton\ProxyBundle\Definition\Loader\DispersalStrategy\SwaggerStrategy')
             ->disableOriginalConstructor()
@@ -112,13 +112,13 @@ class HttpLoaderTest extends \PHPUnit_Framework_TestCase
             ->willReturn(false);
 
         $this->sut->setDispersalStrategy($mock);
-        $this->assertNull($this->sut->load($url));
+        $this->assertNotNull($this->sut->load($url));
     }
 
     /**
      * test the load method
      *
-     * @depends testLoadReturnNull
+     * @depends testLoadShallNotReturnNull
      *
      * @return void
      */


### PR DESCRIPTION
Not being strict with return value caused error when external Swagger service is not available. 