### PR TITLE
http 200 causes cors preflights to cache content

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -223,17 +223,24 @@ class AppControllerTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->request('OPTIONS', '/core/app/?invalidrqlquery');
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request('OPTIONS', '/schema/core/app/collection?invalidrqlquery');
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request('OPTIONS', '/schema/core/app/item?invalidrqlquery');
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+
+        $client = static::createRestClient();
+        $client->request('GET', '/schema/core/app/collection?invalidrqlquery');
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
 
-        foreach (['GET', 'OPTIONS'] as $method) {
-            $client = static::createRestClient();
-            $client->request($method, '/schema/core/app/collection?invalidrqlquery');
-            $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $client = static::createRestClient();
+        $client->request('GET', '/schema/core/app/item?invalidrqlquery');
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
 
-            $client = static::createRestClient();
-            $client->request($method, '/schema/core/app/item?invalidrqlquery');
-            $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-        }
 
         $client = static::createRestClient();
         $client->post('/core/app/?invalidrqlquery', $appData);

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -228,7 +228,7 @@ class AppControllerTest extends RestTestCase
         foreach (['GET', 'OPTIONS'] as $method) {
             $client = static::createRestClient();
             $client->request($method, '/schema/core/app/collection?invalidrqlquery');
-            $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+            $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
 
             $client = static::createRestClient();
             $client->request($method, '/schema/core/app/item?invalidrqlquery');

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -619,7 +619,7 @@ class RestController
         list($app, $module, , $modelName) = explode('.', $request->attributes->get('_route'));
 
         $response = $this->response;
-        $response->setStatusCode(Response::HTTP_OK);
+        $response->setStatusCode(Response::HTTP_NO_CONTENT);
 
         // enabled methods for CorsListener
         $corsMethods = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';


### PR DESCRIPTION
changed the returned http status for options requests to 204 to preve…nt browser from caching cors preflights