### PR TITLE
Feature/evo 4597 rabbitmq handling

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -175,26 +175,22 @@ old_sound_rabbit_mq:
             read_write_timeout: 3
 
             # requires php-amqplib v2.4.1+ and PHP5.4+
-            keepalive: false
+            keepalive: true
 
             # requires php-amqplib v2.4.1+
             heartbeat: 0
+
     producers:
         document_event:
+            auto_setup_fabric: false
             class: OldSound\RabbitMqBundle\RabbitMq\Producer
             connection: default
-            exchange_options:
-                name: graviton
-                type: topic
-    consumers:
-        dump:
-            connection: default
-            exchange_options:
-                name: graviton
-                type: topic
-            queue_options:
-                routing_keys: %graviton.rabbitmq.consumer.dump.routingkeys%
-            callback: graviton.rabbitmq.consumer.dump
+            auto_setup_fabric: true
+            #queue_options:
+            #    name: graviton
+            #    passive:     false
+            #    durable:     true
+            #    exclusive:   false
 
 graviton_proxy:
     sources:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -175,7 +175,7 @@ old_sound_rabbit_mq:
             read_write_timeout: 3
 
             # requires php-amqplib v2.4.1+ and PHP5.4+
-            keepalive: true
+            keepalive: false
 
             # requires php-amqplib v2.4.1+
             heartbeat: 0
@@ -186,11 +186,6 @@ old_sound_rabbit_mq:
             class: OldSound\RabbitMqBundle\RabbitMq\Producer
             connection: default
             auto_setup_fabric: true
-            #queue_options:
-            #    name: graviton
-            #    passive:     false
-            #    durable:     true
-            #    exclusive:   false
 
 graviton_proxy:
     sources:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -185,7 +185,6 @@ old_sound_rabbit_mq:
             auto_setup_fabric: false
             class: OldSound\RabbitMqBundle\RabbitMq\Producer
             connection: default
-            auto_setup_fabric: true
 
 graviton_proxy:
     sources:

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -147,7 +147,9 @@ class EventStatusLinkResponseListener
         // only if we have subscribers, it will create more load as it persists an EventStatus
         $queueEvent = $this->createQueueEventObject();
 
-        /** @var Response $response */
+        /**
+         * @var Response $response
+         */
         $response = $event->getResponse();
 
         if (!empty($queueEvent->getStatusurl()) && !empty($queueEvent->getEvent())) {
@@ -167,12 +169,11 @@ class EventStatusLinkResponseListener
 
         // let's send it to the queue(s) if appropriate
         if (!empty($queueEvent->getEvent())) {
-            $aQueuesForEvent = $this->getSubscribedWorkerIds($queueEvent);
-            foreach( $aQueuesForEvent as $sQueueForEvent )
-            {
+            $queuesForEvent = $this->getSubscribedWorkerIds($queueEvent);
+            foreach ($queuesForEvent as $queueForEvent) {
                 // declare the Queue for the Event if its not there already declared
-                $this->rabbitMqProducer->getChannel()->queue_declare($sQueueForEvent, false, true, false, false);
-                $this->rabbitMqProducer->publish( json_encode($queueEvent), $sQueueForEvent );
+                $this->rabbitMqProducer->getChannel()->queue_declare($queueForEvent, false, true, false, false);
+                $this->rabbitMqProducer->publish(json_encode($queueEvent), $queueForEvent);
             }
         }
     }

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -165,49 +165,16 @@ class EventStatusLinkResponseListener
             );
         }
 
-        // let's send it to the queue if appropriate
+        // let's send it to the queue(s) if appropriate
         if (!empty($queueEvent->getEvent())) {
-            $sQueueForEvent = $this->getRBMQueueNameForEvent($queueEvent->getEvent());
-            if( strlen($sQueueForEvent) )
+            $aQueuesForEvent = $this->getSubscribedWorkerIds($queueEvent);
+            foreach( $aQueuesForEvent as $sQueueForEvent )
             {
                 // declare the Queue for the Event if its not there already declared
                 $this->rabbitMqProducer->getChannel()->queue_declare($sQueueForEvent, false, true, false, false);
                 $this->rabbitMqProducer->publish( json_encode($queueEvent), $sQueueForEvent );
             }
         }
-    }
-
-    /**
-     * @param String $sEventname the Eventname
-     *
-     * @return String Queuename for the RabbitMQ
-     * @Todo $aEventQueues must be fetched from the MongoDB!!!, Collection EventWorker.
-     * This Collection contains the registered Worker-Ids and the events to them
-     * Find out what's up with the generated Model of it (GravitonDyn/EventWorkerBundle) and get it!
-     * This current code is not the solution!!!
-     */
-    private function getRBMQueueNameForEvent( $sInputEventname ) {
-        $sQueueName = '';
-        $aEventQueues = array(
-            'nios-printing' => array(
-                'document.file.file.create',
-                'document.printdocument.printdocument.create',
-                'document.file.file.update',
-                'document.printdocument.printdocument.update'
-            ),
-            'investment-worker' => array(
-                'document.printinvestmentdocument.printinvestmentdocument.create',
-                'document.printinvestmentdocument.printinvestmentdocument.update'
-            ),
-        );
-        foreach($aEventQueues as $sEventQueueName => $aEventQueueDef) {
-            foreach( $aEventQueueDef as $sEventName ) {
-                if( strstr($sEventName, $sInputEventname) ) {
-                    return $sEventQueueName;
-                }
-            }
-        }
-        return $sQueueName;
     }
 
     /**

--- a/src/Graviton/RabbitMqBundle/README.md
+++ b/src/Graviton/RabbitMqBundle/README.md
@@ -10,4 +10,16 @@
 Central to this bundle is `Graviton\RabbitMqBundle\Listener\EventStatusLinkResponseListener`.
 It implements the logic as described in the [publicly available documentation](https://gravity-platform-docs.nova.scapp.io/api/event/).
 
+## RabbitMQ Handling
 
+The "onKernelResponse"-Method of EventStatusLinkResponseListener defines permanent Queue(s) on the RabbitMQ-Server, 
+named after the workerId(s) corresponding to the given Event. These are defined in the MongoDB according to the Registration of the Worker in Graviton
+Check enpoint /event/worker
+Whoever starts first - Graviton-Event (Producer) or Worker (Consumer) - defines the Queue. The Queue-Definitions must be compatible on both sides. 
+Changing the Queue-Settings only on one Side will lead to an Error.
+
+The Queues are defined as persistant even to a failure of the RabbitMQ-Server. RabbitMQ does a balanced round-robin dispatching to multiple workers 
+subscribed to one Queue. The RabbitMQ-Job will stay in the Queue until the Worker assigns a Message Aknowledgment to it.
+
+All this Behaviour is defined by settings on Graviton and/or Worker Side. The Infrastructure i.e. Docker Enviroment just has to provide a RabbitMQ-Server. 
+The Connection-Credentials are set in app/config

--- a/src/Graviton/RabbitMqBundle/README.md
+++ b/src/Graviton/RabbitMqBundle/README.md
@@ -14,7 +14,7 @@ It implements the logic as described in the [publicly available documentation](h
 
 The "onKernelResponse"-Method of EventStatusLinkResponseListener defines permanent Queue(s) on the RabbitMQ-Server, 
 named after the workerId(s) corresponding to the given Event. These are defined in the MongoDB according to the Registration of the Worker in Graviton
-Check enpoint /event/worker
+Check endpoint /event/worker
 Whoever starts first - Graviton-Event (Producer) or Worker (Consumer) - defines the Queue. The Queue-Definitions must be compatible on both sides. 
 Changing the Queue-Settings only on one Side will lead to an Error.
 

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -50,12 +50,12 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        $channelMock = $this->getMockBuilder(
+            '\PhpAmqpLib\Channel\AMQPChannel'
+        )->disableOriginalConstructor()->getMock();
+        
         $producerMock->expects($this->once())->method('getChannel')
-            ->willReturn(
-                $this->getMockBuilder(
-                '\PhpAmqpLib\Channel\AMQPChannel'
-                )->disableOriginalConstructor()->getMock()
-            );
+            ->willReturn($channelMock);
 
         $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->disableOriginalConstructor(
         )->setMethods(['generate'])->getMockForAbstractClass();

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -7,6 +7,8 @@ namespace Graviton\RabbitMqBundle\Tests\Listener;
 
 use Graviton\DocumentBundle\Entity\ExtReference;
 use Graviton\RabbitMqBundle\Listener\EventStatusLinkResponseListener;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPConnection;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -27,7 +29,8 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
     {
         $producerMock = $this->getMockBuilder(
             '\OldSound\RabbitMqBundle\RabbitMq\ProducerInterface'
-        )->disableOriginalConstructor()->setMethods(['publish'])->getMockForAbstractClass();
+        )->disableOriginalConstructor()->setMethods(['publish', 'getChannel'])->getMockForAbstractClass();
+        
         $producerMock->expects($this->once())->method('publish')
         ->will(
             $this->returnCallback(
@@ -40,12 +43,19 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
                     );
 
                     \PHPUnit_Framework_Assert::assertSame(
-                        'document.dude.config.create',
+                        'someWorkerId',
                         $routingKey
                     );
                 }
             )
         );
+
+        $producerMock->expects($this->once())->method('getChannel')
+            ->willReturn(
+                $this->getMockBuilder(
+                '\PhpAmqpLib\Channel\AMQPChannel'
+                )->disableOriginalConstructor()->getMock()
+            );
 
         $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->disableOriginalConstructor(
         )->setMethods(['generate'])->getMockForAbstractClass();
@@ -77,23 +87,23 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
 
         $cursorMock = $this->getMockBuilder('\Doctrine\MongoDB\CursorInterface')->disableOriginalConstructor(
         )->getMockForAbstractClass();
-        $cursorMock->expects($this->once())->method('toArray')->willReturn(['someWorkerId' => 'some content']);
+        $cursorMock->expects($this->any())->method('toArray')->willReturn(['someWorkerId' => 'some content']);
 
         $queryMock = $this->getMockBuilder('\Doctrine\MongoDB\Query\Query')->disableOriginalConstructor()->getMock();
-        $queryMock->expects($this->once())->method('execute')->willReturn($cursorMock);
+        $queryMock->expects($this->any())->method('execute')->willReturn($cursorMock);
 
         $queryBuilderMock = $this->getMockBuilder('\Doctrine\ODM\MongoDB\Query\Builder')->disableOriginalConstructor(
         )->getMock();
-        $queryBuilderMock->expects($this->once())->method('select')->willReturnSelf();
-        $queryBuilderMock->expects($this->once())->method('field')->willReturnSelf();
-        $queryBuilderMock->expects($this->once())->method('equals')->willReturnSelf();
-        $queryBuilderMock->expects($this->once())->method('getQuery')->willReturn($queryMock);
+        $queryBuilderMock->expects($this->any())->method('select')->willReturnSelf();
+        $queryBuilderMock->expects($this->any())->method('field')->willReturnSelf();
+        $queryBuilderMock->expects($this->any())->method('equals')->willReturnSelf();
+        $queryBuilderMock->expects($this->any())->method('getQuery')->willReturn($queryMock);
 
         $documentManagerMock = $this->getMockBuilder(
             '\Doctrine\ODM\MongoDB\DocumentManager'
         )->disableOriginalConstructor()->setMethods(['createQueryBuilder', 'persist', 'flush'])->getMock();
-        $documentManagerMock->expects($this->once())->method('createQueryBuilder')->willReturn($queryBuilderMock);
-        $documentManagerMock->expects($this->once())->method('persist')->with(
+        $documentManagerMock->expects($this->any())->method('createQueryBuilder')->willReturn($queryBuilderMock);
+        $documentManagerMock->expects($this->any())->method('persist')->with(
             $this->callback(
                 function ($obj) {
                     return
@@ -110,7 +120,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
                 }
             )
         );
-        $documentManagerMock->expects($this->once())->method('flush');
+        $documentManagerMock->expects($this->any())->method('flush');
 
         $extrefConverterMock = $this->getMockBuilder(
             '\Graviton\DocumentBundle\Service\ExtReferenceConverter'


### PR DESCRIPTION
- configured  OldSoundRabbitMqBundle from topic exchange with temporary Queues to default queues.
- removed the OldSoundRabbitMqBundle bundle settings for a Consumer, cause its not used currently and the settings caused problems
- moved the queue-definition prior to the EventPublishing in EventStatusLinkResponseListener, didn't use the auto-setup Feature of OldSoundRabbitMqBundle because it didn't work for the used definition.
- Queue definition: Permanent Queues named after the corresponding WorkerId to an Event.
- Events will be eventually published in more than one Queue
- Reduced "spamming" of Events in temporary Queues that no Consumer was ever listening to
- adapted tests
- added Information in the README of the RabbitMQBundle

corresponding PR for the Worker: https://github.com/libgraviton/graviton-worker-base-java/pull/25