### PR TITLE
EVO-4790 overwriting DocumentUrl and EventStatusUrl with relative paths

### DIFF
--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -171,6 +171,11 @@ class EventStatusLinkResponseListener
         if (!empty($queueEvent->getEvent())) {
             $queuesForEvent = $this->getSubscribedWorkerIds($queueEvent);
             foreach ($queuesForEvent as $queueForEvent) {
+                // overwrite $queueEvent documentUrl & statusUrl with relative path.
+                // Do it here, so just the $queueEvent sent to the WorkerBase is affected
+                $queueEvent->setDocumenturl(parse_url($queueEvent->getDocumenturl(), PHP_URL_PATH));
+                $queueEvent->setStatusurl(parse_url($queueEvent->getStatusurl(), PHP_URL_PATH));
+
                 // declare the Queue for the Event if its not there already declared
                 $this->rabbitMqProducer->getChannel()->queue_declare($queueForEvent, false, true, false, false);
                 $this->rabbitMqProducer->publish(json_encode($queueEvent), $queueForEvent);

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -31,14 +31,15 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
             '\OldSound\RabbitMqBundle\RabbitMq\ProducerInterface'
         )->disableOriginalConstructor()->setMethods(['publish', 'getChannel'])->getMockForAbstractClass();
         
+        // this test the values sent to RabbitMQ
         $producerMock->expects($this->once())->method('publish')
         ->will(
             $this->returnCallback(
                 function ($message, $routingKey) {
                     \PHPUnit_Framework_Assert::assertSame(
                         '{"event":"document.core.product.create","coreUserId":"",'.
-                        '"document":{"$ref":"graviton-api-test\/core\/product'.
-                        '"},"status":{"$ref":"http:\/\/graviton-test.lo\/worker\/123jkl890yui567mkl"}}',
+                        '"document":{"$ref":"\/dude\/4'.
+                        '"},"status":{"$ref":"\/worker\/123jkl890yui567mkl"}}',
                         $message
                     );
 
@@ -53,7 +54,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
         $channelMock = $this->getMockBuilder(
             '\PhpAmqpLib\Channel\AMQPChannel'
         )->disableOriginalConstructor()->getMock();
-        
+
         $producerMock->expects($this->once())->method('getChannel')
             ->willReturn($channelMock);
 
@@ -132,7 +133,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
             '\Graviton\RabbitMqBundle\Document\QueueEvent'
         )->setMethods(['getEvent', 'getDocumenturl'])->getMock();
         $queueEventMock->expects($this->exactly(5))->method('getEvent')->willReturn('document.dude.config.create');
-        $queueEventMock->expects($this->exactly(2))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
+        $queueEventMock->expects($this->exactly(3))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
 
         $filterResponseEventMock = $this->getMockBuilder(
             '\Symfony\Component\HttpKernel\Event\FilterResponseEvent'


### PR DESCRIPTION
This goes together with the upcoming Pull Request for the graviton-worker-base-java

- The paths in the QueueEvent to DocumentUrl and EventStatusUrl are overwritten with relative paths just before the QueueEvent is published in the RabbitMQ-Queue to minimize Side Effects.
- With this hack, the Worker can complete the path with http://apialias according to its settings. 
- Will let the workers dependent on worker-base do their jobs in the Docker-Environment

**not backwards compatibel!**

corresponding PR for the worker-base: https://github.com/libgraviton/graviton-worker-base-java/pull/26