### PR TITLE
Feature/evo 4790 configurable selfurl

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -73,4 +73,4 @@ parameters:
     graviton.proxy.swagger.sources: {}
 
     # Graviton SelfUrl FQDN or http://apialias just for usage in communication with Worker(s) via RabbitMQ
-    graviton.selfurl: http://127.0.0.1:8000
+    graviton.selfurl: http://apialias

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -71,3 +71,6 @@ parameters:
     graviton.proxy.httploader.curloptions: []
 
     graviton.proxy.swagger.sources: {}
+
+    # Graviton SelfUrl FQDN or http://apialias just for usage in communication with Worker(s) via RabbitMQ
+    graviton.selfurl: http://127.0.0.1:8000

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -178,18 +178,11 @@ class EventStatusLinkResponseListener
         // let's send it to the queue(s) if appropriate
         if (!empty($queueEvent->getEvent())) {
             $queuesForEvent = $this->getSubscribedWorkerIds($queueEvent);
+            // overwrite $queueEvent documentUrl & statusUrl with the FQDN or apialias injected from the settings.
+            // Do it here, so just the $queueEvent sent to the WorkerBase is affected
+            $queueEvent->setDocumenturl($this->gravitonSelfUrl.parse_url($queueEvent->getDocumenturl(), PHP_URL_PATH));
+            $queueEvent->setStatusurl($this->gravitonSelfUrl.parse_url($queueEvent->getStatusurl(), PHP_URL_PATH));
             foreach ($queuesForEvent as $queueForEvent) {
-                // overwrite $queueEvent documentUrl & statusUrl with the FQDN or apialias injected from the settings.
-                // Do it here, so just the $queueEvent sent to the WorkerBase is affected
-                $queueEvent->setDocumenturl(
-                    $this->gravitonSelfUrl.
-                    parse_url($queueEvent->getDocumenturl(), PHP_URL_PATH)
-                );
-                $queueEvent->setStatusurl(
-                    $this->gravitonSelfUrl.
-                    parse_url($queueEvent->getStatusurl(), PHP_URL_PATH)
-                );
-
                 // declare the Queue for the Event if its not there already declared
                 $this->rabbitMqProducer->getChannel()->queue_declare($queueForEvent, false, true, false, false);
                 $this->rabbitMqProducer->publish(json_encode($queueEvent), $queueForEvent);

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -129,6 +129,7 @@ class EventStatusLinkResponseListener
         $this->extRefConverter = $extRefConverter;
         $this->queueEventDocument = $queueEventDocument;
         $this->eventMap = $eventMap;
+        $this->gravitonSelfUrl = $gravitonSelfUrl;
         $this->eventWorkerClassname = $eventWorkerClassname;
         $this->eventStatusClassname = $eventStatusClassname;
         $this->eventStatusStatusClassname = $eventStatusStatusClassname;

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -181,8 +181,14 @@ class EventStatusLinkResponseListener
             foreach ($queuesForEvent as $queueForEvent) {
                 // overwrite $queueEvent documentUrl & statusUrl with the FQDN or apialias injected from the settings.
                 // Do it here, so just the $queueEvent sent to the WorkerBase is affected
-                $queueEvent->setDocumenturl($this->gravitonSelfUrl.parse_url($queueEvent->getDocumenturl(), PHP_URL_PATH));
-                $queueEvent->setStatusurl($this->gravitonSelfUrl.parse_url($queueEvent->getStatusurl(), PHP_URL_PATH));
+                $queueEvent->setDocumenturl(
+                    $this->gravitonSelfUrl.
+                    parse_url($queueEvent->getDocumenturl(), PHP_URL_PATH)
+                );
+                $queueEvent->setStatusurl(
+                    $this->gravitonSelfUrl.
+                    parse_url($queueEvent->getStatusurl(), PHP_URL_PATH)
+                );
 
                 // declare the Queue for the Event if its not there already declared
                 $this->rabbitMqProducer->getChannel()->queue_declare($queueForEvent, false, true, false, false);

--- a/src/Graviton/RabbitMqBundle/Resources/config/services.xml
+++ b/src/Graviton/RabbitMqBundle/Resources/config/services.xml
@@ -32,6 +32,7 @@
             <argument type="service" id="graviton.document.service.extrefconverter" />
             <argument type="service" id="graviton.rabbitmq.document.queueevent" />
             <argument>%graviton.document.eventmap%</argument>
+            <argument>%graviton.selfurl%</argument>
             <argument>%graviton.rabbitmq.document.eventworker.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatus.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatusstatus.class%</argument>

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -37,8 +37,8 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
                 function ($message, $routingKey) {
                     \PHPUnit_Framework_Assert::assertSame(
                         '{"event":"document.core.product.create","coreUserId":"",'.
-                        '"document":{"$ref":"graviton-api-test\/core\/product'.
-                        '"},"status":{"$ref":"http:\/\/graviton-test.lo\/worker\/123jkl890yui567mkl"}}',
+                        '"document":{"$ref":"http:\/\/apialias\/dude\/4'.
+                        '"},"status":{"$ref":"http:\/\/apialias\/worker\/123jkl890yui567mkl"}}',
                         $message
                     );
 
@@ -132,7 +132,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
             '\Graviton\RabbitMqBundle\Document\QueueEvent'
         )->setMethods(['getEvent', 'getDocumenturl'])->getMock();
         $queueEventMock->expects($this->exactly(5))->method('getEvent')->willReturn('document.dude.config.create');
-        $queueEventMock->expects($this->exactly(2))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
+        $queueEventMock->expects($this->exactly(3))->method('getDocumenturl')->willReturn('http://localhost/dude/4');
 
         $filterResponseEventMock = $this->getMockBuilder(
             '\Symfony\Component\HttpKernel\Event\FilterResponseEvent'
@@ -159,6 +159,7 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
                   ]
               ]
             ],
+            'http://apialias',
             '\GravitonDyn\EventWorkerBundle\Document\EventWorker',
             '\GravitonDyn\EventStatusBundle\Document\EventStatus',
             '\GravitonDyn\EventStatusBundle\Document\EventStatusStatus',


### PR DESCRIPTION
Instead of a relative path sent to the Worker which the worker completes, its much easier to make the Graviton-BaseUrl configurable - but just for the use with the RabbitMQ. This should work just as good and solve the "apialias-Problem" in the Docker-Environment.

- configurable
- downwards compatible
- no need for upgrading the worker-base and its dependent workers.

makes PRs https://github.com/libgraviton/graviton/pull/411 and https://github.com/libgraviton/graviton-worker-base-java/pull/26 obsolete