### PR TITLE
add new 'ignored' status to /event/status worker status

### DIFF
--- a/src/Graviton/RabbitMqBundle/Resources/config/services.xml
+++ b/src/Graviton/RabbitMqBundle/Resources/config/services.xml
@@ -68,6 +68,9 @@
                 <argument>working</argument>
             </call>
             <call method="addStatus">
+                <argument>ignored</argument>
+            </call>
+            <call method="addStatus">
                 <argument>done</argument>
             </call>
             <call method="addStatus">


### PR DESCRIPTION
for EVO-5106..

adds a new possible value for `status.status` in `/event/status`. The new `ignored` status shall be set by a worker if he decides to not do anything on a given work item, as opposed to just set it to `done`. The status `done` without having actually done anything is misleading, we need to be able to distinguish that case.