### PR TITLE
Spring cleaning :D

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "doctrine/mongodb-odm-bundle": "~3.1",
         "stof/doctrine-extensions-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
-        "davidbadura/faker-bundle": "~1.1",
         "misd/guzzle-bundle": "~1.1",
         "knplabs/knp-paginator-bundle": "~2.5",
         "php-jsonpointer/php-jsonpointer": "~1.1",
@@ -65,7 +64,8 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "dev-master",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "~0.18.1"
+        "graviton/test-services-bundle": "~0.18.1",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "08fd2f1a232854bb7af98c47bb79a8dd",
-    "content-hash": "cd1448494f9d1e9165f73a535a370b1b",
+    "hash": "09da0a426a4944e84b14c960963201b1",
+    "content-hash": "300b2911fd1326bf8745322c4242da6f",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -171,49 +171,6 @@
                 "transliterator"
             ],
             "time": "2015-09-28 16:26:35"
-        },
-        {
-            "name": "davidbadura/faker-bundle",
-            "version": "1.1.0",
-            "target-dir": "DavidBadura/FakerBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/DavidBadura/FakerBundle.git",
-                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/DavidBadura/FakerBundle/zipball/0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
-                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
-                "shasum": ""
-            },
-            "require": {
-                "fzaninotto/faker": "~1.0",
-                "php": ">=5.3.0",
-                "symfony/symfony": ">=2.6"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-0": {
-                    "DavidBadura\\FakerBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Badura",
-                    "email": "d.badura@gmx.de"
-                }
-            ],
-            "keywords": [
-                "Symfony2",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2015-09-14 08:59:32"
         },
         {
             "name": "dbtlr/php-airbrake",
@@ -1567,54 +1524,6 @@
                 "html"
             ],
             "time": "2015-08-05 01:03:42"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2016-04-29 12:21:54"
         },
         {
             "name": "gedmo/doctrine-extensions",
@@ -5536,6 +5445,97 @@
     ],
     "packages-dev": [
         {
+            "name": "davidbadura/faker-bundle",
+            "version": "1.1.0",
+            "target-dir": "DavidBadura/FakerBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DavidBadura/FakerBundle.git",
+                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DavidBadura/FakerBundle/zipball/0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
+                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "~1.0",
+                "php": ">=5.3.0",
+                "symfony/symfony": ">=2.6"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-0": {
+                    "DavidBadura\\FakerBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Badura",
+                    "email": "d.badura@gmx.de"
+                }
+            ],
+            "keywords": [
+                "Symfony2",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2015-09-14 08:59:32"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2016-04-29 12:21:54"
+        },
+        {
             "name": "graviton/test-services-bundle",
             "version": "v0.18.1",
             "source": {
@@ -6883,6 +6883,61 @@
                 "standards"
             ],
             "time": "2016-04-03 22:58:34"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "3231629ff97abccd60f93ff900accfb5b39c8200"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/3231629ff97abccd60f93ff900accfb5b39c8200",
+                "reference": "3231629ff97abccd60f93ff900accfb5b39c8200",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2016-04-12 18:09:53"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -52,6 +52,7 @@
     <ini name="xdebug.max_nesting_level" value="200"/>
     <ini name="memory_limit" value="-1"/>
     <env name="BOOTSTRAP_CLEAR_CACHE_ENV" value="test"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
   </php>
   <listeners>
     <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />

--- a/src/Graviton/CoreBundle/Controller/MainController.php
+++ b/src/Graviton/CoreBundle/Controller/MainController.php
@@ -13,6 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * MainController
@@ -160,8 +161,8 @@ class MainController
                 $schemaRoute = implode('.', array($app, $bundle, $rest, $document, 'canonicalSchema'));
 
                 return array(
-                    '$ref' => $router->generate($routeName, array(), true),
-                    'profile' => $router->generate($schemaRoute, array(), true),
+                    '$ref' => $router->generate($routeName, array(), UrlGeneratorInterface::ABSOLUTE_URL),
+                    'profile' => $router->generate($schemaRoute, array(), UrlGeneratorInterface::ABSOLUTE_URL),
                 );
             },
             array_keys($optionRoutes)
@@ -189,7 +190,7 @@ class MainController
         $links = new LinkHeader(array());
         $links->add(
             new LinkHeaderItem(
-                $this->router->generate('graviton.core.rest.app.all', array (), true),
+                $this->router->generate('graviton.core.rest.app.all', array (), UrlGeneratorInterface::ABSOLUTE_URL),
                 array ('rel' => 'apps', 'type' => 'application/json')
             )
         );
@@ -223,7 +224,7 @@ class MainController
         $mainRoute = $this->router->generate(
             'graviton.core.static.main.all',
             array(),
-            true
+            UrlGeneratorInterface::ABSOLUTE_URL
         );
         $services = array_map(
             function ($apiRoute) use ($mainRoute, $definition) {

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -39,9 +39,8 @@
             <tag name="graviton.rest"/>
         </service>
         <service id="graviton.core.repository.app"
-                 class="%graviton.core.repository.app.class%"
-                 factory-service="doctrine_mongodb.odm.default_document_manager"
-                 factory-method="getRepository">
+            class="%graviton.core.repository.app.class%">
+            <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
             <argument type="string">GravitonCoreBundle:App</argument>
         </service>
         <service id="graviton.core.model.app"
@@ -62,9 +61,8 @@
             <tag name="graviton.rest" read-only="true"/>
         </service>
         <service id="graviton.core.repository.product"
-                 class="%graviton.core.repository.product.class%"
-                 factory-service="doctrine_mongodb.odm.default_document_manager"
-                 factory-method="getRepository">
+            class="%graviton.core.repository.product.class%">
+            <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
             <argument type="string">GravitonCoreBundle:Product</argument>
         </service>
         <service id="graviton.core.model.product"

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -123,7 +123,7 @@ class MainControllerTest extends RestTestCase
             ->with(
                 $this->equalTo('graviton.core.rest.app.all'),
                 $this->isType('array'),
-                $this->isType('boolean')
+                $this->isType('int')
             )
             ->will($this->returnValue("http://localhost/core/app"));
 
@@ -179,7 +179,7 @@ class MainControllerTest extends RestTestCase
             ->with(
                 $this->isType('string'),
                 $this->isType('array'),
-                $this->isType('boolean')
+                $this->isType('int')
             )
             ->will(
                 $this->onConsecutiveCalls(

--- a/src/Graviton/DocumentBundle/Service/ExtReferenceConverter.php
+++ b/src/Graviton/DocumentBundle/Service/ExtReferenceConverter.php
@@ -8,6 +8,7 @@ namespace Graviton\DocumentBundle\Service;
 use Graviton\DocumentBundle\Entity\ExtReference;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Extref converter
@@ -87,7 +88,7 @@ class ExtReferenceConverter implements ExtReferenceConverterInterface
         return $this->router->generate(
             $this->mapping[$extReference->getRef()].'.get',
             ['id' => $extReference->getId()],
-            true
+            UrlGeneratorInterface::ABSOLUTE_URL
         );
     }
 

--- a/src/Graviton/FileBundle/Resources/config/services.xml
+++ b/src/Graviton/FileBundle/Resources/config/services.xml
@@ -17,7 +17,8 @@
         <parameter key="graviton.file.file_manager.class">Graviton\FileBundle\FileManager</parameter>
     </parameters>
     <services>
-        <service id="graviton.aws_s3.client" class="%graviton.aws_s3.client.class%" factory-class="%graviton.aws_s3.client.class%" factory-method="factory">
+        <service id="graviton.aws_s3.client" class="%graviton.aws_s3.client.class%">
+            <factory class="%graviton.aws_s3.client.class%" method="factory"/>
             <argument>%graviton.aws_s3.client.args%</argument>
         </service>
 

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -609,8 +609,12 @@ class ResourceGenerator extends AbstractGenerator
             $this->addAttributeToNode('class', '%' . $id . '.class%', $dom, $attrNode);
             $this->addAttributeToNode('parent', $parent, $dom, $attrNode);
             $this->addAttributeToNode('scope', $scope, $dom, $attrNode);
-            $this->addAttributeToNode('factory-service', $factoryService, $dom, $attrNode);
-            $this->addAttributeToNode('factory-method', $factoryMethod, $dom, $attrNode);
+            if ($factoryService && $factoryMethod) {
+                $factoryNode = $dom->createElement('factory');
+                $this->addAttributeToNode('service', $factoryService, $dom, $factoryNode);
+                $this->addAttributeToNode('method', $factoryMethod, $dom, $factoryNode);
+                $attrNode->appendChild($factoryNode);
+            }
             $this->addCallsToService($calls, $dom, $attrNode);
 
             if ($tag) {

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -35,9 +35,8 @@
   <services>
     <service id="graviton.i18n.document.language" class="%graviton.i18n.document.language.class%"/>
     <service id="graviton.i18n.repository.language"
-             class="%graviton.i18n.repository.language.class%"
-             factory-service="doctrine_mongodb.odm.default_document_manager"
-         factory-method="getRepository">
+        class="%graviton.i18n.repository.language.class%">
+      <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
       <argument type="string">GravitonI18nBundle:Language</argument>
     </service>
     <service id="graviton.i18n.model.language"
@@ -57,15 +56,13 @@
       <tag name="graviton.rest"/>
     </service>
     <service id="graviton.i18n.repository.translatable"
-      class="%graviton.i18n.repository.translatable.class%"
-      factory-service="doctrine_mongodb.odm.default_document_manager"
-      factory-method="getRepository">
+        class="%graviton.i18n.repository.translatable.class%">
+      <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
       <argument type="string">GravitonI18nBundle:Translatable</argument>
     </service>
     <service id="graviton.i18n.repository.translatablelanguage"
-      class="%graviton.i18n.repository.translatablelanguage.class%"
-      factory-service="doctrine_mongodb.odm.default_document_manager"
-      factory-method="getRepository">
+        class="%graviton.i18n.repository.translatablelanguage.class%">
+      <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
       <argument type="string">GravitonI18nBundle:TranslatableLanguage</argument>
     </service>
     <service id="graviton.i18n.model.translatable"
@@ -114,7 +111,9 @@
       <tag name="translation.loader" alias="odm"/>
     </service>
     <service id="graviton.i18n.translator" alias="translator"/>
-    <service id="graviton.i18n.request" class="%graviton.i18n.request.class%" factory-service="request_stack" factory-method="getCurrentRequest"/>
+    <service id="graviton.i18n.request" class="%graviton.i18n.request.class%">
+      <factory service="request_stack" method="getCurrentRequest"/>
+    </service>
     <service id="graviton.i18n.listener.i18nserializer" class="%graviton.i18n.listener.i18nserializer.class%">
       <call method="setUtils">
         <argument type="service" id="graviton.18n.utils"/>

--- a/src/Graviton/PersonBundle/Resources/config/services.xml
+++ b/src/Graviton/PersonBundle/Resources/config/services.xml
@@ -14,9 +14,8 @@
     <service id="graviton.person.controller.abstractcustomer" abstract="true" parent="graviton.rest.controller" class="%graviton.person.controller.abstractcustomer.class%">
     </service>
     <service id="graviton.person.repository.personcontact"
-             class="%graviton.person.repository.personcontact.class%"
-             factory-service="doctrine_mongodb.odm.default_document_manager"
-             factory-method="getRepository">
+        class="%graviton.person.repository.personcontact.class%">
+      <factory service="doctrine_mongodb.odm.default_document_manager" method="getRepository"/>
       <argument type="string">GravitonPersonBundle:PersonContact</argument>
     </service>
     <service id="graviton.person.model.personcontact"

--- a/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/SelfLinkResponseListener.php
@@ -9,6 +9,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\RestBundle\Event\RestEvent;
@@ -88,7 +89,7 @@ class SelfLinkResponseListener
             }
             $url = $this->getRqlUrl(
                 $request,
-                $this->router->generate($routeName, $params, true) . $query
+                $this->router->generate($routeName, $params, UrlGeneratorInterface::ABSOLUTE_URL) . $query
             );
         } catch (\Exception $e) {
             $addHeader = false;

--- a/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/CanonicalSchemaLinkResponseListener.php
@@ -7,6 +7,7 @@ namespace Graviton\SchemaBundle\Listener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\SchemaBundle\SchemaUtils;
@@ -48,7 +49,7 @@ class CanonicalSchemaLinkResponseListener
             $linkHeader = LinkHeader::fromResponse($response);
 
             $routeName = SchemaUtils::getSchemaRouteName($request->get('_route'));
-            $url = $this->router->generate($routeName, array(), true);
+            $url = $this->router->generate($routeName, array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
             // append rel=canonical link to link headers
             $linkHeader->add(new LinkHeaderItem($url, array('rel' => 'canonical')));

--- a/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
+++ b/src/Graviton/SchemaBundle/Listener/SchemaContentTypeResponseListener.php
@@ -7,6 +7,7 @@ namespace Graviton\SchemaBundle\Listener;
 
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\SchemaBundle\SchemaUtils;
 
@@ -57,7 +58,10 @@ class SchemaContentTypeResponseListener
         if ($request->get('_route') != 'graviton.core.static.main.all') {
             try {
                 $schemaRoute = SchemaUtils::getSchemaRouteName($request->get('_route'));
-                $contentType .= sprintf('; profile=%s', $this->router->generate($schemaRoute, array(), true));
+                $contentType .= sprintf(
+                    '; profile=%s',
+                    $this->router->generate($schemaRoute, array(), UrlGeneratorInterface::ABSOLUTE_URL)
+                );
             } catch (\Exception $e) {
                 return true;
             }

--- a/src/Graviton/SchemaBundle/SchemaUtils.php
+++ b/src/Graviton/SchemaBundle/SchemaUtils.php
@@ -13,6 +13,7 @@ use Graviton\SchemaBundle\Document\Schema;
 use Graviton\SchemaBundle\Service\RepositoryFactory;
 use Metadata\MetadataFactoryInterface as SerializerMetadataFactoryInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Utils for generating schemas.
@@ -265,7 +266,7 @@ class SchemaUtils
                         $urls[] = $this->router->generate(
                             $this->extrefServiceMapping[$collection].'.all',
                             [],
-                            true
+                            UrlGeneratorInterface::ABSOLUTE_URL
                         );
                     } elseif ($collection === '*') {
                         $urls[] = '*';

--- a/src/Graviton/SecurityBundle/Resources/config/services.xml
+++ b/src/Graviton/SecurityBundle/Resources/config/services.xml
@@ -48,10 +48,9 @@
         </service>
 
         <service id="graviton.security.authentication.provider"
-                 class="Graviton\RestBundle\Model\ModelInterface"
-                 factory-service="graviton.security.authentication.factory"
-                 factory-method="create"
-                />
+                 class="Graviton\RestBundle\Model\ModelInterface">
+            <factory service="graviton.security.authentication.factory" method="create"/>
+        </service>
 
         <service id="graviton.security.authentication.provider.model.noop"
                  class="Graviton\SecurityBundle\User\Model\NullModel">

--- a/src/Graviton/TestBundle/Resources/config/services.xml
+++ b/src/Graviton/TestBundle/Resources/config/services.xml
@@ -25,6 +25,8 @@
     </service>
     <service id="test.client.history" class="%test.client.history.class%" scope="prototype" />
     <service id="test.client.cookiejar" class="%test.client.cookiejar.class%" scope="prototype" />
-    <service id="test.faker" class="%test.faker.faker.class%" factory-class="%test.faker.factory.class%" factory-method="create"/>
+    <service id="test.faker" class="%test.faker.faker.class%">
+      <factory class="%test.faker.factory.class%" method="create"/>
+    </service>
    </services>
 </container>


### PR DESCRIPTION
This gets rid of some deprecation warning by doing the following.

* update calls to `router->generate` to use constant based argument
* rewrite factory service configuration to the `<factory>` tag style
* dropping faker from production requirements since it should not be there and does not see any use
* install `symfony/phpunit-bridge` to aid future development

There are still more deprecated things going on but I prefer not to bloat this PR. Maybe we'll be able to remove `SYMFONY_DEPRECATIONS_HELPER=weak` after having fixed more stuff at a later stage.