### PR TITLE
Add indexes as defined in target.indexes to doctrine mapping

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Config.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Config.json
@@ -38,7 +38,11 @@
         ]
     },
     "target": {
-        "indexes": [],
+        "indexes": [
+          "key",
+          "default",
+          "value"    
+        ],
         "relations": [],
         "fields": [
             {

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinition.php
@@ -453,4 +453,16 @@ class JsonDefinition
 
         return $collectionName;
     }
+
+    /**
+     * @return string[]
+     */
+    public function getIndexes()
+    {
+        $indexes = [];
+        if ($this->def->getTarget()->getIndexes()) {
+            $indexes = $this->def->getTarget()->getIndexes();
+        }
+        return $indexes;
+    }
 }

--- a/src/Graviton/GeneratorBundle/Definition/Schema/Target.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/Target.php
@@ -23,6 +23,11 @@ class Target
     private $fields = [];
 
     /**
+     * @var string[]
+     */
+    private $indexes = [];
+
+    /**
      * @return Relation[]
      */
     public function getRelations()
@@ -76,5 +81,23 @@ class Target
     {
         $this->fields[] = $field;
         return $this;
+    }
+
+    /**
+     * @param string[] $indexes indexes from json def
+     * @return $this
+     */
+    public function setIndexes($indexes)
+    {
+        $this->indexes = $indexes;
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIndexes()
+    {
+        return $this->indexes;
     }
 }

--- a/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/ResourceGenerator.php
@@ -165,6 +165,7 @@ class ResourceGenerator extends AbstractGenerator
             ->setParameter('isrecordOriginFlagSet', $this->json->isRecordOriginFlagSet())
             ->setParameter('recordOriginModifiable', $this->json->isRecordOriginModifiable())
             ->setParameter('collection', $this->json->getServiceCollection())
+            ->setParameter('indexes', $this->json->getIndexes())
             ->getParameters();
 
         $this->generateDocument($parameters, $dir, $document, $withRepository);
@@ -223,7 +224,7 @@ class ResourceGenerator extends AbstractGenerator
                 $parameters,
                 [
                     'document' => $document.'Embedded',
-                    'docType' => 'embedded-document',
+                    'docType' => 'embedded-document'
                 ]
             )
         );

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Target.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Target.xml
@@ -7,5 +7,8 @@
         <property name="fields"
                   type="array&lt;Graviton\GeneratorBundle\Definition\Schema\Field&gt;"
                   serialized-name="fields"/>
+        <property name="indexes"
+                  type="array&lt;string&gt;"
+                  serialized-name="indexes"/>
     </class>
 </serializer>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -74,5 +74,15 @@
             <field fieldName="recordOrigin" type="string" strategy="pushAll"/>
         {% endif %}
 
+        {% if indexes is defined and indexes is not empty %}
+            <indexes>
+                <index background="true">
+            {% for index in indexes %}
+                    <key name="{{ index }}"/>
+            {% endfor %}
+                </index>
+            </indexes>
+        {% endif %}
+
     </{{ docType }}>
 </doctrine-mongo-mapping>

--- a/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
@@ -669,6 +669,12 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('intarray', $field->getName());
     }
 
+    public function testIndexes()
+    {
+        $jsonDef = $this->loadJsonDefinition($this->fullDefPath);
+        $this->assertInternalType('array', $jsonDef->getIndexes());
+    }
+
     /**
      * Get field by path
      *

--- a/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionTest.php
@@ -669,6 +669,11 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('intarray', $field->getName());
     }
 
+    /**
+     * test if indexes are exposed in def
+     *
+     * @return void
+     */
     public function testIndexes()
     {
         $jsonDef = $this->loadJsonDefinition($this->fullDefPath);


### PR DESCRIPTION
* [x] configure doctrine indexes as defined in json-defs
* [x] index some fields in `/core/config/` so we have something to test

This was done as part of [EVO-5196](https://issue.swisscom.ch/browse/EVO-5196) and gets us half the way there. IMHO these changes should have been implemented quite some time ago.

I need work on this issue some more for it to add all the search fields. Those changes will need proper checking of all downstream use-case if we want to realize it properly.