### PR TITLE
Add command to initialize symfony/translation from mongodb

### DIFF
--- a/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
+++ b/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Graviton\I18nBundle\Document\Translatable;
 use Graviton\I18nBundle\Repository\LanguageRepository;
 use Graviton\I18nBundle\Repository\TranslatableRepository;
 

--- a/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
+++ b/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * create translation resources based on the available resources in the mongodb catalog
+ */
+
+namespace Graviton\I18nBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Graviton\I18nBundle\Document\Translatable;
+use Graviton\I18nBundle\Repository\LanguageRepository;
+use Graviton\I18nBundle\Repository\TranslatableRepository;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class CreateTranslationResourcesCommand extends Command
+{
+    /**
+     * @var LanguageRepository
+     */
+    private $languageRepo;
+
+    /**
+     * @var TranslatableRepository
+     */
+    private $translatableRepo;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $resourceDir;
+
+    /**
+     * @param LanguageRepository     $languageRepo     Language Repository
+     * @param TranslatableRepository $translatableRepo Translatable Repository
+     * @param Filesystem             $filesystem       symfony/filesystem tooling
+     */
+    public function __construct(
+        LanguageRepository $languageRepo,
+        TranslatableRepository $translatableRepo,
+        Filesystem $filesystem
+    ) {
+        $this->languageRepo = $languageRepo;
+        $this->translatableRepo = $translatableRepo;
+        $this->filesystem = $filesystem;
+        $this->resourceDir = __DIR__.'/../Resources/translations/';
+
+        parent::__construct();
+    }
+
+    /**
+     * set up command
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('graviton:i18n:create:resources')
+            ->setDescription(
+                'Create translation resource stub files for all the available languages/domains in the database'
+            );
+    }
+
+    /**
+     * run command
+     *
+     * @param InputInterface  $input  input interface
+     * @param OutputInterface $output output interface
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln("Creating translation resource stubs");
+
+        $languages = $this->languageRepo->findAll();
+        $domains = $this->translatableRepo->createQueryBuilder()
+            ->distinct('domain')
+            ->select('domain')
+            ->getQuery()
+            ->execute()
+            ->toArray();
+
+        array_walk(
+            $languages,
+            function ($language) use ($output, $domains) {
+                array_walk(
+                    $domains,
+                    function ($domain) use ($output, $language) {
+                        $file = implode('.', [$domain, $language->getId(), 'odm']);
+                        $this->filesystem->touch(implode(DIRECTORY_SEPARATOR, [$this->resourceDir, $file]));
+                        $output->writeln("<info>Generated file $file</info>");
+                    }
+                );
+            }
+        );
+    }
+}

--- a/src/Graviton/I18nBundle/Resources/config/services.xml
+++ b/src/Graviton/I18nBundle/Resources/config/services.xml
@@ -27,6 +27,7 @@
     <parameter key="graviton.i18n.cacheutils.class">Graviton\I18nBundle\Service\I18nCacheUtils</parameter>
     <parameter key="graviton.i18n.form.transformer.translatabletodefaultstring.class">Graviton\I18nBundle\Form\DataTransformer\TranslatableToDefaultStringTransformer</parameter>
     <parameter key="graviton.i18n.form.type.translatable.class">Graviton\I18nBundle\Form\Type\TranslatableType</parameter>
+    <parameter key="graviton.i18n.command.createtranslationresources.class">Graviton\I18nBundle\Command\CreateTranslationResourcesCommand</parameter>
 
     <!-- should we move this to somewhere else? -->
     <parameter key="translator.class">Graviton\I18nBundle\Translator\Translator</parameter>
@@ -165,5 +166,13 @@
       <argument type="service" id="graviton.i18n.form.transformer.translatabletodefaultstring"/>
       <tag name="form.type" alias="translatable"/>
     </service>
+
+    <service id="graviton.i18n.command.createtranslationresources" class="%graviton.i18n.command.createtranslationresources.class%">
+      <argument type="service" id="graviton.i18n.repository.language"/>
+      <argument type="service" id="graviton.i18n.repository.translatable"/>
+      <argument type="service" id="filesystem"/>
+      <tag name="console.command"/>
+    </service>
+
   </services>
 </container>

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -6,7 +6,7 @@
 namespace Graviton\I18nBundle\Tests\Command;
 
 use Symfony\Component\Console\Tester\CommandTester;
-use Graviton\GeneratorBundle\Command\GenerateBundleCommand;
+use Graviton\I18nBundle\Command\CreateTranslationResourcesCommand;
 
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
@@ -40,7 +40,7 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $builderMock = $this->getMockbuilder('\Doctrine\ODM\MongoDB\Query\Builder')
+        $builderMock = $this->getMockBuilder('\Doctrine\ODM\MongoDB\Query\Builder')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -85,7 +85,7 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
             ->method('touch');
 
         $command = new CommandTester(
-            new \Graviton\I18nBundle\Command\CreateTranslationResourcesCommand(
+            new CreateTranslationResourcesCommand(
                 $languageMock,
                 $translatableMock,
                 $fsMock

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * functional tests for creating translation resource files
+ */
+
+namespace Graviton\I18nBundle\Tests\Command;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Graviton\GeneratorBundle\Command\GenerateBundleCommand;
+
+/**
+ * functional tests for graviton:generate:bundle
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ *
+ * @todo fix that updateKernel is not getting tested
+ */
+class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test graviton:i118n:create:resources command
+     *
+     * @return void
+     */
+    public function testLoadCreateCommand()
+    {
+        $languageMock = $this->getMockBuilder('\Graviton\I18nBundle\Repository\LanguageRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $enMock = $this->getMock('\Graviton\I18nBundle\Document\Language');
+        $enMock->expects($this->any())->method('getId')->willReturn('en');
+
+        $deMock = $this->getMock('\Graviton\I18nBundle\Document\Language');
+        $deMock->expects($this->any())->method('getId')->willReturn('de');
+
+        $languageMock->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$enMock, $deMock]);
+
+        $translatableMock = $this->getMockBuilder('\Graviton\I18nBundle\Repository\TranslatableRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $builderMock = $this->getMockbuilder('\Doctrine\ODM\MongoDB\Query\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $builderMock
+            ->expects($this->once())
+            ->method('distinct')
+            ->with('domain')
+            ->willReturn($builderMock);
+
+        $builderMock
+            ->expects($this->once())
+            ->method('select')
+            ->with('domain')
+            ->willReturn($builderMock);
+
+        $queryMock = $this->getMockBuilder('\Doctrine\ODM\MongoDB\Query\Query')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $builderMock
+            ->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($queryMock);
+
+        $queryMock
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn($queryMock);
+        $queryMock
+            ->expects($this->once())
+            ->method('toArray')
+            ->willReturn(['core', 'i18n']);
+
+        $translatableMock
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturn($builderMock);
+
+        $fsMock = $this->getMock('\Symfony\Component\Filesystem\Filesystem');
+
+        $fsMock->expects($this->exactly(4))
+            ->method('touch');
+
+        $command = new CommandTester(
+            new \Graviton\I18nBundle\Command\CreateTranslationResourcesCommand(
+                $languageMock,
+                $translatableMock,
+                $fsMock
+            )
+        );
+        $command->execute(array());
+
+        $this->assertContains('Creating translation resource stubs', $command->getDisplay());
+        $this->assertContains('Generated file core.en.odm', $command->getDisplay());
+        $this->assertContains('Generated file core.de.odm', $command->getDisplay());
+        $this->assertContains('Generated file i18n.en.odm', $command->getDisplay());
+        $this->assertContains('Generated file i18n.de.odm', $command->getDisplay());
+    }
+}

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -9,13 +9,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Graviton\GeneratorBundle\Command\GenerateBundleCommand;
 
 /**
- * functional tests for graviton:generate:bundle
- *
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
- *
- * @todo fix that updateKernel is not getting tested
  */
 class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,7 +20,7 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testLoadCreateCommand()
+    public function testCreateResourcesCommand()
     {
         $languageMock = $this->getMockBuilder('\Graviton\I18nBundle\Repository\LanguageRepository')
             ->disableOriginalConstructor()


### PR DESCRIPTION
This should fix the issue of losing translations during redeploy on immutable infrastructure.