### PR TITLE
Fix typo in name of command

### DIFF
--- a/src/Graviton/I18nBundle/Command/LoadMissingCommand.php
+++ b/src/Graviton/I18nBundle/Command/LoadMissingCommand.php
@@ -34,7 +34,7 @@ class LoadMissingCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('graviton:i118n:load:missing')
+            ->setName('graviton:i18n:load:missing')
             ->setDescription('Generate translatables for strings in en.');
     }
 


### PR DESCRIPTION
I recently stumbled upon this and it's still itching. I don't think anyone is actually using the command so this change should not have an impact.