### PR TITLE
fix doctrine strategy on primitives & update doctrine/* deps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3996da0ad73fc9411229e7f281e1d9",
-    "content-hash": "596adcbbaceecd138141302d9aada23f",
+    "hash": "44a0f271b86c1c3f889303c0e4d0e609",
+    "content-hash": "8c651665e45626715300935953969021",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -626,16 +626,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "e9c2ccf573b59b7cea566390f34254fed3c20ed9"
+                "reference": "fd51907c6c76acaa8a5234822a4f901c1500afc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/e9c2ccf573b59b7cea566390f34254fed3c20ed9",
-                "reference": "e9c2ccf573b59b7cea566390f34254fed3c20ed9",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/fd51907c6c76acaa8a5234822a4f901c1500afc1",
+                "reference": "fd51907c6c76acaa8a5234822a4f901c1500afc1",
                 "shasum": ""
             },
             "require": {
@@ -652,13 +652,14 @@
                 "phpunit/phpunit": "~4",
                 "satooshi/php-coveralls": "~0.6.1",
                 "symfony/phpunit-bridge": "~2.7|~3.0",
+                "symfony/property-info": "~2.8|~3.0",
                 "symfony/validator": "~2.2|~3.0",
                 "symfony/yaml": "~2.2|~3.0",
                 "twig/twig": "~1.10"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
-                "symfony/web-profiler-bundle": "to use the data collector"
+                "symfony/web-profiler-bundle": "To use the data collector."
             },
             "type": "symfony-bundle",
             "extra": {
@@ -701,7 +702,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2016-01-10 17:21:44"
+            "time": "2016-04-21 19:55:56"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -1101,16 +1102,16 @@
         },
         {
             "name": "doctrine/mongodb-odm",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/mongodb-odm.git",
-                "reference": "318c9651bdf18a3bcb6f88b0bddd385e1a82284e"
+                "reference": "1137922032d098a2e284575f2ce30e83abbecea2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/318c9651bdf18a3bcb6f88b0bddd385e1a82284e",
-                "reference": "318c9651bdf18a3bcb6f88b0bddd385e1a82284e",
+                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/1137922032d098a2e284575f2ce30e83abbecea2",
+                "reference": "1137922032d098a2e284575f2ce30e83abbecea2",
                 "shasum": ""
             },
             "require": {
@@ -1120,8 +1121,8 @@
                 "doctrine/common": "~2.4",
                 "doctrine/inflector": "~1.0",
                 "doctrine/instantiator": "~1.0.1",
-                "doctrine/mongodb": "~1.2",
-                "php": ">=5.3.2",
+                "doctrine/mongodb": "~1.3",
+                "php": "^5.6 || ^7.0",
                 "symfony/console": "~2.3|~3.0"
             },
             "require-dev": {
@@ -1134,7 +1135,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1180,7 +1181,7 @@
                 "odm",
                 "persistence"
             ],
-            "time": "2016-02-16 10:02:45"
+            "time": "2016-06-09 14:21:30"
         },
         {
             "name": "doctrine/mongodb-odm-bundle",
@@ -3389,6 +3390,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": true,
             "time": "2014-12-01 08:29:51"
         },
         {

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -65,13 +65,13 @@
                 {% elseif '[]' in field.type or field.type == 'array' %}
                     <field fieldName="{{ field.fieldName }}" type="collection"/>
                 {% else %}
-                    <field fieldName="{{ field.fieldName }}" type="{{ field.type }}" strategy="pushAll"/>
+                    <field fieldName="{{ field.fieldName }}" type="{{ field.type }}"/>
                 {% endif %}
             {% endif %}
         {% endfor %}
 
         {% if isrecordOriginFlagSet %}
-            <field fieldName="recordOrigin" type="string" strategy="pushAll"/>
+            <field fieldName="recordOrigin" type="string"/>
         {% endif %}
 
     {% if indexes is defined and indexes is not empty %}


### PR DESCRIPTION
I updated to the new doctrine stuff in my branch and got this error message

```
[Doctrine\ODM\MongoDB\Mapping\MappingException]                                                                                              
  Invalid strategy pushAll used in GravitonDyn\TestCaseTranslatableArrayBundle\Document\TestCaseTranslatableArray::array with type collection
```

And indeed, the `strategy` attribute should only be set on `embed-*` and `ref-*` fields, not others (surely not the primitives we do there). And there we already set it (to `set`).. so all dandy there.

This is only a problem when we want to update `doctrine/mongodb-odm` (what we should do), as 1.1.0 complains about this wrong definition.

So this updates the doctrine deps and fixes our xml definitions..
