### PR TITLE
Update phpunit and sensio/generator-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "hwi/oauth-bundle": "~0.4",
         "graviton/deploy-scripts": "~0.4",
         "graviton/json-schema": "~0.8",
-        "hadesarchitect/json-schema-bundle": "~0.1.0",
+        "hadesarchitect/json-schema-bundle": "=0.1.0",
         "php-jsonpatch/php-jsonpatch": "~1.2.2",
         "antimattr/mongodb-migrations": "^1.0",
         "jenssegers/proxy": ">=3.0.0-beta2",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/monolog-bundle": "~2.4",
         "sensio/distribution-bundle": "~3.0.12",
         "sensio/framework-extra-bundle": "~3.0",
-        "sensio/generator-bundle": "~2.3",
+        "sensio/generator-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.1",
         "jms/serializer-bundle": ">=1.1,<2",
         "jms/di-extra-bundle": "~1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3996da0ad73fc9411229e7f281e1d9",
-    "content-hash": "596adcbbaceecd138141302d9aada23f",
+    "hash": "44a0f271b86c1c3f889303c0e4d0e609",
+    "content-hash": "8c651665e45626715300935953969021",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -5445,97 +5445,6 @@
     ],
     "packages-dev": [
         {
-            "name": "davidbadura/faker-bundle",
-            "version": "1.1.0",
-            "target-dir": "DavidBadura/FakerBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/DavidBadura/FakerBundle.git",
-                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/DavidBadura/FakerBundle/zipball/0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
-                "reference": "0d15887f89b0b61bc79a3dbc7a23140564cdd50e",
-                "shasum": ""
-            },
-            "require": {
-                "fzaninotto/faker": "~1.0",
-                "php": ">=5.3.0",
-                "symfony/symfony": ">=2.6"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-0": {
-                    "DavidBadura\\FakerBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Badura",
-                    "email": "d.badura@gmx.de"
-                }
-            ],
-            "keywords": [
-                "Symfony2",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2015-09-14 08:59:32"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2016-04-29 12:21:54"
-        },
-        {
             "name": "graviton/test-services-bundle",
             "version": "v0.18.1",
             "source": {
@@ -5924,16 +5833,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.3.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2431befdd451fac43fbcde94d1a92fb3b8b68f86"
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2431befdd451fac43fbcde94d1a92fb3b8b68f86",
-                "reference": "2431befdd451fac43fbcde94d1a92fb3b8b68f86",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
                 "shasum": ""
             },
             "require": {
@@ -5947,7 +5856,7 @@
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
@@ -5957,7 +5866,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -5983,7 +5892,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-04-08 08:14:53"
+            "time": "2016-06-03 05:03:56"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6075,20 +5984,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -6112,7 +6024,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -6165,16 +6077,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.3.2",
+            "version": "5.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2c6da3536035617bae3fe3db37283c9e0eb63ab3"
+                "reference": "02d5b64aa0837a038a5a4faeeefa5ef44bdcb928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2c6da3536035617bae3fe3db37283c9e0eb63ab3",
-                "reference": "2c6da3536035617bae3fe3db37283c9e0eb63ab3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/02d5b64aa0837a038a5a4faeeefa5ef44bdcb928",
+                "reference": "02d5b64aa0837a038a5a4faeeefa5ef44bdcb928",
                 "shasum": ""
             },
             "require": {
@@ -6186,11 +6098,11 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^3.3.0",
+                "phpunit/php-code-coverage": "^4.0",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.1",
+                "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
@@ -6201,6 +6113,9 @@
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
             },
@@ -6210,7 +6125,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "5.4.x-dev"
                 }
             },
             "autoload": {
@@ -6236,30 +6151,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-04-12 16:20:08"
+            "time": "2016-06-09 09:09:27"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.1.3",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "151c96874bff6fe61a25039df60e776613a61489"
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/151c96874bff6fe61a25039df60e776613a61489",
-                "reference": "151c96874bff6fe61a25039df60e776613a61489",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.6",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -6267,7 +6185,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -6292,7 +6210,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-04-20 14:39:26"
+            "time": "2016-06-12 07:37:26"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "746501f1c3975444bf11f4bd27276fbc",
-    "content-hash": "7bf15c79cfcd407c5bb4d49272501278",
+    "hash": "2b751b7f050b044e7e6d0df08b672559",
+    "content-hash": "6351554cd0ad894bc0fc7699fdb9cfde",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -3390,6 +3390,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": true,
             "time": "2014-12-01 08:29:51"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "44a0f271b86c1c3f889303c0e4d0e609",
-    "content-hash": "8c651665e45626715300935953969021",
+    "hash": "746501f1c3975444bf11f4bd27276fbc",
+    "content-hash": "7bf15c79cfcd407c5bb4d49272501278",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -4108,38 +4108,42 @@
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v2.5.3",
-            "target-dir": "Sensio/Bundle/GeneratorBundle",
+            "version": "v3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "e50108c2133ee5c9c484555faed50c17a61221d3"
+                "reference": "ac91535054d025937d897d78ebb5fc2da5e955a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/e50108c2133ee5c9c484555faed50c17a61221d3",
-                "reference": "e50108c2133ee5c9c484555faed50c17a61221d3",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/ac91535054d025937d897d78ebb5fc2da5e955a4",
+                "reference": "ac91535054d025937d897d78ebb5fc2da5e955a4",
                 "shasum": ""
             },
             "require": {
-                "symfony/console": "~2.5",
-                "symfony/framework-bundle": "~2.2"
+                "symfony/console": "~2.7|~3.0",
+                "symfony/framework-bundle": "~2.7|~3.0",
+                "symfony/process": "~2.7|~3.0",
+                "symfony/yaml": "~2.7|~3.0"
             },
             "require-dev": {
-                "doctrine/orm": "~2.2,>=2.2.3",
-                "symfony/doctrine-bridge": "~2.2",
-                "twig/twig": "~1.11"
+                "doctrine/orm": "~2.4",
+                "symfony/doctrine-bridge": "~2.7|~3.0",
+                "twig/twig": "~1.18"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Sensio\\Bundle\\GeneratorBundle": ""
-                }
+                "psr-4": {
+                    "Sensio\\Bundle\\GeneratorBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4152,7 +4156,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2015-03-17 06:36:52"
+            "time": "2016-02-26 04:36:01"
         },
         {
             "name": "sensiolabs/security-checker",

--- a/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/MainControllerTest.php
@@ -127,10 +127,10 @@ class MainControllerTest extends RestTestCase
             )
             ->will($this->returnValue("http://localhost/core/app"));
 
-        $responseDouble = $this->getMock('Symfony\Component\HttpFoundation\Response');
-        $restUtilsDouble = $this->getMock('Graviton\RestBundle\Service\RestUtilsInterface');
-        $templateDouble = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $apiLoaderDouble = $this->getMock('Graviton\ProxyBundle\Service\ApiDefinitionLoader');
+        $responseDouble = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $restUtilsDouble = $this->createMock('Graviton\RestBundle\Service\RestUtilsInterface');
+        $templateDouble = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $apiLoaderDouble = $this->createMock('Graviton\ProxyBundle\Service\ApiDefinitionLoader');
         $configuration = [
             'petstore' => [
                 'prefix' => 'petstore',
@@ -190,10 +190,10 @@ class MainControllerTest extends RestTestCase
                 )
             );
 
-        $responseDouble = $this->getMock('Symfony\Component\HttpFoundation\Response');
-        $restUtilsDouble = $this->getMock('Graviton\RestBundle\Service\RestUtilsInterface');
-        $templateDouble = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $apiLoaderDouble = $this->getMock('Graviton\ProxyBundle\Service\ApiDefinitionLoader');
+        $responseDouble = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $restUtilsDouble = $this->createMock('Graviton\RestBundle\Service\RestUtilsInterface');
+        $templateDouble = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $apiLoaderDouble = $this->createMock('Graviton\ProxyBundle\Service\ApiDefinitionLoader');
         $configuration = [
             'petstore' => [
                 'prefix' => 'petstore',

--- a/src/Graviton/DocumentBundle/Tests/Form/Type/DocumentTypeTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Form/Type/DocumentTypeTest.php
@@ -91,7 +91,7 @@ class DocumentTypeTest extends \PHPUnit_Framework_TestCase
         $sut = new DocumentType($this->fieldBuilderDouble, [$class => []]);
         $sut->initialize($class);
 
-        $resolverDouble = $this->getMock('Symfony\Component\OptionsResolver\OptionsResolver');
+        $resolverDouble = $this->createMock('Symfony\Component\OptionsResolver\OptionsResolver');
         $resolverDouble
             ->expects($this->once())
             ->method('setDefaults')
@@ -116,7 +116,7 @@ class DocumentTypeTest extends \PHPUnit_Framework_TestCase
         $sut = new DocumentType($this->fieldBuilderDouble, [$class => []]);
         $sut->initialize($class);
 
-        $builderDouble = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $builderDouble = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $builderDouble
             ->expects($this->once())
             ->method('addEventListener')

--- a/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
@@ -241,7 +241,6 @@ class GenerateDynamicBundleCommand extends Command
                 '--format' => 'xml',
                 '--json' => $this->serializer->serialize($subRecource->getDef(), 'json'),
                 '--fields' => $this->getFieldString($subRecource),
-                '--with-repository' => null,
                 '--no-controller' => 'true',
             ];
             $this->generateResource($arguments, $output, $jsonDef);
@@ -273,8 +272,7 @@ class GenerateDynamicBundleCommand extends Command
                 '--entity' => $bundleName . ':' . $jsonDef->getId(),
                 '--json' => $this->serializer->serialize($jsonDef->getDef(), 'json'),
                 '--format' => 'xml',
-                '--fields' => $this->getFieldString($jsonDef),
-                '--with-repository' => null
+                '--fields' => $this->getFieldString($jsonDef)
             );
 
             $this->generateResource($arguments, $output, $jsonDef);
@@ -355,7 +353,6 @@ class GenerateDynamicBundleCommand extends Command
             '--format' => $input->getOption('bundleFormat'),
             '--doUpdateKernel' => 'false',
             '--loaderBundleName' => $input->getOption('bundleBundleName'),
-            '--structure' => null
         );
 
         $this->runner->executeCommand(

--- a/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateResourceCommand.php
@@ -88,10 +88,6 @@ class GenerateResourceCommand extends GenerateDoctrineEntityCommand
             $input,
             $output
         );
-
-        $output->writeln(
-            'For the time being you need to fix titles and add descriptions in Resource/config/schema manually'
-        );
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Generator/BundleGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/BundleGenerator.php
@@ -6,6 +6,7 @@
 namespace Graviton\GeneratorBundle\Generator;
 
 use Symfony\Component\DependencyInjection\Container;
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 
 /**
  * bundle containing various code generators
@@ -20,6 +21,23 @@ use Symfony\Component\DependencyInjection\Container;
  */
 class BundleGenerator extends AbstractGenerator
 {
+    /**
+     * generate a bundle from a Bundle model
+     *
+     * @param Bundle $bundle bundle model
+     *
+     * @return void
+     */
+    public function generateBundle(Bundle $bundle)
+    {
+        return $this->generate(
+            $bundle->getNamespace(),
+            $bundle->getName(),
+            $bundle->getTargetDirectory().'/../../',
+            $bundle->getConfigurationFormat()
+        );
+    }
+
     /**
      * generate bundle code
      *

--- a/src/Graviton/GeneratorBundle/README.md
+++ b/src/Graviton/GeneratorBundle/README.md
@@ -17,8 +17,8 @@ you will need to fix this by removing the doctrine and serializer config in ``Re
 ### Generate a new Resource
 
 ```bash
-php app/console graviton:generate:resource --entity=GravitonFooBundle:Bar --format=xml --fields="name:string" --with-repository
-php app/console graviton:generate:resource --entity=GravitonFooBundle:Baz --format=xml --fields="name:string isTrue:boolean consultant:Graviton\\PersonBundle\\Document\\Consultant" --with-repository
+php app/console graviton:generate:resource --entity=GravitonFooBundle:Bar --format=xml --fields="name:string"
+php app/console graviton:generate:resource --entity=GravitonFooBundle:Baz --format=xml --fields="name:string isTrue:boolean consultant:Graviton\\PersonBundle\\Document\\Consultant"
 ```
 You will need to clean up the models Resource/schema/<name>.json file after generation. You may replace titles and you must
 add descriptions in the fields marked @todo.

--- a/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
@@ -107,7 +107,7 @@ class GenerateBundleCommandTest extends BaseTest
      */
     protected function getBundle()
     {
-        $bundle = $this->getMock('Graviton\BundleBundle\GravitonBundleBundle');
+        $bundle = $this->createMock('Graviton\BundleBundle\GravitonBundleBundle');
         $bundle
             ->expects($this->any())
             ->method('getPath')

--- a/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
@@ -36,32 +36,6 @@ class GenerateBundleCommandTest extends BaseTest
     }
 
     /**
-     * add xml test to upstreams test data
-     *
-     * @return array[]
-     *
-     * @codeCoverageIgnore
-     */
-    public function getInteractiveCommandData()
-    {
-        $tmp = sys_get_temp_dir();
-
-        return array_merge(
-            parent::getInteractiveCommandData(),
-            array(
-                array(
-                    array(
-                        '--dir' => $tmp,
-                        '--format' => 'xml'
-                    ),
-                    "Foo/BarBundle\n",
-                    array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'xml', false)
-                )
-            )
-        );
-    }
-
-    /**
      * get command
      *
      * @param \Graviton\GeneratorBundle\Generator\BundleGenerator $generator generator
@@ -94,7 +68,7 @@ class GenerateBundleCommandTest extends BaseTest
         return $this
             ->getMockBuilder('Graviton\GeneratorBundle\Generator\BundleGenerator')
             ->disableOriginalConstructor()
-            ->setMethods(array('generate'))
+            ->setMethods(['generate', 'generateBundle'])
             ->getMock();
     }
 

--- a/src/Graviton/GeneratorBundle/Tests/Command/GenerateDynamicBundleCommandTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Command/GenerateDynamicBundleCommandTest.php
@@ -45,11 +45,11 @@ class GenerateDynamicBundleCommandTest extends BaseTest
             ->setMethods(array('setCommandLine', 'run', 'isSuccessful', 'getErrorOutput', 'getExitCode'))
             ->getMock();
 
-        $kernelDouble = $this->getMock('\Symfony\Component\HttpKernel\KernelInterface');
+        $kernelDouble = $this->createMock('\Symfony\Component\HttpKernel\KernelInterface');
         $runnerDouble = $this->getMockBuilder('\Graviton\GeneratorBundle\CommandRunner')
             ->setConstructorArgs(array($kernelDouble, $processDouble))
             ->getMock();
-        $xmlManipulatorDouble = $this->getMock('\Graviton\GeneratorBundle\Manipulator\File\XmlManipulator');
+        $xmlManipulatorDouble = $this->createMock('\Graviton\GeneratorBundle\Manipulator\File\XmlManipulator');
 
         $commando = new GenerateDynamicBundleCommand(
             $runnerDouble,
@@ -198,8 +198,8 @@ class GenerateDynamicBundleCommandTest extends BaseTest
      */
     private function executeGenerateSubresources(JsonDefinition $jsonDefDouble)
     {
-        $outputDouble = $this->getMock('Symfony\\Component\\Console\\Output\\OutputInterface');
-        $xmlManipulatorDouble = $this->getMock('\Graviton\GeneratorBundle\Manipulator\File\XmlManipulator');
+        $outputDouble = $this->createMock('Symfony\\Component\\Console\\Output\\OutputInterface');
+        $xmlManipulatorDouble = $this->createMock('\Graviton\GeneratorBundle\Manipulator\File\XmlManipulator');
 
         $command = $this->getProxyBuilder('\\Graviton\\GeneratorBundle\\Command\\GenerateDynamicBundleCommand')
             ->disableOriginalConstructor()

--- a/src/Graviton/GeneratorBundle/Tests/CommandRunnerTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/CommandRunnerTest.php
@@ -33,7 +33,7 @@ class CommandRunnerTest extends \PHPUnit_Framework_TestCase
             ->method('isSuccessful')
             ->willReturn(false);
 
-        $kernelDouble = $this->getMock('\Symfony\Component\HttpKernel\KernelInterface');
+        $kernelDouble = $this->createMock('\Symfony\Component\HttpKernel\KernelInterface');
         $kernelDouble
             ->expects($this->once())
             ->method('getRootDir')

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGenerator/FieldMapperTest.php
@@ -23,7 +23,7 @@ class FieldMapperTest extends \PHPUnit_Framework_TestCase
 
         $context = new \StdClass;
 
-        $mapperDouble = $this->getMock('\Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapperInterface');
+        $mapperDouble = $this->createMock('\Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapperInterface');
         $mapperDouble->expects($this->exactly(2))
             ->method('map')
             ->with([], $context)

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGeneratorProxy.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGeneratorProxy.php
@@ -22,16 +22,15 @@ class ResourceGeneratorProxy extends ResourceGenerator
      * (non-PHPdoc)
      * @see \Graviton\GeneratorBundle\Generator\ResourceGenerator::generateDocument()
      *
-     * @param array   $parameters     twig parameters
-     * @param string  $dir            base bundle dir
-     * @param string  $document       document name
-     * @param boolean $withRepository generate repository class
+     * @param array  $parameters twig parameters
+     * @param string $dir        base bundle dir
+     * @param string $document   document name
      *
      * @return void
      */
-    public function generateDocument($parameters, $dir, $document, $withRepository)
+    public function generateDocument($parameters, $dir, $document)
     {
-        parent::generateDocument($parameters, $dir, $document, $withRepository);
+        parent::generateDocument($parameters, $dir, $document);
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGeneratorTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Generator/ResourceGeneratorTest.php
@@ -257,7 +257,7 @@ class ResourceGeneratorTest extends GravitonTestCase
     public function testGenerateDocument($base)
     {
         $servicesMock = $this->getMockBuilder('\DOMDocument')
-            ->setMethods(array("saveXml"))
+            ->setMethods(['saveXml', 'getElementsByTagName'])
             ->getMock();
 
         $jsonDefinitionMock = $this->getMockBuilder('\Graviton\GeneratorBundle\Definition\JsonDefinition')
@@ -282,7 +282,7 @@ class ResourceGeneratorTest extends GravitonTestCase
             ->getMock();
 
         $generator
-            ->expects($this->exactly(5))
+            ->expects($this->exactly(7))
             ->method('renderFile');
 
         $generator
@@ -294,17 +294,32 @@ class ResourceGeneratorTest extends GravitonTestCase
             ->expects($this->exactly(2))
             ->method('addXmlParameter');
 
+        $containerNodeMock = $this->getMockBuilder('\DOMNode')
+            ->setMethods(['item', 'appendChild'])
+            ->getMock();
+
+        $servicesMock
+            ->expects($this->any())
+            ->method('getElementsByTagName')
+            ->willReturn($containerNodeMock);
+
+        $containerNodeMock->length = 0;
+        $containerNodeMock
+            ->expects($this->exactly(2))
+            ->method('item')
+            ->with(0)
+            ->willReturn($containerNodeMock);
 
         $generator
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('addService')
             ->with(
-                $this->equalTo($servicesMock),
-                $this->equalTo($docName)
+                $this->equalTo($servicesMock)//,
+                //$this->equalTo($docName)
             )
             ->will($this->returnValue($servicesMock));
 
-        $generator->generateDocument($parameters, $dir, $document, false);
+        $generator->generateDocument($parameters, $dir, $document);
     }
 
     /**

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -26,10 +26,10 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $enMock = $this->getMock('\Graviton\I18nBundle\Document\Language');
+        $enMock = $this->createMock('\Graviton\I18nBundle\Document\Language');
         $enMock->expects($this->any())->method('getId')->willReturn('en');
 
-        $deMock = $this->getMock('\Graviton\I18nBundle\Document\Language');
+        $deMock = $this->createMock('\Graviton\I18nBundle\Document\Language');
         $deMock->expects($this->any())->method('getId')->willReturn('de');
 
         $languageMock->expects($this->once())
@@ -79,7 +79,7 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
             ->method('createQueryBuilder')
             ->willReturn($builderMock);
 
-        $fsMock = $this->getMock('\Symfony\Component\Filesystem\Filesystem');
+        $fsMock = $this->createMock('\Symfony\Component\Filesystem\Filesystem');
 
         $fsMock->expects($this->exactly(4))
             ->method('touch');

--- a/src/Graviton/I18nBundle/Tests/Form/Type/TranslatableTypeTest.php
+++ b/src/Graviton/I18nBundle/Tests/Form/Type/TranslatableTypeTest.php
@@ -69,7 +69,7 @@ class TranslatableTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getDefaultLanguage')
             ->willReturn('en');
 
-        $builderDouble = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $builderDouble = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
 
         $builderDouble
             ->expects($this->exactly(2))

--- a/src/Graviton/ProxyBundle/Tests/Definition/Loader/HttpLoaderTest.php
+++ b/src/Graviton/ProxyBundle/Tests/Definition/Loader/HttpLoaderTest.php
@@ -41,7 +41,7 @@ class HttpLoaderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method("getBody")
             ->willReturn("{ 'test': 'bablaba' }");
-        $curlMock = $this->getMock('Guzzle\Common\Collection');
+        $curlMock = $this->createMock('Guzzle\Common\Collection');
         $request = $this->getMockForAbstractClass('Guzzle\Http\Message\RequestInterface');
         $request->expects($this->any())
             ->method("send")
@@ -58,7 +58,7 @@ class HttpLoaderTest extends \PHPUnit_Framework_TestCase
             ->willReturn($request);
         $validator = $this->getMockForAbstractClass('Symfony\Component\Validator\Validator\ValidatorInterface');
 
-        $this->logger = $this->getMock('Psr\Log\Loggerinterface');
+        $this->logger = $this->createMock('Psr\Log\Loggerinterface');
 
         $this->sut = new HttpLoader($validator, $client, $this->logger);
     }
@@ -153,7 +153,7 @@ class HttpLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $storeKey = 'testSwagger';
         $cachedContent = '{"swagger": "2.0"}';
-        $apiDefinition = $this->getMock('Graviton\ProxyBundle\Definition\ApiDefinition');
+        $apiDefinition = $this->createMock('Graviton\ProxyBundle\Definition\ApiDefinition');
 
         $mock = $this->getMockBuilder('Graviton\ProxyBundle\Definition\Loader\DispersalStrategy\SwaggerStrategy')
             ->disableOriginalConstructor()

--- a/src/Graviton/RestBundle/Tests/Listener/XVersionResponseListenerTest.php
+++ b/src/Graviton/RestBundle/Tests/Listener/XVersionResponseListenerTest.php
@@ -80,7 +80,7 @@ class XVersionResponseListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
 
         $loggerDouble = $this->getMockForAbstractClass('\Psr\Log\LoggerInterface');
-        $serviceDouble = $this->getMock(
+        $serviceDouble = $this->createMock(
             '\Graviton\CoreBundle\Service\CoreUtils',
             array(),
             array(__DIR__ . '/../../../../../app/cache/test')


### PR DESCRIPTION
The phpunit was split out of @narcoticfresh's work in #430 to make that more lean and I'll take care of merging it there when we get this to develop. I realized that the time is ready to bump sensio/generator-bundle while I was looking into this and was able to bodge our code to conform to what the new bundle gives us. I haven't been able to get https://github.com/sensiolabs/SensioGeneratorBundle/pull/497 merged which would have also taken care of the remaining warnings left after this hack.

To test this in a graviton based wrapper you will need to update this in a fashion similar to the incantation `composer update graviton/* phpunit/* sensio/*` so it does not pull unwanted changes.