### PR TITLE
Use PhpExecutableFinder to run php commands

### DIFF
--- a/src/Graviton/GeneratorBundle/CommandRunner.php
+++ b/src/Graviton/GeneratorBundle/CommandRunner.php
@@ -8,6 +8,7 @@ namespace Graviton\GeneratorBundle;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
@@ -99,7 +100,19 @@ class CommandRunner
         // get path to console from kernel..
         $consolePath = $this->kernel->getRootDir() . '/console';
 
-        $cmd = 'php ' . $consolePath . ' -n ';
+        // this code was copied from Symfony\Component\Process\PhpProcess and deserves a cleanup
+        $executableFinder = new PhpExecutableFinder();
+        if (false === $php = $executableFinder->find()) {
+            $php = null;
+        }
+        if ('\\' !== DIRECTORY_SEPARATOR && null !== $php) {
+            // exec is mandatory to deal with sending a signal to the process
+            // see https://github.com/symfony/symfony/issues/5030 about prepending
+            // command with exec
+            $php = 'exec '.$php;
+        }
+
+        $cmd = $php.' '.$consolePath.' -n ';
 
         foreach ($args as $key => $val) {
             if (strlen($key) > 1) {


### PR DESCRIPTION
I had quite some issues with getting the stuff in the feature/other-validation branch due to me having multiple php installs.

This uses an approach similar to what `Symfony\Component\Process\PhpProcess` does to figure out what executable to use.

It also wraps the call in exec as needed so signal properly reach the spawned commands.