### PR TITLE
When using guzzle to upload files these did not have filename and the…

### DIFF
--- a/src/Graviton/FileBundle/FileManager.php
+++ b/src/Graviton/FileBundle/FileManager.php
@@ -12,6 +12,7 @@ use GravitonDyn\FileBundle\Document\File as FileDocument;
 use Symfony\Component\HttpFoundation\File\Exception\UploadException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use GravitonDyn\FileBundle\Document\FileMetadata;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -378,7 +379,10 @@ class FileManager
             $fInfo = finfo_open(FILEINFO_MIME_TYPE);
             $contentType = finfo_file($fInfo, $file);
             if (!$contentType) {
-                throw new HttpException(400, "Could not determine Content type of file: ".$fileName);
+                throw new HttpException(
+                    Response::HTTP_NOT_ACCEPTABLE, 
+                    'Could not determine Content type of file: '.$fileName
+                );
             }
         }
 

--- a/src/Graviton/FileBundle/FileManager.php
+++ b/src/Graviton/FileBundle/FileManager.php
@@ -380,7 +380,7 @@ class FileManager
             $contentType = finfo_file($fInfo, $file);
             if (!$contentType) {
                 throw new HttpException(
-                    Response::HTTP_NOT_ACCEPTABLE, 
+                    Response::HTTP_NOT_ACCEPTABLE,
                     'Could not determine Content type of file: '.$fileName
                 );
             }

--- a/src/Graviton/FileBundle/FileManager.php
+++ b/src/Graviton/FileBundle/FileManager.php
@@ -362,7 +362,7 @@ class FileManager
 
         $dir = ini_get('upload_tmp_dir');
         $dir = (empty($dir)) ? sys_get_temp_dir() : $dir;
-        $file = $dir . '/' . $fileName;
+        $file = $dir . DIRECTORY_SEPARATOR . $fileName;
 
         $fileContent = substr($fileInfo[1], 0, -2);
 


### PR DESCRIPTION
… only way to send params like metadata was in header. This fixes both.