### PR TITLE
Fixes a limit issue in search with Rql

### DIFF
--- a/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
+++ b/src/Graviton/CoreBundle/Service/CoreVersionUtils.php
@@ -70,43 +70,18 @@ class CoreVersionUtils
     private function getContextVersion()
     {
         $output = $this->runComposerInContext('show -s --no-ansi');
-        $gitVersion = $this->getGitVersion();
-
         $lines = explode(PHP_EOL, $output);
         $wrapper = array();
-
         foreach ($lines as $line) {
             if (strpos($line, 'versions : *') !== false) {
                 list(, $wrapperVersion) = explode(': *', $line, 2);
                 $wrapper['id'] = 'self';
-                $wrapper['version'] = $gitVersion !== 'dev' ?
-                    $gitVersion : $this->getVersionNumber(trim($wrapperVersion));
+                $wrapper['version'] = $this->getVersionNumber(trim($wrapperVersion));
                 break;
             }
         }
 
         return $wrapper;
-    }
-
-    /**
-     * Retrieve Tag git Version if possible.
-     *
-     * @return string
-     */
-    private function getGitVersion()
-    {
-        $path =  ($this->isWrapperContext())
-            ? $this->rootDir.'/../../../../'
-            : $this->rootDir.'/../';
-        $contextDir = escapeshellarg($path);
-        $process = new Process('cd '.$contextDir.' && git describe --tags');
-        $process->mustRun();
-
-        try {
-            return $this->getVersionOrBranchName($process->getOutput());
-        } catch (InvalidArgumentException $e) {
-            return 'dev';
-        }
     }
 
     /**

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -247,7 +247,9 @@ class DocumentModel extends SchemaModel implements ModelInterface
         // Remove the Search from RQL xiag
         if ($hasSearch && $nodes) {
             $newXiagQuery = new XiagQuery();
-            $newXiagQuery->setLimit($xiagQuery->getLimit());
+            if ($xiagQuery->getLimit()) {
+                $newXiagQuery->setLimit($xiagQuery->getLimit());
+            }
             if ($xiagQuery->getSelect()) {
                 $newXiagQuery->setSelect($xiagQuery->getSelect());
             }


### PR DESCRIPTION
When using RQL param ?search we generate a new Query to remove the "search" string and build a unique TEXT. The limit resulted could be null and resulted in a exception, this would not happen in real as there is always present a limit in each rql request. This just fix this in case search is done without a limit and uses therefore the default value.