### PR TITLE
Bump MongoDB on travis and enforce unit/integration test split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+sudo: required
 services:
 - mongodb
 - rabbitmq
@@ -10,6 +10,10 @@ addons:
     packages:
     - mongodb-org-server
 before_script:
+- >
+    if [ "$PHPUNIT_SUITE" != "integration" ]; then
+        sudo service mongodb stop
+    fi
 - >
     if [ "$PHPUNIT_SUITE" != "unit" ]; then
         phpenv config-rm xdebug.ini
@@ -45,7 +49,9 @@ script:
         composer run-script post-install-cmd && \
         touch src/Graviton/I18nBundle/Resources/translations/i18n.de.odm && \
         touch src/Graviton/I18nBundle/Resources/translations/i18n.es.odm && \
-        php app/console graviton:generate:build-indexes && \
+        if [ "$PHPUNIT_SUITE" == "integration" ]; then
+            php app/console graviton:generate:build-indexes
+        fi && \
         if [ "$PHPUNIT_SUITE" == "unit" ]; then
           COVERAGE=" --coverage-clover=coverage.clover "
         fi && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: required
+sudo: false
 services:
 - mongodb
 - rabbitmq
@@ -12,7 +12,7 @@ addons:
 before_script:
 - >
     if [ "$PHPUNIT_SUITE" != "integration" ]; then
-        sudo service mongodb stop
+        export MONGODB_URI=mongodb://does.not.exist.example.org:443
     fi
 - >
     if [ "$PHPUNIT_SUITE" != "unit" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 addons:
   apt:
     sources:
-    - mongodb-3.0-precise
+    - mongodb-3.2-precise
     packages:
     - mongodb-org-server
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: php
+sudo: false
 services:
 - mongodb
 - rabbitmq
-sudo: false
+addons:
+  apt:
+    sources:
+    - mongodb-3.0-precise
+    packages:
+    - mongodb-org-server
 before_script:
 - >
     if [ "$PHPUNIT_SUITE" != "unit" ]; then

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,8 @@
       <file>src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyServiceTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/JsonExceptionListerTest.php</file>
+      <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</file>
+      <file>src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php</file>
     </testsuite>
     <testsuite name="unit">
       <directory>src/*/*Bundle/Tests</directory>
@@ -31,6 +33,8 @@
       <exclude>src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php</exclude>
       <exclude>src/Graviton/CoreBundle/Tests/Services/ReadOnlyServiceTest.php</exclude>
       <exclude>src/Graviton/CoreBundle/Tests/Services/JsonExceptionListerTest.php</exclude>
+      <exclude>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</exclude>
+      <exclude>src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php</exclude>
     </testsuite>
   </testsuites>
   <filter>

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -76,12 +76,19 @@ class ModuleControllerTest extends RestTestCase
     public function testSearchWeightedIndex()
     {
         $client = static::createRestClient();
-
-        $client->request('GET', '/core/module/?search(module%20payandsave%20real)&gt(order,0)&select(key,path)');
+        $client->request('GET', '/core/module/?search(module%20payandsave%20realestate)&gt(order,0)&select(key,path)');
         $results = $client->getResults();
 
-        $this->assertEquals('payAndSave', $results[0]->key);
-        $this->assertEquals('realEstate', $results[1]->key);
+        // This are the weighted important result, payAndSave and realEstate, order is not important.
+        $importantResults = [
+            $results[0]->key => $results[0]->path,
+            $results[1]->key => $results[1]->path
+        ];
+
+        $this->assertArrayHasKey('payAndSave', $importantResults);
+        $this->assertArrayHasKey('realEstate', $importantResults);
+
+        // Now, there shall be 5 results as we have 5 path containing module
         $this->assertEquals(5, count($results));
     }
 

--- a/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ModuleControllerTest.php
@@ -57,15 +57,15 @@ class ModuleControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
         $client->request('GET', '/core/module/?search(module)&select(key)');
-        $this->assertEquals('retirement', $client->getResults()[0]->key);
-        $this->assertEquals('realEstate', $client->getResults()[1]->key);
-        $this->assertEquals('investment', $client->getResults()[2]->key);
-        $this->assertEquals('requisition', $client->getResults()[3]->key);
-        $this->assertEquals('payAndSave', $client->getResults()[4]->key);
 
+        // should not find 'AdminRef'
+        $this->assertEquals(5, count($client->getResults()));
+
+        // the sixth
         $client = static::createRestClient();
         $client->request('GET', '/core/module/?search(AdminRef)&select(key)');
         $this->assertEquals('AdminRef', $client->getResults()[0]->key);
+        $this->assertEquals(1, count($client->getResults()));
     }
 
     /**
@@ -77,12 +77,12 @@ class ModuleControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
 
-        $client->request('GET', '/core/module/?search(module%20adminref)&gt(order,0)&select(key,path)');
+        $client->request('GET', '/core/module/?search(module%20payandsave%20real)&gt(order,0)&select(key,path)');
         $results = $client->getResults();
 
-        $this->assertEquals('AdminRef', $results[0]->key);
-        $this->assertEquals('retirement', $results[1]->key);
-        $this->assertEquals('realEstate', $results[2]->key);
+        $this->assertEquals('payAndSave', $results[0]->key);
+        $this->assertEquals('realEstate', $results[1]->key);
+        $this->assertEquals(5, count($results));
     }
 
     /**
@@ -753,7 +753,7 @@ class ModuleControllerTest extends RestTestCase
         $client->post('/core/module/', $testModule);
         $response = $client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
-        
+
         // Create element 2
         $testModule = new \stdClass;
         $testModule->key = 'i.ban.haz.dot';

--- a/src/Graviton/RabbitMqBundle/Tests/Controller/EventStatusControllerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Controller/EventStatusControllerTest.php
@@ -32,7 +32,9 @@ class EventStatusControllerTest extends RestTestCase
         $statusEntry = new \stdClass();
         $statusEntry->workerId = 'testworker';
         $statusEntry->status = 'opened';
-        $statusEntry->action  = 'status-key-action';
+        $statusEntry->action = (object) [
+            '$ref' => 'http://localhost/event/action/abba'
+        ];
 
         $status->status = [$statusEntry];
 
@@ -49,7 +51,7 @@ class EventStatusControllerTest extends RestTestCase
         $results = $client->getResults();
 
         $this->assertEquals('opened', $results->status[0]->status);
-        $this->assertEquals('status-key-action', $results->status[0]->action);
+        $this->assertEquals('http://localhost/event/action/abba', $results->status[0]->action->{'$ref'});
 
         // set invalid status
         $results->status[0]->status = 'thinking';

--- a/src/Graviton/SchemaBundle/Tests/Controller/SchemaConstraintsTest.php
+++ b/src/Graviton/SchemaBundle/Tests/Controller/SchemaConstraintsTest.php
@@ -166,7 +166,7 @@ class SchemaConstraintsTest extends RestTestCase
             'decimal-string' => [
                 'field' => 'decimalField',
                 'acceptedValue' => '1000000000.5555',
-                'rejectedValue' => '1.55555', // too much precision
+                'rejectedValue' => '1.555555555', // too much precision
                 'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,8})?$'
             ],
             'decimal-string-notation' => [

--- a/src/Graviton/SchemaBundle/Tests/Controller/SchemaConstraintsTest.php
+++ b/src/Graviton/SchemaBundle/Tests/Controller/SchemaConstraintsTest.php
@@ -167,19 +167,19 @@ class SchemaConstraintsTest extends RestTestCase
                 'field' => 'decimalField',
                 'acceptedValue' => '1000000000.5555',
                 'rejectedValue' => '1.55555', // too much precision
-                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,4})?$'
+                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,8})?$'
             ],
             'decimal-string-notation' => [
                 'field' => 'decimalField',
                 'acceptedValue' => '1000000000',
                 'rejectedValue' => '1,0', // wrong separator
-                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,4})?$'
+                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,8})?$'
             ],
             'decimal-string-string' => [
                 'field' => 'decimalField',
                 'acceptedValue' => '0',
                 'rejectedValue' => 'somestring', // string
-                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,4})?$'
+                'errorMessage' => 'Does not match the regex pattern ^[+\-]?\d+(\.\d{0,8})?$'
             ],
 
             // Count (number of array elements)


### PR DESCRIPTION
* [x] install mongodb 3.2 in test env (matches our current production)
* [x] move integration tests from unit testsuite to integration testsuite ae5e3dc1a13c3665202480961219c812cc5836f7
* [x] update configuration to point to a nonexistent mongodb when not doing integration tests (so new tests in the unit testsuite will fail if they try to access the database)