### PR TITLE
EVO-6336 ommit doubled service display

### DIFF
--- a/src/Graviton/CoreBundle/Controller/MainController.php
+++ b/src/Graviton/CoreBundle/Controller/MainController.php
@@ -169,7 +169,7 @@ class MainController
         );
 
         foreach ($services as $key => $val) {
-            if ($this->isRelevantForMainPage($val)) {
+            if ($this->isRelevantForMainPage($val) && !in_array($val['$ref'], $sortArr)) {
                 $sortArr[$key] = $val['$ref'];
             } else {
                 unset($services[$key]);


### PR DESCRIPTION
* this fixes the problem of showing the whoami service in the services list twice

the display of the services is done by the method determineServices who takes as argument an array that holds all routes of graviton & the adapter. The whoami route is additionally defined as "additionalRoute" in app/config.yml which leads to the doubled  display of it here. 