### PR TITLE
EVO-7046 - fix incorporation of rql queries into pagination Link header parts

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -165,6 +165,35 @@ class AppControllerTest extends RestTestCase
         );
 
         $this->assertSame('2', $response->headers->get('X-Total-Count'));
+
+        /*** pagination with different rql test **/
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app/?limit(1)&select(id)&sort(-order)');
+        $this->assertEquals(1, count($client->getResults()));
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            'http://localhost/core/app/?limit(1)&select(id)&sort(-order)>; rel="self"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app/?limit(1%2C1)&select(id)&sort(-order)>; rel="next"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app/?limit(1%2C1)&select(id)&sort(-order)>; rel="last"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertNotContains(
+            'rel="prev"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertSame('2', $response->headers->get('X-Total-Count'));
     }
 
     /**

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -133,10 +133,11 @@ class PagingLinkResponseListener
             $limit = sprintf('limit(%s,%s)', $perPage, $page);
         }
         if (strpos($rql, 'limit') !== false) {
-            $rql = preg_replace('/limit\(.*\)/', $limit, $rql);
+            $rql = preg_replace('/limit\(.*\)/U', $limit, $rql);
         } else {
-            $rql = $limit;
+            $rql .= '&'.$limit;
         }
+
         $url = $this->getRqlUrl(
             $request,
             $this->router->generate($routeName, [], true) . '?' . strtr($rql, [',' => '%2C'])


### PR DESCRIPTION
regex there was too greedy, replacing everything.. also adding a small assertion for that..

i'll need a tag right asap after merging this..