### PR TITLE
fix wrong id handling in recordorigin constraint

### DIFF
--- a/src/Graviton/SchemaBundle/Constraint/ConstraintUtils.php
+++ b/src/Graviton/SchemaBundle/Constraint/ConstraintUtils.php
@@ -97,8 +97,7 @@ class ConstraintUtils
         }
 
         // if we have a request, it must override it..
-        if (
-            $this->requestStack->getCurrentRequest() instanceof Request &&
+        if ($this->requestStack->getCurrentRequest() instanceof Request &&
             $this->requestStack->getCurrentRequest()->attributes->has('id')
         ) {
             $currentRecordId = $this->requestStack->getCurrentRequest()->attributes->get('id');

--- a/src/Graviton/SchemaBundle/Constraint/RecordOriginConstraint.php
+++ b/src/Graviton/SchemaBundle/Constraint/RecordOriginConstraint.php
@@ -176,7 +176,7 @@ class RecordOriginConstraint
             $iteration = 1;
             foreach ($parts as $part) {
                 if ($iteration < $numParts) {
-                    if (!is_object($val->{$part})) {
+                    if (!isset($val->{$part}) || !is_object($val->{$part})) {
                         $val->{$part} = new \stdClass();
                     }
                     $val = &$val->{$part};

--- a/src/Graviton/SchemaBundle/Resources/config/services.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/services.xml
@@ -94,6 +94,7 @@
     <service id="graviton.schema.constraint.utils" class="%graviton.schema.constraint.utils.class%">
       <argument type="service" id="doctrine_mongodb.odm.default_document_manager"/>
       <argument type="service" id="graviton.rest.restutils"/>
+      <argument type="service" id="request_stack"/>
       <tag name="kernel.event_listener" event="graviton.json_schema.constraint.schema" method="onSchemaValidation" priority="999"/>
     </service>
     <service id="graviton.schema.utils" class="%graviton.schema.service.schemautils.class%">

--- a/src/Graviton/SchemaBundle/Tests/Controller/RecordOriginConstraintTest.php
+++ b/src/Graviton/SchemaBundle/Tests/Controller/RecordOriginConstraintTest.php
@@ -54,6 +54,35 @@ class RecordOriginConstraintTest extends RestTestCase
     }
 
     /**
+     * tests for the case if user doesn't provide an id in payload.. constraint
+     * must take the id from the request in that case.
+     *
+     * @return void
+     */
+    public function testRecordOriginHandlingWithNoIdInPayload()
+    {
+        $record = (object) [
+            //'id' => '' - no, no id.. that's the point ;-)
+            'customerNumber' => 555,
+            'name' => 'Muster Hans'
+        ];
+
+        $client = static::createRestClient();
+        $client->put('/person/customer/100', $record);
+
+        $this->assertEquals(
+            (object) [
+                'propertyPath' => 'recordOrigin',
+                'message' => 'Prohibited modification attempt on record with recordOrigin of core'
+            ],
+            $client->getResults()[0]
+        );
+
+        $this->assertEquals(1, count($client->getResults()));
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /**
      * Test the validation of the RecordOriginConstraint
      *
      * @param array   $fieldsToSet      Fields to be modified


### PR DESCRIPTION
triggered through EVO-6960, we found an error how the `RecordOriginConstraint` checks if a current record exists or not. Falsely, it assumed there will always be an ID in payload - but as `RestUtils` in its check, also `ConstraintUtils` must fall back to the `Request` attribute `id` to make sure. Actually, the `Request` attribute is the one that must win.

We still have the check in place (in `RestUtils`) that will deny a request with a different id in payload and in the request URL..

This PR fixes the issue and adds an integration test to avoid regression..