### PR TITLE
don't cascade deletes on DELETE

### DIFF
--- a/src/Graviton/CoreBundle/Tests/Controller/EmbeddingDocumentsTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/EmbeddingDocumentsTest.php
@@ -228,6 +228,29 @@ class EmbeddingDocumentsTest extends RestTestCase
     }
 
     /**
+     * Assert that if we send a DELETE request to an entity, referenced objects will not be deleted
+     * as well..
+     *
+     * @return void
+     */
+    public function testThatReferencedObjectsWillNotBeDeletedOnDelete()
+    {
+        $client = static::createRestClient();
+        $client->request('DELETE', '/testcase/embedtest-document-as-deep-reference/test');
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $this->assertEmpty($client->getResults());
+
+        // check it's really gone ;-)
+        $client = static::createRestClient();
+        $client->request('GET', '/testcase/embedtest-document-as-deep-reference/test');
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+
+        // both entities should still exist
+        $this->assertEntityExists('one', 'one');
+        $this->assertEntityExists('two', 'two');
+    }
+
+    /**
      * Test Document as deep reference
      *
      * @return void

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -432,11 +432,14 @@ class DocumentModel extends SchemaModel implements ModelInterface
             $entity = $this->find($id);
         }
 
+        $this->checkIfOriginRecord($entity);
         $return = $entity;
-        if ($entity) {
-            $this->checkIfOriginRecord($entity);
-            $this->manager->remove($entity);
-            $this->manager->flush();
+
+        if (is_callable([$entity, 'getId']) && $entity->getId() != null) {
+            $this->deleteById($entity->getId());
+            // detach so odm knows it's gone
+            $this->manager->detach($entity);
+            $this->manager->clear();
             $return = null;
         }
 


### PR DESCRIPTION
when we introduced 'new validation', we changed the `PUT` behavior that will not cascade deletes on referenced objects on the record to be updated.

But the issue still persists on `DELETE` request. Consider the following flow:
* User takes a /person/customer entity
* Changes `recordOrigin` to `hans` 
* `PUT`s it to /person/customer
* `DELETE`s it..

All referenced objects will be deleted in that case. In case of /person/customer, luckily this is only `CustomerGroup` at the moment (I observed missing `CustomerGroup`s on public instances and this may be the explanation).

But other services which my reference a `ConsultantLocation` or whatever will delete that `ConsultantLocation` - core data gets lost.

So we need to fix that..