### PR TITLE
Feature/evo 6619 loop db translations

### DIFF
--- a/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
+++ b/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
@@ -85,7 +85,7 @@ class CreateTranslationResourcesCommand extends Command
         $output->writeln("Creating translation resource stubs");
 
         // Pause a bit before generating the languages.
-        $this->verifyDbConnection($output);
+        $this->openDbConnection($output);
 
         $languages = $this->languageRepo->findAll();
         $domains = $this->translatableRepo->createQueryBuilder()
@@ -117,7 +117,7 @@ class CreateTranslationResourcesCommand extends Command
      *
      * @return void
      */
-    private function verifyDbConnection(OutputInterface $output)
+    private function openDbConnection(OutputInterface $output)
     {
         $output->writeln('Checking DB connection');
 

--- a/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
+++ b/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
@@ -122,12 +122,7 @@ class CreateTranslationResourcesCommand extends Command
         $output->writeln('Checking DB connection');
 
         $loopCount = 0;
-        $documentManager = $this->languageRepo->getDocumentManager();
-        if (!$documentManager) {
-            return;
-        }
-        
-        $connection = $documentManager->getConnection();
+        $connection = $this->languageRepo->getDocumentManager()->getConnection();
 
         while (!($connected = $connection->isConnected())) {
             try {

--- a/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
+++ b/src/Graviton/I18nBundle/Command/CreateTranslationResourcesCommand.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\I18nBundle\Command;
 
+use MongoDB\Driver\Exception\ConnectionTimeoutException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -83,6 +84,9 @@ class CreateTranslationResourcesCommand extends Command
     {
         $output->writeln("Creating translation resource stubs");
 
+        // Pause a bit before generating the languages.
+        $this->verifyDbConnection($output);
+
         $languages = $this->languageRepo->findAll();
         $domains = $this->translatableRepo->createQueryBuilder()
             ->distinct('domain')
@@ -104,5 +108,41 @@ class CreateTranslationResourcesCommand extends Command
                 );
             }
         );
+    }
+
+    /**
+     * Loop until DB connection is insured.
+     *
+     * @param OutputInterface $output Used to inform about db connection status
+     *
+     * @return void
+     */
+    private function verifyDbConnection(OutputInterface $output)
+    {
+        $output->writeln('Checking DB connection');
+
+        $loopCount = 0;
+        $documentManager = $this->languageRepo->getDocumentManager();
+        if (!$documentManager) {
+            return;
+        }
+        
+        $connection = $documentManager->getConnection();
+
+        while (!($connected = $connection->isConnected())) {
+            try {
+                $connection->connect();
+                break;
+            } catch (\MongoConnectionException $e) {
+                $output->writeln('DB is not yet connected, sleep 1 second.');
+                sleep(1);
+            }
+            $loopCount++;
+            if ($loopCount > 20) {
+                throw new ConnectionTimeoutException('DB connection failed.');
+            }
+        }
+
+        $output->writeln('DB connected.');
     }
 }

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -36,6 +36,22 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
             ->method('findAll')
             ->willReturn([$enMock, $deMock]);
 
+        $connection = $this->getMockBuilder('\Doctrine\MongoDB\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $connection->expects($this->any())->method('isConnected')
+            ->willReturn(true);
+
+        $documentManager = $this->getMockBuilder('\Doctrine\ODM\MongoDB\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $documentManager->expects($this->once())->method('getConnection')
+            ->willReturn($connection);
+
+        $languageMock->expects($this->once())
+            ->method('getDocumentManager')
+            ->willReturn($documentManager);
+
         $translatableMock = $this->getMockBuilder('\Graviton\I18nBundle\Repository\TranslatableRepository')
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
+++ b/src/Graviton/I18nBundle/Tests/Command/CreateTranslationResourcesCommandTest.php
@@ -94,6 +94,7 @@ class CreateTranslationResourcesCommandTest extends \PHPUnit_Framework_TestCase
         $command->execute(array());
 
         $this->assertContains('Creating translation resource stubs', $command->getDisplay());
+        $this->assertContains('Checking DB connection', $command->getDisplay());
         $this->assertContains('Generated file core.en.odm', $command->getDisplay());
         $this->assertContains('Generated file core.de.odm', $command->getDisplay());
         $this->assertContains('Generated file i18n.en.odm', $command->getDisplay());


### PR DESCRIPTION
On docker up network connection can fail a few seconds so we run a loop until db is connected. This should avoid that sometimes we do not have all expected translations.