### PR TITLE
send weak etags to satisfy revers proxies like nginx

### DIFF
--- a/src/Graviton/CacheBundle/Listener/ETagResponseListener.php
+++ b/src/Graviton/CacheBundle/Listener/ETagResponseListener.php
@@ -27,6 +27,11 @@ class ETagResponseListener
     {
         $response = $event->getResponse();
 
-        $response->headers->set('ETag', sha1($response->getContent()));
+        /**
+         * the "W/" prefix is necessary to qualify it as a "weak" Etag.
+         * only then a proxy like nginx will leave the tag alone because a strong cannot
+         * match if gzip is applied.
+         */
+        $response->headers->set('ETag', 'W/'.sha1($response->getContent()));
     }
 }


### PR DESCRIPTION
this is kinda urgent.. ;-)

it seems nginx is eating our `Etag` when compression is used (see EVO-7191, the comments there).. nginx stops doing this if we qualify our Etag as 'weak', indicated with the prefix of `W/`..

Small change big impact ;-)