### PR TITLE
Remove KnpPaginatorBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "stof/doctrine-extensions-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
         "misd/guzzle-bundle": "~1.1",
-        "knplabs/knp-paginator-bundle": "~2.5",
         "exercise/htmlpurifier-bundle": "~0.2",
         "graviton/php-rql-parser": ">=2.0.2",
         "graviton/rql-parser-bundle": "~0.11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c1e21816cba8b94ab1b18b95c8d6496e",
-    "content-hash": "9e9257121e2f27cbcc09be2d2b759b2f",
+    "hash": "4bc826cd4729cc2aed2f3adfd7a8f1ec",
+    "content-hash": "ed09a4b4fa42011359467fb42c2f5b31",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -2915,77 +2915,6 @@
             "time": "2016-03-03 09:36:22"
         },
         {
-            "name": "knplabs/knp-components",
-            "version": "1.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/KnpLabs/knp-components.git",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/bc49e739d1cce94d783b1e23bc5b263b38dc47da",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "doctrine/mongodb-odm": "~1.0@beta",
-                "doctrine/orm": "~2.4",
-                "doctrine/phpcr-odm": "~1.2",
-                "jackalope/jackalope-doctrine-dbal": "~1.2",
-                "phpunit/phpunit": "~4.2",
-                "ruflin/elastica": "~1.0",
-                "symfony/event-dispatcher": "~2.5"
-            },
-            "suggest": {
-                "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",
-                "doctrine/mongodb-odm": "to allow usage pagination with Doctrine ODM MongoDB",
-                "doctrine/orm": "to allow usage pagination with Doctrine ORM",
-                "doctrine/phpcr-odm": "to allow usage pagination with Doctrine ODM PHPCR",
-                "propel/propel1": "to allow usage pagination with Propel ORM",
-                "ruflin/Elastica": "to allow usage pagination with ElasticSearch Client",
-                "solarium/solarium": "to allow usage pagination with Solarium Client"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Knp\\Component": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "KnpLabs Team",
-                    "homepage": "http://knplabs.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://github.com/KnpLabs/knp-components/contributors"
-                }
-            ],
-            "description": "Knplabs component library",
-            "homepage": "http://github.com/KnpLabs/knp-components",
-            "keywords": [
-                "components",
-                "knp",
-                "knplabs",
-                "pager",
-                "paginator"
-            ],
-            "time": "2016-04-21 06:26:20"
-        },
-        {
             "name": "knplabs/knp-gaufrette-bundle",
             "version": "0.3.0",
             "source": {
@@ -3042,67 +2971,6 @@
                 "media"
             ],
             "time": "2016-01-16 00:12:11"
-        },
-        {
-            "name": "knplabs/knp-paginator-bundle",
-            "version": "2.5.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/KnpLabs/KnpPaginatorBundle.git",
-                "reference": "c988761005504007c6c87d6a557641281194a0e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpPaginatorBundle/zipball/c988761005504007c6c87d6a557641281194a0e5",
-                "reference": "c988761005504007c6c87d6a557641281194a0e5",
-                "shasum": ""
-            },
-            "require": {
-                "knplabs/knp-components": "~1.2",
-                "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.3|~3.0",
-                "twig/twig": "~1.12|~2"
-            },
-            "require-dev": {
-                "symfony/expression-language": "~2.4|~3.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Knp\\Bundle\\PaginatorBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "KnpLabs Team",
-                    "homepage": "http://knplabs.com"
-                },
-                {
-                    "name": "Symfony2 Community",
-                    "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle/contributors"
-                }
-            ],
-            "description": "Paginator bundle for Symfony2 to automate pagination and simplify sorting and other features",
-            "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle",
-            "keywords": [
-                "Symfony2",
-                "bundle",
-                "knp",
-                "knplabs",
-                "pager",
-                "pagination",
-                "paginator"
-            ],
-            "time": "2016-04-20 11:40:30"
         },
         {
             "name": "kriswallsmith/buzz",

--- a/src/Graviton/RestBundle/GravitonRestBundle.php
+++ b/src/Graviton/RestBundle/GravitonRestBundle.php
@@ -5,7 +5,6 @@
 
 namespace Graviton\RestBundle;
 
-use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,7 +36,6 @@ class GravitonRestBundle extends Bundle implements GravitonBundleInterface
         return array(
             new MisdGuzzleBundle(),
             new JMSSerializerBundle(),
-            new KnpPaginatorBundle(),
         );
     }
 

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -50,9 +50,6 @@
         <service id="graviton.rest.doctrine" alias="doctrine"/>
         <service id="graviton.rest.router" alias="router"/>
 
-        <!-- Pagination -->
-        <service id="graviton.rest.paginator" alias="knp_paginator"/>
-
         <!-- Routing -->
         <!-- Routing collection -->
         <service id="graviton.rest.routing.collection" class="%graviton.rest.routing.collection.class%"/>

--- a/src/Graviton/RestBundle/Tests/GravitonRestBundleTest.php
+++ b/src/Graviton/RestBundle/Tests/GravitonRestBundleTest.php
@@ -7,7 +7,6 @@ namespace Graviton\RestBundle\Tests;
 
 use Graviton\RestBundle\GravitonRestBundle;
 use JMS\SerializerBundle\JMSSerializerBundle;
-use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Misd\GuzzleBundle\MisdGuzzleBundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
@@ -46,7 +45,6 @@ class GravitonRestBundleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains(new JMSSerializerBundle(), $result, '', false, false);
         $this->assertContains(new MisdGuzzleBundle(), $result, '', false, false);
-        $this->assertContains(new KnpPaginatorBundle(), $result, '', false, false);
     }
 
     /**


### PR DESCRIPTION
It seems to be quite some time ago when we stopped using this and reimplemented it natively in our MongoDB queries.