### PR TITLE
[WIP] Feature/evo 7278 created by proposal

### DIFF
--- a/src/Graviton/CoreBundle/Document/App.php
+++ b/src/Graviton/CoreBundle/Document/App.php
@@ -14,7 +14,7 @@ use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class App implements TranslatableDocumentInterface
+class App extends BaseDocument implements TranslatableDocumentInterface
 {
     /**
      * @var string app id

--- a/src/Graviton/CoreBundle/Document/BaseDocument.php
+++ b/src/Graviton/CoreBundle/Document/BaseDocument.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Document meant to keep unified Base Document structure.
+ */
+
+namespace Graviton\CoreBundle\Document;
+
+// To not show in any Serialised output.
+use JMS\Serializer\Annotation\ExclusionPolicy;
+
+/**
+ * App
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ *
+ * @ExclusionPolicy("all")
+ */
+class BaseDocument
+{
+    /**
+     * @var string app id
+     */
+    protected $iddoc;
+
+    /**
+     * @var \datetime modifiedAt date
+     */
+    protected $modifiedAt;
+
+    /**
+     * @var string updatedAt username
+     */
+    protected $modifiedBy;
+
+    /**
+     * @return string
+     */
+    public function getIddoc()
+    {
+        return $this->iddoc;
+    }
+
+    /**
+     * @param string $id DocumentId
+     * @return void
+     */
+    public function setIddoc($id)
+    {
+        $this->iddoc = $id;
+    }
+
+    /**
+     * @return \datetime Time it was modified
+     */
+    public function getModifiedAt()
+    {
+        return $this->modifiedAt;
+    }
+
+    /**
+     * @param \datetime $modifiedAt When document was modified
+     * @return void
+     */
+    public function setModifiedAt($modifiedAt)
+    {
+        $this->modifiedAt = $modifiedAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModifiedBy()
+    {
+        return $this->modifiedBy;
+    }
+
+    /**
+     * @param string $modifiedBy Who modified document
+     * @return void
+     */
+    public function setModifiedBy($modifiedBy)
+    {
+        $this->modifiedBy = $modifiedBy;
+    }
+}

--- a/src/Graviton/CoreBundle/Listener/BaseDocumentListener.php
+++ b/src/Graviton/CoreBundle/Listener/BaseDocumentListener.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Document Listener, to keep track of when and who updated a Document, beyond the logs.
+ * RQL enabled search by but fields are by default hidden.
+ */
+
+namespace Graviton\CoreBundle\Listener;
+
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Graviton\CoreBundle\Document\BaseDocument;
+use Graviton\SecurityBundle\Entities\SecurityUser;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Use doctrine odm lister to set or update modified by who and when
+ *
+ * @author  List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class BaseDocumentListener
+{
+    /**
+     * @var TokenStorage
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var string for current username
+     */
+    private $currentUsername;
+
+    /**
+     * BaseDocumentListener constructor.
+     *
+     * @param TokenStorage $tokenStorage Sf session storage
+     */
+    public function __construct(
+        TokenStorage $tokenStorage
+    ) {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Before persisting a change in DB we set who and when did it
+     *
+     * @param LifecycleEventArgs $args Lifecycle events
+     * @return void
+     */
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $document = $args->getDocument();
+        if ($document instanceof BaseDocument) {
+            $document->setModifiedAt(new \DateTime());
+            if ($name = $this->getSecurityUserUsername()) {
+                $document->setModifiedBy($name);
+            }
+        }
+    }
+
+    /**
+     * Before updating a change in DB we set who and when did it
+     *
+     * @param LifecycleEventArgs $args Lifecycle events
+     * @return void
+     */
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $document = $args->getDocument();
+        if ($document instanceof BaseDocument) {
+            $document->setModifiedAt(new \DateTime());
+            if ($name = $this->getSecurityUserUsername()) {
+                $document->setModifiedBy($name);
+            }
+        }
+    }
+    
+    /**
+     * Security needs to be enabled to get Object.
+     *
+     * @return String Username if available
+     */
+    public function getSecurityUserUsername()
+    {
+        if ($this->currentUsername) {
+            return $this->currentUsername;
+        }
+
+        /** @var PreAuthenticatedToken $token */
+        if (($token = $this->tokenStorage->getToken())
+            && ($user = $token->getUser()) instanceof UserInterface ) {
+            /** @var SecurityUser $user */
+            return $user->getUsername();
+        }
+        return 'none';
+    }
+}

--- a/src/Graviton/CoreBundle/Resources/config/doctrine/BaseDocument.mongodb.xml
+++ b/src/Graviton/CoreBundle/Resources/config/doctrine/BaseDocument.mongodb.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <document name="Graviton\CoreBundle\Document\BaseDocument">
+    <field fieldName="iddoc" id="true" strategy="UUID"/>
+    <field fieldName="modifiedAt" type="date"/>
+    <field fieldName="modifiedBy" type="string"/>
+  </document>
+</doctrine-mongo-mapping>

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -17,6 +17,7 @@
         <parameter key="graviton.core.service.coreutils.class">Graviton\CoreBundle\Service\CoreUtils</parameter>
         <parameter key="graviton.core.service.coreversionutils.class">Graviton\CoreBundle\Service\CoreVersionUtils</parameter>
         <parameter key="graviton.core.listener.jsonexceptionlistener.class">Graviton\CoreBundle\Listener\JsonExceptionListener</parameter>
+        <parameter key="graviton.core.listener.basedocument.class">Graviton\CoreBundle\Listener\BaseDocumentListener</parameter>
     </parameters>
     <services>
         <service id="graviton.core.controller.main"
@@ -124,6 +125,13 @@
                 <argument type="service" id="graviton.core.command.parser"/>
             </call>
             <tag name="console.command" />
+        </service>
+
+        <service id="graviton.core.listener.basedocument_db_listener"
+                 class="%graviton.core.listener.basedocument.class%">
+            <argument type="service" id="security.token_storage" />
+            <tag name="doctrine_mongodb.odm.event_listener" event="prePersist"/>
+            <tag name="doctrine_mongodb.odm.event_listener" event="preUpdate"/>
         </service>
     </services>
 </container>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -8,9 +8,9 @@
     </mapped-superclass>
 
     {% if docType is defined and docType == "embedded-document" %}
-        {% set isEmbeddedDocument = true %}
+        {% set hideIdField = true %}
     {% else %}
-        {% set isEmbeddedDocument = false %}
+        {% set hideIdField = false %}
     {% endif %}
 
     {% if docType is not defined %}
@@ -20,7 +20,7 @@
   <{{ docType }} name="{{ base }}Document\{{ document }}" repository-class="{{ base }}Repository\{{ document}}Repository" collection="{{ collection }}" inheritance-type="COLLECTION_PER_CLASS">
 
   {% if idField is defined %}
-      {% if isEmbeddedDocument == false %}
+      {% if hideIdField == false %}
           <field fieldName="id" id="true" strategy="UUID" />
       {% else %}
           <field fieldName="id" type="{{ idField.doctrineType }}" id="false"/>
@@ -74,7 +74,6 @@
             <field fieldName="recordOrigin" type="string"/>
         {% endif %}
 
-{% if not isEmbeddedDocument %}
     <indexes>
     {% if indexes is defined and indexes is not empty %}
             {% for index in indexes %}
@@ -95,7 +94,6 @@
             </index>
     {% endif %}
     </indexes>
-{% endif %}
 
     </{{ docType }}>
 </doctrine-mongo-mapping>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/DocumentBase.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/DocumentBase.php.twig
@@ -6,6 +6,7 @@
 namespace {{ base }}Document;
 
 use \Doctrine\Common\Collections\ArrayCollection;
+use Graviton\CoreBundle\Document\BaseDocument;
 use Graviton\I18nBundle\Document\TranslatableDocumentInterface;
 use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\DeserializationContext;
@@ -22,7 +23,7 @@ use Graviton\GeneratorBundle\Generator\ResourceGenerator\XDynamicKey;
 * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
 * @link     http://swisscom.ch
 */
-abstract class {{ document }}Base implements TranslatableDocumentInterface{% if isrecordOriginFlagSet %}, \Graviton\RestBundle\Model\RecordOriginInterface{% endif %}
+abstract class {{ document }}Base extends BaseDocument implements TranslatableDocumentInterface{% if isrecordOriginFlagSet %}, \Graviton\RestBundle\Model\RecordOriginInterface{% endif %}
 {
 
 /**


### PR DESCRIPTION
We need a silent DB insert on who modified and when a document on last time. 
Initially we intended to use the standard createdAt/By and updatedAt/By but due to delete the document on "update" I could not use it that way. So after discussion I propose the simple solution to run it using modifiedAt/By. 
This can be queried in RQL but value will not be visible in any output ( Unless specifically "exposed" ).
