### PR TITLE
EVO-7435 - add new field in external link service

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/ExternalLinks.json
+++ b/src/Graviton/CoreBundle/Resources/definition/ExternalLinks.json
@@ -42,12 +42,10 @@
         "description": "The order index"
       },
       {
-        "name": "type.ref",
-        "type": "extref",
-        "title": "Type",
-        "description": "Link to any element in order to build groups of links.",
-        "exposeAs": "$ref",
-        "collection": ["*"]
+        "name": "group",
+        "type": "varchar",
+        "title": "Group",
+        "description": "A field to build groups of links."
       }
     ]
   }

--- a/src/Graviton/CoreBundle/Resources/definition/ExternalLinks.json
+++ b/src/Graviton/CoreBundle/Resources/definition/ExternalLinks.json
@@ -23,7 +23,6 @@
         "description": "Name of the external link",
         "translatable": true
       },
-
       {
         "name": "url",
         "type": "varchar",
@@ -41,6 +40,14 @@
         "type": "int",
         "title": "Order",
         "description": "The order index"
+      },
+      {
+        "name": "type.ref",
+        "type": "extref",
+        "title": "Type",
+        "description": "Link to any element in order to build groups of links.",
+        "exposeAs": "$ref",
+        "collection": ["*"]
       }
     ]
   }


### PR DESCRIPTION
a simple new extref field that allows to create groups of links by setting them the same type extref..