### PR TITLE
Make it configurable to hide a field if its embedded extref is empty

### DIFF
--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionField.php
@@ -102,6 +102,7 @@ class JsonDefinitionField implements DefinitionElementInterface
             'title'                 => $this->definition->getTitle(),
             'description'           => $this->definition->getDescription(),
             'readOnly'              => $this->definition->getReadOnly(),
+            'hideOnEmptyExtref'     => $this->definition->isHideOnEmptyExtref(),
             'recordOriginException' => $this->definition->isRecordOriginException(),
             'required'              => $this->definition->getRequired(),
             'searchable'            => $this->definition->getSearchable(),

--- a/src/Graviton/GeneratorBundle/Definition/JsonDefinitionHash.php
+++ b/src/Graviton/GeneratorBundle/Definition/JsonDefinitionHash.php
@@ -83,6 +83,7 @@ class JsonDefinitionHash implements DefinitionElementInterface
                 'readOnly'          => $this->definition->getReadOnly(),
                 'required'          => $this->definition->getRequired(),
                 'searchable'        => $this->definition->getSearchable(),
+                'hideOnEmptyExtref' => $this->definition->isHideOnEmptyExtref(),
                 'constraints'       => array_map(
                     [Utils\ConstraintNormalizer::class, 'normalize'],
                     $this->definition->getConstraints()

--- a/src/Graviton/GeneratorBundle/Definition/Schema/Field.php
+++ b/src/Graviton/GeneratorBundle/Definition/Schema/Field.php
@@ -50,6 +50,10 @@ class Field
     /**
      * @var bool
      */
+    private $hideOnEmptyExtref = false;
+    /**
+     * @var bool
+     */
     private $required = false;
     /**
      * @var integer
@@ -198,6 +202,28 @@ class Field
     {
         $this->readOnly = $readOnly;
         return $this;
+    }
+
+    /**
+     * is HideOnEmptyExtref
+     *
+     * @return boolean HideOnEmptyExtref
+     */
+    public function isHideOnEmptyExtref()
+    {
+        return $this->hideOnEmptyExtref;
+    }
+
+    /**
+     * set setHideOnEmptyExtref
+     *
+     * @param boolean $hideOnEmptyExtref hideOnEmptyExtref
+     *
+     * @return void
+     */
+    public function setHideOnEmptyExtref($hideOnEmptyExtref)
+    {
+        $this->hideOnEmptyExtref = $hideOnEmptyExtref;
     }
 
     /**

--- a/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Field.xml
+++ b/src/Graviton/GeneratorBundle/Resources/config/serializer/Definition.Schema.Field.xml
@@ -22,6 +22,9 @@
         <property name="readOnly"
                   type="boolean"
                   serialized-name="readOnly"/>
+        <property name="hideOnEmptyExtref"
+                  type="boolean"
+                  serialized-name="hideOnEmptyExtref"/>
         <property name="recordOriginException"
                   type="boolean"
                   serialized-name="recordOriginException"/>

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/DocumentBase.php.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/DocumentBase.php.twig
@@ -39,10 +39,10 @@ protected $deletedDate;
 
 {% for field in fields %}
     /**
-    {% if 'Graviton' in field.type %}
-        * @var \{{ field.type }} ${{ field.fieldName }}
+    {% if 'Graviton' in field.serializerType %}
+        * @return \{{ field.serializerType }} ${{ field.fieldName }}
     {% else %}
-        * @var {{ field.type }} ${{ field.fieldName }}
+        * @return {{ field.serializerType }} ${{ field.fieldName }}
     {% endif %}
     */
     {% if field.type == 'array' %}
@@ -130,10 +130,10 @@ return $this->deletedDate;
     /**
     * Get {{ field.fieldName }}
     *
-    {% if 'Graviton' in field.type %}
-        * @return \{{ field.type }} ${{ field.fieldName }}
+    {% if 'Graviton' in field.serializerType %}
+        * @return \{{ field.serializerType }} ${{ field.fieldName }}
     {% else %}
-        * @return {{ field.type }} ${{ field.fieldName }}
+        * @return {{ field.serializerType }} ${{ field.fieldName }}
     {% endif %}
     */
     {% if field.type == 'boolean' %}
@@ -145,17 +145,21 @@ return $this->deletedDate;
     {% if field.xDynamicKey is defined and field.xDynamicKey != null %}
         return XDynamicKey::resolveRef($this->{{ field.fieldName }}, '{{ field.xDynamicKey.refField }}');
     {% else %}
-        return $this->{{ field.fieldName }};
+        {% if field.hideOnEmptyExtref is defined and field.hideOnEmptyExtref==true and field.relType=='embed' %}
+            return $this->{{ field.fieldName }} && $this->{{ field.fieldName }}->getRef() ? $this->{{ field.fieldName }} : null;
+        {% else %}
+            return $this->{{ field.fieldName }};
+        {% endif %}
     {% endif %}
     }
 
     /**
     * Set {{ field.fieldName }}
     *
-    {% if 'Graviton' in field.type %}
-        * @param \{{ field.type }} ${{ field.fieldName }} object for {{ field.fieldName }}
+    {% if 'Graviton' in field.serializerType %}
+        * @param \{{ field.serializerType }} ${{ field.fieldName }} object for {{ field.fieldName }}
     {% else %}
-        * @param {{ field.type }} ${{ field.fieldName }} value for {{ field.fieldName }}
+        * @param {{ field.serializerType }} ${{ field.fieldName }} value for {{ field.fieldName }}
     {% endif %}
     *
     * @return self
@@ -194,7 +198,7 @@ return $this->deletedDate;
         /**
         * add element to {{ field.fieldName }}
         *
-        * @param {{ itemTypeName }} ${{ field.singularName }} value to add to {{ field.fieldName }}
+        * @param \{{ itemTypeName }} ${{ field.singularName }} value to add to {{ field.fieldName }}
         *
         * @return self
         */
@@ -206,7 +210,7 @@ return $this->deletedDate;
         /**
         * remove element from {{ field.fieldName }}
         *
-        * @param {{ itemTypeName }} ${{ field.singularName }} value to remove from {{ field.fieldName }}
+        * @param \{{ itemTypeName }} ${{ field.singularName }} value to remove from {{ field.fieldName }}
         *
         * @return self
         */

--- a/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/model/schema.json.twig
@@ -40,6 +40,10 @@
       "readOnly": {{ field.readOnly|json_encode() }},
 {% endif %}
 
+{% if field.hideOnEmptyExtref is defined and field.hideOnEmptyExtref == true %}
+        "hideOnEmptyExtref": {{ field.hideOnEmptyExtref|json_encode() }},
+{% endif %}
+
 {% if field.recordOriginException is defined and field.recordOriginException == true %}
       "recordOriginException": {{ field.recordOriginException|json_encode() }},
 {% endif %}

--- a/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionElementTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/DefinitionElementTest.php
@@ -117,7 +117,8 @@ class DefinitionElementTest extends \PHPUnit_Framework_TestCase
             'collection' => array(),
             'xDynamicKey' => null,
             'searchable' => 1,
-            'recordOriginException' => false
+            'recordOriginException' => false,
+            'hideOnEmptyExtref' => false
         );
 
         $this->assertEquals($def, $field->getDefAsArray());

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionFieldTest.php
@@ -159,16 +159,17 @@ class JsonDefinitionFieldTest extends BaseJsonDefinitionFieldTest
             array_replace(
                 $this->getBaseDefAsArray($definition),
                 [
-                    'name'                 => $field->getName(),
-                    'type'                 => $field->getType(),
-                    'exposedName'          => $definition->getExposeAs(),
-                    'doctrineType'         => $field->getTypeDoctrine(),
-                    'serializerType'       => $field->getTypeSerializer(),
-                    'relType'              => null,
-                    'isClassType'          => false,
-                    'xDynamicKey'          => null,
-                    'searchable'           => 0,
-                    'recordOriginException' => false
+                    'name'                  => $field->getName(),
+                    'type'                  => $field->getType(),
+                    'exposedName'           => $definition->getExposeAs(),
+                    'doctrineType'          => $field->getTypeDoctrine(),
+                    'serializerType'        => $field->getTypeSerializer(),
+                    'relType'               => null,
+                    'isClassType'           => false,
+                    'xDynamicKey'           => null,
+                    'searchable'            => 0,
+                    'recordOriginException' => false,
+                    'hideOnEmptyExtref'     => false
                 ]
             ),
             $field->getDefAsArray()
@@ -205,7 +206,8 @@ class JsonDefinitionFieldTest extends BaseJsonDefinitionFieldTest
                     'isClassType'           => false,
                     'xDynamicKey'           => $key,
                     'searchable'            => 0,
-                    'recordOriginException' => false
+                    'recordOriginException' => false,
+                    'hideOnEmptyExtref'     => false
                 ]
             ),
             $field->getDefAsArray()

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionHashTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionHashTest.php
@@ -113,7 +113,7 @@ class JsonDefinitionHashTest extends \PHPUnit_Framework_TestCase
                 'isClassType'       => true,
                 'constraints'       => [],
                 'required'          => false, // default required state for anonymous hash is false
-                'searchable'        => 0,
+                'searchable'        => 0
             ],
             $field->getDefAsArray()
         );
@@ -158,6 +158,7 @@ class JsonDefinitionHashTest extends \PHPUnit_Framework_TestCase
                 'readOnly'          => $definition->getReadOnly(),
                 'required'          => $definition->getRequired(),
                 'searchable'        => $definition->getSearchable(),
+                'hideOnEmptyExtref' => $definition->isHideOnEmptyExtref()
             ],
             $field->getDefAsArray()
         );

--- a/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionRelTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Definition/JsonDefinitionRelTest.php
@@ -97,7 +97,8 @@ class JsonDefinitionRelTest extends BaseJsonDefinitionFieldTest
                     'relType'               => $relation->getType(),
                     'isClassType'           => true,
                     'searchable'            => 0,
-                    'recordOriginException' => false
+                    'recordOriginException' => false,
+                    'hideOnEmptyExtref'     => false
                 ]
             ),
             $field->getDefAsArray()

--- a/src/Graviton/SchemaBundle/Model/SchemaModel.php
+++ b/src/Graviton/SchemaBundle/Model/SchemaModel.php
@@ -190,6 +190,18 @@ class SchemaModel implements ContainerAwareInterface
     }
 
     /**
+     * get hideOnEmptyExtref flag for a given field
+     *
+     * @param string $field field name
+     *
+     * @return boolean the hideOnEmptyExtref flag
+     */
+    public function getHideOnEmptyExtref($field)
+    {
+        return $this->getSchemaField($field, 'hideOnEmptyExtref', false);
+    }
+
+    /**
      * get readOnly flag for a given field
      *
      * @param string $field field name

--- a/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
+++ b/src/Graviton/SchemaBundle/Resources/config/serializer/Document.Schema.xml
@@ -7,6 +7,7 @@
     <property name="readOnly" type="boolean" accessor-getter="getReadOnly" accessor-setter="setReadOnly" expose="true"/>
     <property name="recordOriginModifiable" serialized-name="x-recordOriginModifiable" type="boolean" accessor-getter="isRecordOriginModifiable" accessor-setter="setRecordOriginModifiable" expose="true"/>
     <property name="recordOriginException" serialized-name="x-recordOriginException" type="boolean" accessor-getter="isRecordOriginException" accessor-setter="setRecordOriginException" expose="true"/>
+    <property name="hideOnEmptyExtref" serialized-name="x-hideOnEmptyExtref" type="boolean" accessor-getter="isHideOnEmptyExtref" accessor-setter="setHideOnEmptyExtref" expose="true"/>
     <property name="format" type="string" accessor-getter="getFormat" accessor-setter="setFormat" expose="true"/>
     <property name="minLength" type="integer" accessor-getter="getMinLength" accessor-setter="setMinLength" expose="true"/>
     <property name="maxLength" type="integer" accessor-getter="getMaxLength" accessor-setter="setMaxLength" expose="true"/>


### PR DESCRIPTION
Problem: Some clients of the RestAPI have difficulties finding no $ref- entry embedded in an JSON-Object for extrefs. Even if this is a valid JSON-Object.
This could be solved globally with a lot of unwanted side-effects. Therefore this PR introduces the setting `hideOnEmptyExtref` for the wrapper Class of an Extref-Definition:
```
...
{
   "name": "hiddenOnEmptyOptionalExtref",
   "type": "object",
   "hideOnEmptyExtref": true
},
{
    "name": "hiddenOnEmptyOptionalExtref.ref",
     "type": "extrem",
     "exposeAs": "$ref",
     "required": false
}
...
```
Like this, this behavior can be punctually defined where its needed.