### PR TITLE
fix paging headers when user doesnt provide rql

### DIFF
--- a/src/Graviton/CoreBundle/DataFixtures/MongoDB/LoadAppDataExceedSinglePageLimit.php
+++ b/src/Graviton/CoreBundle/DataFixtures/MongoDB/LoadAppDataExceedSinglePageLimit.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * /core/app fixtures for mongodb app collection, exceeding one page size.
+ */
+
+namespace Graviton\CoreBundle\DataFixtures\MongoDB;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Graviton\CoreBundle\Document\App;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class LoadAppDataExceedSinglePageLimit implements FixtureInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param ObjectManager $manager Object Manager
+     *
+     * @return void
+     */
+    public function load(ObjectManager $manager)
+    {
+        $howManyApps = 15;
+        $createdCount = 0;
+
+        while ($createdCount < $howManyApps) {
+            $app = new App;
+            $app->setId('app'.$createdCount);
+            $app->setName('App'.$createdCount);
+            $app->setShowInMenu(true);
+            $app->setOrder($createdCount);
+
+            $manager->persist($app);
+            $createdCount++;
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php
@@ -80,6 +80,43 @@ class AppControllerTest extends RestTestCase
     }
 
     /**
+     * test that our paging headers are correct if client does NOT provide rql BUT
+     * we have more records in the db then the default pagesize (= we will add limit() clauses to Link elements)
+     *
+     * @return void
+     */
+    public function testGeneratedPagingHeadersNoRql()
+    {
+        $this->loadFixtures(
+            [
+                'Graviton\CoreBundle\DataFixtures\MongoDB\LoadAppDataExceedSinglePageLimit'
+            ],
+            null,
+            'doctrine_mongodb'
+        );
+
+        $client = static::createRestClient();
+        $client->request('GET', '/core/app/');
+
+        $response = $client->getResponse();
+
+        $this->assertContains(
+            '<http://localhost/core/app/?limit(0%2C10)>; rel="self"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app/?limit(10%2C10)>; rel="next"',
+            $response->headers->get('Link')
+        );
+
+        $this->assertContains(
+            '<http://localhost/core/app/?limit(10%2C10)>; rel="last"',
+            $response->headers->get('Link')
+        );
+    }
+
+    /**
      * test if we can get list of apps, paged and with filters..
      *
      * @return void

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -134,6 +134,8 @@ class PagingLinkResponseListener
         }
         if (strpos($rql, 'limit') !== false) {
             $rql = preg_replace('/limit\(.*\)/U', $limit, $rql);
+        } elseif (empty($rql)) {
+            $rql .= $limit;
         } else {
             $rql .= '&'.$limit;
         }


### PR DESCRIPTION
we currently generate wrong paging headers if the user doesn't pass any rql *but* we have more than the default pagesize in the database..

we generate:
```
Link: <https://host/person/customer/?&limit(10%2C10)>; rel="next",<https://host/?&limit(10%2C170)>; rel="last",<https://host/person/customer/?limit(0%2C10)>; rel="self"
```

and `?&limit` makes the url invalid.. this PR corrects this..