### PR TITLE
Feature/evo 8123 rql select update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "libgraviton/codesniffer": "~1.3",
         "lapistano/proxy-object": "dev-master",
         "johnkary/phpunit-speedtrap": "~1.0",
-        "graviton/test-services-bundle": "~0.22",
+        "graviton/test-services-bundle": "~0.23",
         "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "52c2216340f778133ecad319862ce6f8",
-    "content-hash": "ccfb9b1ee6cef7746d9097b0cd5282c4",
+    "hash": "63e941a42846f24563c102c1987c9047",
+    "content-hash": "85f95f71d686b005290fabbd66c10cc4",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -4701,16 +4701,16 @@
     "packages-dev": [
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.22.0",
+            "version": "v0.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "323fe8680b4a312775c715494f45ab90b115623c"
+                "reference": "b8448cc57673295cb11ebabad9632086a3c17f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/323fe8680b4a312775c715494f45ab90b115623c",
-                "reference": "323fe8680b4a312775c715494f45ab90b115623c",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/b8448cc57673295cb11ebabad9632086a3c17f96",
+                "reference": "b8448cc57673295cb11ebabad9632086a3c17f96",
                 "shasum": ""
             },
             "type": "library",
@@ -4730,10 +4730,10 @@
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
             "support": {
-                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.22.0",
+                "source": "https://github.com/libgraviton/GravitonTestServicesBundle/tree/v0.23.0",
                 "issues": "https://github.com/libgraviton/GravitonTestServicesBundle/issues"
             },
-            "time": "2016-10-07 07:11:25"
+            "time": "2016-10-26 07:37:12"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/src/Graviton/CoreBundle/Tests/Controller/SerializerSelectExclusionStrategyTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/SerializerSelectExclusionStrategyTest.php
@@ -5,6 +5,7 @@
 
 namespace Graviton\CoreBundle\Tests\Controller;
 
+use Graviton\RestBundle\ExclusionStrategy\SelectExclusionStrategy;
 use Graviton\TestBundle\Test\RestTestCase;
 use GravitonDyn\TestCaseDeepEqualNamingBundle\DataFixtures\MongoDB\LoadTestCaseDeepEqualNamingData;
 use Symfony\Component\HttpFoundation\Response;
@@ -106,5 +107,36 @@ class SerializerSelectExclusionStrategyTest extends RestTestCase
         );
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $this->assertEquals($expectedResult, $client->getResults());
+    }
+
+    /**
+     * Test the private select function
+     *
+     * @return void
+     */
+    public function testSelectExclusionStrategyPrivateCreateArrayByPath()
+    {
+        /** @var SelectExclusionStrategy $class */
+        $class = $this->getContainer()->get('graviton.rest.serializer.exclusionstrategy.selectexclusionstrategy');
+        $method = $this->getPrivateClassMethod(get_class($class), 'createArrayByPath');
+
+        $mainResult = [];
+
+        $path = 'level.levela.levela1';
+        $arr = $method->invokeArgs($class, [$path]);
+        $mainResult = array_merge_recursive($mainResult, $arr);
+
+        $path = 'level.levelb.levelb1';
+        $arr = $method->invokeArgs($class, [$path]);
+        $mainResult = array_merge_recursive($mainResult, $arr);
+
+        $expectedResult = [
+            'level' => [
+                'levela' => ['levela1' => true],
+                'levelb' => ['levelb1' => true]
+            ]
+        ];
+
+        $this->assertEquals($expectedResult, $mainResult);
     }
 }

--- a/src/Graviton/CoreBundle/Tests/resources/serializer-exclusion-nested-double.json
+++ b/src/Graviton/CoreBundle/Tests/resources/serializer-exclusion-nested-double.json
@@ -1,0 +1,92 @@
+[
+  {
+    "level": [
+      {
+        "levela": [
+          {
+            "levela1": [
+              {
+                "levela2": "testdata1 A2 reached"
+              }
+            ]
+          }
+        ],
+        "levelb": [
+          {
+            "levelb1": [
+              {
+                "levelb2": "testdata1 B2 reached"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "id": "testdata1"
+  },
+  {
+    "level": [
+      {
+        "levela": [
+          {
+            "levela1": [
+              {}
+            ]
+          }
+        ],
+        "levelb": [
+          {
+            "levelb1": [
+              {
+                "levelb2": " testdata2 2 reached"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "id": "testdata2"
+  },
+  {
+    "level": [
+      {
+        "levela": [
+          {
+            "levela1": []
+          }
+        ],
+        "levelb": [
+          {
+            "levelb1": [
+              {
+                "levelb2": "testdata3 B2  reached"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "id": "testdata3"
+  },
+  {
+    "level": [
+      {
+        "levela": [
+          {
+            "levela1": [
+              {
+                "levela2": "testdata4 A2 reached"
+              }
+            ]
+          }
+        ],
+        "levelb": [
+          {
+            "levelb1": []
+          }
+        ]
+      }
+    ],
+    "id": "testdata4"
+  }
+]

--- a/src/Graviton/RestBundle/ExclusionStrategy/SelectExclusionStrategy.php
+++ b/src/Graviton/RestBundle/ExclusionStrategy/SelectExclusionStrategy.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Context;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Xiag\Rql\Parser\Query;
+use Xiag\Rql\Parser\Node\SelectNode;
 
 /**
  * In this Strategy we skip all properties on first level who are not selected if there is a select in rql.
@@ -26,16 +27,6 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
     protected $requestStack;
 
     /**
-     * @var Array $selectedFields contains all the selected fields and its combinations with nested fields
-     */
-    protected $selectedFields;
-
-    /**
-     * @var Array $selectedLeafs contains the leafs of the selection "tree"
-     */
-    protected $selectedLeafs;
-
-    /**
      * @var Boolean $isSelect
      */
     protected $isSelect;
@@ -46,9 +37,9 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
     protected $currentPath;
 
     /**
-     * @var Integer $currentDepth
+     * @var array for selected tree level
      */
-    protected $currentDepth;
+    protected $selectTree = [];
 
     /**
      * SelectExclusionStrategy constructor.
@@ -58,9 +49,25 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
-        $this->currentDepth = 0;
-        $this->currentPath = [];
-        $this->getSelectedFieldsFromRQL();
+        $this->createSelectionTreeFromRQL();
+    }
+
+    /**
+     * Convert dot string to array.
+     *
+     * @param string $path string dotted array
+     *
+     * @return array
+     */
+    private function createArrayByPath($path)
+    {
+        $arr = [];
+        $scope = &$arr;
+        $keys = explode('.', $path);
+        while ($key = array_shift($keys)) {
+            $scope = &$scope[$key];
+        }
+        return $arr;
     }
 
     /**
@@ -69,35 +76,26 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
      * called once in the object, so shouldSkipProperty can use the information for every field
      * @return void
      */
-    private function getSelectedFieldsFromRQL()
+    private function createSelectionTreeFromRQL()
     {
         $currentRequest = $this->requestStack->getCurrentRequest();
-        $this->selectedFields = [];
-        $this->selectedLeafs = [];
+        $this->selectTree = [];
+        $this->currentPath = [];
         $this->isSelect = false;
+
+        /** @var SelectNode $select */
         if ($currentRequest
             && ($rqlQuery = $currentRequest->get('rqlQuery')) instanceof Query
             && $select = $rqlQuery->getSelect()
         ) {
             $this->isSelect = true;
-            // the selected fields are the leafs
-            $this->selectedLeafs = $select->getFields();
-            // get all combinations of leaf with nested fields
-            foreach ($this->selectedLeafs as $selectedLeaf) {
-                //clean up $
-                $selectedLeaf = str_replace('$', '', $selectedLeaf);
-                $this->selectedFields[] = $selectedLeaf;
-                if (strstr($selectedLeaf, '.')) {
-                    $nestedFields = explode('.', $selectedLeaf);
-                    for ($i = 1; $i < count($nestedFields); $i++) {
-                        $this->selectedFields[] = implode('.', array_slice($nestedFields, 0, $i));
-                    }
-                }
+            // Build simple selected field tree
+            foreach ($select->getFields() as $field) {
+                $field = str_replace('$', '', $field);
+                $arr = $this->createArrayByPath($field);
+                $this->selectTree = array_merge_recursive($this->selectTree, $arr);
             }
-            // id is always included in response (bug/feature)?
-            if (!in_array('id', $this->selectedFields)) {
-                $this->selectedFields[] = 'id';
-            };
+            $this->selectTree['id'] = true;
         }
     }
 
@@ -126,31 +124,32 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
             return false;
         }
 
-        // calculate the currentPath in the "tree" of the document to be serialized
-        $depth = $context->getDepth() - 1;
-        if ($depth <= $this->currentDepth) {
-            // reduce the currentPath by one step
-            array_pop($this->currentPath);
-            // start a new currentPath on depth 0
-            if ($depth == 0) {
-                $this->currentPath = [];
-            }
-        }
-        $this->currentPath[] = $property->name;
-        $this->currentDepth = $depth;
-        $currentPath = implode('.', $this->currentPath);
+        // Level starts at 1, so -1 to have it level 0
+        $depth = $context->getDepth()-1;
 
-        // test the currentpath
-        $skip = ! in_array($currentPath, $this->selectedFields);
-        // give it a second chance if its a nested path, go through all the selectedLeafs
-        if ($this->currentDepth>0 && $skip) {
-            foreach ($this->selectedLeafs as $leaf) {
-                if (strstr($currentPath, $leaf)) {
-                    $skip = false;
-                    break;
-                }
+        // Here we build a level based array so we get them all
+        $this->currentPath[$depth] = $property->name;
+        $keyPath = [];
+        foreach ($this->currentPath as $key => $path) {
+            if ($key > $depth && array_key_exists($key, $this->currentPath)) {
+                unset($this->currentPath[$key]);
+            } else {
+                $keyPath[] = $path;
             }
         }
-        return $skip;
+
+        // check path and parent/son should be seen.
+        $tree = $this->selectTree;
+        foreach ($keyPath as $path) {
+            if (empty($tree)) {
+                break;
+            }
+            if (array_key_exists($path, $tree)) {
+                $tree = $tree[$path];
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Graviton/RestBundle/ExclusionStrategy/SelectExclusionStrategy.php
+++ b/src/Graviton/RestBundle/ExclusionStrategy/SelectExclusionStrategy.php
@@ -61,13 +61,14 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
      */
     private function createArrayByPath($path)
     {
-        $arr = [];
-        $scope = &$arr;
         $keys = explode('.', $path);
-        while ($key = array_shift($keys)) {
-            $scope = &$scope[$key];
+        $val = true;
+        $localArray = [];
+        for ($i=count($keys)-1; $i>=0; $i--) {
+            $localArray = [$keys[$i]=>$val];
+            $val = $localArray;
         }
-        return $arr;
+        return $localArray;
     }
 
     /**
@@ -141,7 +142,7 @@ class SelectExclusionStrategy implements ExclusionStrategyInterface
         // check path and parent/son should be seen.
         $tree = $this->selectTree;
         foreach ($keyPath as $path) {
-            if (empty($tree)) {
+            if (!is_array($tree)) {
                 break;
             }
             if (array_key_exists($path, $tree)) {


### PR DESCRIPTION
RQL select error discovered in very nested element. 
The added test do not fully cover the issue as the problem is when using a select with:
field1.field2.field3.field4
field1.field2.fieldX3.fieldX4

if field3 is empty the hole select for field1 is returned as empty and unset to be displayed in url. 
