### PR TITLE
EVO-8294 On posting a file, there should be the option to set custom HASH.

### DIFF
--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -217,7 +217,8 @@ class FileManager
 
         // File related, if no file uploaded we keep original file info.
         if ($file) {
-            $hash = hash('sha256', file_get_contents($file->getRealPath()));
+            $hash = $metadata->getHash() ? $metadata->getHash() :
+                hash('sha256', file_get_contents($file->getRealPath()));
             $metadata->setHash($hash);
             $metadata->setMime($file->getMimeType());
             $metadata->setSize($file->getSize());

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -508,6 +508,7 @@ class FileControllerTest extends RestTestCase
             }
           ],
           "metadata": {
+            "hash": "demo-test-hash",
             "action":[{"command":"print"},{"command":"archive"}],
             "additionalInformation": "someInfo",
             "additionalProperties": [
@@ -554,6 +555,7 @@ class FileControllerTest extends RestTestCase
         );
         $this->assertCount(2, $returnData['metadata']['additionalProperties']);
         $this->assertEquals($metaData['metadata']['filename'], $returnData['metadata']['filename']);
+        $this->assertEquals($metaData['metadata']['hash'], $returnData['metadata']['hash']);
 
         // clean up
         $client = $this->createClient();


### PR DESCRIPTION
Based on EVO-5984, added the functionality. Posted files will now have custom hash if so is sent.