### PR TITLE
AMQP listener update with SecurityUtility and Test

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -4,7 +4,8 @@ imports:
 
 parameters:
     kernel.debug: false
-    graviton.rabbitmq.listener.eventstatusresponselistener.class: Graviton\RabbitMqBundle\Listener\DummyResponseListener
+    graviton.rabbitmq.producer.job.class: Graviton\RabbitMqBundle\Producer\Dummy
+    #graviton.rabbitmq.listener.eventstatusresponselistener.class: Graviton\RabbitMqBundle\Listener\DummyResponseListener
 
 framework:
     test: ~

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -17,9 +17,7 @@ use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Graviton\SecurityBundle\Service\SecurityUtils;
 use GravitonDyn\EventStatusBundle\Document\EventStatus;
 
 /**
@@ -46,7 +44,7 @@ class EventStatusLinkResponseListener
     private $request;
 
     /**
-     * @var QueueEvent queueevent document
+     * @var QueueEvent queue event document
      */
     private $queueEventDocument;
 
@@ -91,9 +89,9 @@ class EventStatusLinkResponseListener
     private $documentManager;
 
     /**
-     * @var TokenStorage
+     * @var SecurityUtils
      */
-    protected $tokenStorage;
+    protected $securityUtils;
 
     /**
      * @param ProducerInterface     $rabbitMqProducer                  RabbitMQ dependency
@@ -108,7 +106,7 @@ class EventStatusLinkResponseListener
      * @param string                $eventStatusStatusClassname        classname of the EventStatusStatus document
      * @param string                $eventStatusEventResourceClassname classname of the E*S*E*Resource document
      * @param string                $eventStatusRouteName              name of the route to EventStatus
-     * @param TokenStorage          $tokenStorage                      Security service
+     * @param SecurityUtils         $securityUtils                     Security utils service
      */
     public function __construct(
         ProducerInterface $rabbitMqProducer,
@@ -123,7 +121,7 @@ class EventStatusLinkResponseListener
         $eventStatusStatusClassname,
         $eventStatusEventResourceClassname,
         $eventStatusRouteName,
-        TokenStorage $tokenStorage
+        SecurityUtils $securityUtils
     ) {
         $this->rabbitMqProducer = $rabbitMqProducer;
         $this->router = $router;
@@ -137,7 +135,7 @@ class EventStatusLinkResponseListener
         $this->eventStatusStatusClassname = $eventStatusStatusClassname;
         $this->eventStatusEventResourceClassname = $eventStatusEventResourceClassname;
         $this->eventStatusRouteName = $eventStatusRouteName;
-        $this->tokenStorage = $tokenStorage;
+        $this->securityUtils = $securityUtils;
     }
 
     /**
@@ -344,10 +342,8 @@ class EventStatusLinkResponseListener
      */
     private function getSecurityUsername()
     {
-        /** @var PreAuthenticatedToken $token */
-        if (($token = $this->tokenStorage->getToken())
-            && ($user = $token->getUser()) instanceof UserInterface ) {
-            return $user->getUsername();
+        if ($this->securityUtils->isSecurityUser()) {
+            return $this->securityUtils->getSecurityUsername();
         }
 
         return '';

--- a/src/Graviton/RabbitMqBundle/Producer/Dummy.php
+++ b/src/Graviton/RabbitMqBundle/Producer/Dummy.php
@@ -1,19 +1,21 @@
 <?php
 /**
- * dummy publisher
+ * dummy job producer
  */
 
 namespace Graviton\RabbitMqBundle\Producer;
 
-use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
 
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-class Dummy extends Producer
+class Dummy implements ProducerInterface
 {
+    /** @var array list of events */
+    private $eventList = [];
 
     /**
      * Publishes the message and merges additional properties with basic properties
@@ -25,6 +27,81 @@ class Dummy extends Producer
      * @return void
      */
     public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    {
+        $this->eventList[] = $msgBody;
+    }
+
+    /**
+     * Dummy.
+     *
+     * @return DummyChannel
+     */
+    public function getChannel()
+    {
+        return new DummyChannel();
+    }
+
+    /**
+     * Reset event list
+     * @return void
+     */
+    public function resetEventList()
+    {
+        $this->eventList = [];
+    }
+
+    /**
+     * Get current event list
+     *
+     * @return array
+     */
+    public function getEventList()
+    {
+        return $this->eventList;
+    }
+
+    /**
+     * Dummy setter
+     * @param string $d dummy value
+     * @return void
+     */
+    public function setContentType($d)
+    {
+    }
+
+    /**
+     * Dummy setter
+     * @param string $d dummy value
+     * @return void
+     */
+    public function setExchangeOptions($d)
+    {
+    }
+
+    /**
+     * Dummy setter
+     * @param string $d dummy value
+     * @return void
+     */
+    public function setQueueOptions($d)
+    {
+    }
+
+    /**
+     * Dummy setter
+     * @param bool $d dummy value
+     * @return void
+     */
+    public function disableAutoSetupFabric($d = false)
+    {
+    }
+
+    /**
+     * Dummy setter
+     * @param bool $d dummy value
+     * @return void
+     */
+    public function setEventDispatcher($d = false)
     {
     }
 }

--- a/src/Graviton/RabbitMqBundle/Producer/DummyChannel.php
+++ b/src/Graviton/RabbitMqBundle/Producer/DummyChannel.php
@@ -5,9 +5,6 @@
 
 namespace Graviton\RabbitMqBundle\Producer;
 
-use OldSound\RabbitMqBundle\RabbitMq\Producer;
-use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
-
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
@@ -32,14 +29,14 @@ class DummyChannel
 
     /**
      * Dummy function queue_declare
-     * @param string $queue  tmp value
-     * @param bool   $false1 tmp value
-     * @param bool   $true1  tmp value
-     * @param bool   $false2 tmp value
-     * @param bool   $false3 tmp value
+     * @param string $queue tmp value
+     * @param bool   $fooA  tmp value
+     * @param bool   $fooB  tmp value
+     * @param bool   $fooC  tmp value
+     * @param bool   $fooD  tmp value
      * @return void
      */
-    public function queueDeclare($queue, $false1, $true1, $false2, $false3)
+    public function queueDeclare($queue, $fooA, $fooB, $fooC, $fooD)
     {
     }
 }

--- a/src/Graviton/RabbitMqBundle/Producer/DummyChannel.php
+++ b/src/Graviton/RabbitMqBundle/Producer/DummyChannel.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * dummy job producer
+ */
+
+namespace Graviton\RabbitMqBundle\Producer;
+
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class DummyChannel
+{
+    /**
+     * Faking the not conventional call queue_declare
+     *
+     * @param string $method    Simple implementation to match our camelcase validation
+     * @param array  $arguments Data list
+     * @return mixed
+     */
+    public function __call($method, $arguments)
+    {
+        $method = 'queueDeclare';
+        if (isset($this->$method)) {
+            call_user_func_array($this->$method, array_merge([&$this], $arguments));
+        }
+    }
+
+    /**
+     * Dummy function queue_declare
+     * @param string $queue  tmp value
+     * @param bool   $false1 tmp value
+     * @param bool   $true1  tmp value
+     * @param bool   $false2 tmp value
+     * @param bool   $false3 tmp value
+     * @return void
+     */
+    public function queueDeclare($queue, $false1, $true1, $false2, $false3)
+    {
+    }
+}

--- a/src/Graviton/RabbitMqBundle/Producer/JobProducer.php
+++ b/src/Graviton/RabbitMqBundle/Producer/JobProducer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * dummy publisher
+ */
+
+namespace Graviton\RabbitMqBundle\Producer;
+
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class JobProducer extends Producer
+{
+}

--- a/src/Graviton/RabbitMqBundle/Resources/config/services.xml
+++ b/src/Graviton/RabbitMqBundle/Resources/config/services.xml
@@ -12,6 +12,7 @@
         <parameter key="graviton.rabbitmq.document.eventstatuseventresource.class">GravitonDyn\EventStatusBundle\Document\EventStatusEventResourceEmbedded</parameter>
         <parameter key="graviton.rabbitmq.validator.validinformationtype.class">Graviton\RabbitMqBundle\Validator\Constraints\ValidInformationTypeValidator</parameter>
         <parameter key="graviton.rabbitmq.validator.validstatus.class">Graviton\RabbitMqBundle\Validator\Constraints\ValidStatusValidator</parameter>
+        <parameter key="graviton.rabbitmq.producer.job.class">Graviton\RabbitMqBundle\Producer\JobProducer</parameter>
 
         <!-- this is the route the DocumentEventPublisher will use to generate the 'statusUrl' field where the status can be fetched -->
         <parameter key="graviton.rabbitmq.document.eventstatusstatus.route">gravitondyn.eventstatus.rest.eventstatus.get</parameter>
@@ -19,7 +20,9 @@
     <services>
         <service id="graviton.rabbitmq.consumer.dump" class="%graviton.rabbitmq.consumer.dump.class%" />
         <service id="graviton.rabbitmq.document.queueevent" class="%graviton.rabbitmq.document.queueevent.class%" />
-        <service id="graviton.rabbitmq.jobproducer" parent="old_sound_rabbit_mq.document_event_producer">
+        <service id="graviton.rabbitmq.jobproducer"
+                 class="%graviton.rabbitmq.producer.job.class%"
+                 parent="old_sound_rabbit_mq.document_event_producer">
             <call method="setContentType">
                 <argument>application/json</argument>
             </call>
@@ -37,7 +40,7 @@
             <argument>%graviton.rabbitmq.document.eventstatusstatus.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatuseventresource.class%</argument>
             <argument>%graviton.rabbitmq.document.eventstatusstatus.route%</argument>
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="graviton.security.service.utils" />
             <!-- the event 'graviton.rest.response.selfaware' will be dispatched by the SelfLinkResponseListener -->
             <tag name="kernel.event_listener" event="graviton.rest.response.selfaware" method="onKernelResponse"/>
         </service>

--- a/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Listener/EventStatusLinkResponseListenerTest.php
@@ -62,9 +62,9 @@ class EventStatusLinkResponseListenerTest extends \PHPUnit_Framework_TestCase
         );
 
         $securityMock = $this
-            ->getMockBuilder('\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage')
+            ->getMockBuilder('Graviton\SecurityBundle\Service\SecurityUtils')
             ->disableOriginalConstructor()
-            ->setMethods(['getToken'])->getMockForAbstractClass();
+            ->setMethods(['isSecurityUser'])->getMockForAbstractClass();
 
         $requestMock = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor(
         )->setMethods(['get'])->getMock();

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Rs\Json\Patch;
 use Rs\Json\Patch\InvalidPatchDocumentJsonException;
@@ -618,7 +617,7 @@ class RestController
     /**
      * Security needs to be enabled to get Object.
      *
-     * @return SecurityUser
+     * @return String
      * @throws UsernameNotFoundException
      */
     public function getSecurityUser()

--- a/src/Graviton/SecurityBundle/Service/SecurityUtils.php
+++ b/src/Graviton/SecurityBundle/Service/SecurityUtils.php
@@ -58,7 +58,7 @@ class SecurityUtils
     /**
      * Find current user
      *
-     * @return string|bool
+     * @return string
      * @throws UsernameNotFoundException
      */
     public function getSecurityUser()


### PR DESCRIPTION
Added Test for class EventStatusLinkResponseListener, no mock.
Changes storage token to use our SecurityUtils.
Created a AMQP dummy channel class so no events are put on queue but still able to see and match output. 