### PR TITLE
Language Translatable ID to be sha1 encoded to avoid index overflow.

### DIFF
--- a/src/Graviton/I18nBundle/Document/Translatable.php
+++ b/src/Graviton/I18nBundle/Document/Translatable.php
@@ -45,7 +45,7 @@ class Translatable
     protected $isLocalized;
 
     /**
-     * set id
+     * set id, converted to sha1 40 chars if not xdigit
      *
      * @param string $id id
      *
@@ -53,7 +53,7 @@ class Translatable
      */
     public function setId($id)
     {
-        $this->id = $id;
+        $this->id = ctype_xdigit($id) ? $id : sha1($id);
     }
 
     /**

--- a/src/Graviton/I18nBundle/Migrations/MongoDB/Version20161122111410.php
+++ b/src/Graviton/I18nBundle/Migrations/MongoDB/Version20161122111410.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Index migration
+ */
+
+namespace Graviton\I18nBundle\Migrations\MongoDB;
+
+use AntiMattr\MongoDB\Migrations\AbstractMigration;
+use Doctrine\MongoDB\Database;
+use Graviton\I18nBundle\Document\Translatable;
+use MongoDB;
+use MongoCollection;
+
+/**
+ * Migrate domain_1_locale_1_original_1 index
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/MIT MIT License
+ * @link     http://swisscom.ch
+ */
+class Version20161122111410 extends AbstractMigration
+{
+    /**
+     * @var string
+     */
+    private $collection = 'Translatable';
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Build id for the new sha1 implementation';
+    }
+
+    /**
+     * recreate index without unique flag
+     *
+     * @param Database $db database to migrate
+     *
+     * @return void
+     */
+    public function up(Database $db)
+    {
+        $collection = $db->createCollection($this->collection);
+        $qb = $collection->createQueryBuilder();
+        /** @var Translatable $translatable */
+        foreach ($qb->find() as $translatable) {
+            $id = $translatable->getId();
+            if (!ctype_xdigit($id)) {
+                $collection->update(
+                    ['id' => $id],
+                    ['id' => sha1($id)]
+                );
+            }
+        }
+    }
+
+    /**
+     * re-add unique flag to index
+     *
+     * @param Database $db database to migrate
+     *
+     * @return void
+     */
+    public function down(Database $db)
+    {
+    }
+}

--- a/src/Graviton/I18nBundle/Resources/config/doctrine/Translatable.mongodb.xml
+++ b/src/Graviton/I18nBundle/Resources/config/doctrine/Translatable.mongodb.xml
@@ -18,7 +18,6 @@
       <index unique="false">
         <key name="domain"/>
         <key name="locale"/>
-        <key name="original"/>
       </index>
     </indexes>
   </document>

--- a/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/TranslatableControllerTest.php
@@ -43,7 +43,7 @@ class TranslatableControllerTest extends RestTestCase
         $client->request('GET', '/i18n/translatable/');
         $results = $client->getResults();
 
-        $this->assertEquals('http://localhost/i18n/language/de', $results[0]->language->{'$ref'});
+        $this->assertEquals('http://localhost/i18n/language/de', $results[1]->language->{'$ref'});
     }
 
     /**
@@ -55,7 +55,7 @@ class TranslatableControllerTest extends RestTestCase
     {
         $client = static::createRestClient();
 
-        $client->request('GET', '/i18n/translatable/i18n-de-English');
+        $client->request('GET', '/i18n/translatable/'.sha1('i18n-de-English'));
         $results = $client->getResults();
 
         $this->assertEquals('http://localhost/i18n/language/de', $results->language->{'$ref'});


### PR DESCRIPTION
Due to long original translation we need to remove the index original and update how id is generated