### PR TITLE
File create date shall be kept.

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -118,11 +118,6 @@ class FileController extends RestController
      */
     public function putAction($id, Request $request)
     {
-        // If a json request, let parent handle it
-        if ('application/json' == $request->getContentType()) {
-            return parent::putAction($id, $request);
-        }
-
         $request = $this->requestManager->updateFileRequest($request);
 
         $file = new File();

--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -236,11 +236,14 @@ class FileManager
             $metadata->setSize($originalMetadata->getSize());
         }
 
-        if (!$original || !$metadata->getCreatedate()) {
+        // Creation date. keep original if available
+        if ($original && $original->getMetadata() && $original->getMetadata()->getCreatedate()) {
+            $metadata->setCreatedate($original->getMetadata()->getCreatedate());
+        } else {
             $metadata->setCreatedate($now);
         }
-        $metadata->setModificationdate($now);
 
+        $metadata->setModificationdate($now);
         $document->setMetadata($metadata);
 
         return $document;


### PR DESCRIPTION
On put requests, file metadata creationDate could be overwritten. This should not be possible.
We could define service as read-only field but we need to keep back-compatibility until workers and clients are updated.