### PR TITLE
Feature/evo 8323 configurable cache

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -75,3 +75,7 @@ parameters:
 
     # Add full qualified type, application/pdf, image/jpeg...
     graviton.file.allowed.mime_types: []
+
+    # List of collections to be saved in cache, in seconds
+    graviton.cache.collections:
+        EventStatus: 60

--- a/src/Graviton/CoreBundle/Controller/VersionController.php
+++ b/src/Graviton/CoreBundle/Controller/VersionController.php
@@ -28,31 +28,12 @@ class VersionController extends RestController
     private $coreUtils;
 
     /**
-     * @param Response           $response    Response
-     * @param RestUtilsInterface $restUtils   Rest utils
-     * @param Router             $router      Router
-     * @param EngineInterface    $templating  Templating
-     * @param ContainerInterface $container   Container
-     * @param SchemaUtils        $schemaUtils schema utils
-     * @param CoreUtils          $coreUtils   coreUtils
+     * Build core utils
+     * @param CoreUtils $coreUtils coreUtils
+     * @return void
      */
-    public function __construct(
-        Response $response,
-        RestUtilsInterface $restUtils,
-        Router $router,
-        EngineInterface $templating,
-        ContainerInterface $container,
-        SchemaUtils $schemaUtils,
-        CoreUtils $coreUtils
-    ) {
-        parent::__construct(
-            $response,
-            $restUtils,
-            $router,
-            $templating,
-            $container,
-            $schemaUtils
-        );
+    public function setCoreUtils(CoreUtils $coreUtils)
+    {
         $this->coreUtils = $coreUtils;
     }
 

--- a/src/Graviton/CoreBundle/Resources/config/services.xml
+++ b/src/Graviton/CoreBundle/Resources/config/services.xml
@@ -65,7 +65,9 @@
 
         <service id="graviton.core.controller.version"
                  class="Graviton\CoreBundle\Controller\VersionController" parent="graviton.rest.controller">
-            <argument type="service" id="graviton.core.utils"/>
+            <call method="setCoreUtils">
+                <argument type="service" id="graviton.core.utils"/>
+            </call>
             <call method="setModel">
                 <argument type="service" id="graviton.core.model.version"/>
             </call>

--- a/src/Graviton/DocumentBundle/Resources/config/services.xml
+++ b/src/Graviton/DocumentBundle/Resources/config/services.xml
@@ -4,6 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="graviton.document.service.extrefconverter.class">Graviton\DocumentBundle\Service\ExtReferenceConverter</parameter>
+        <parameter key="graviton.document.service.collectioncache.class">Graviton\DocumentBundle\Service\CollectionCache</parameter>
         <parameter key="graviton.document.listener.extreferencesearchlistener.class">Graviton\DocumentBundle\Listener\ExtReferenceSearchListener</parameter>
         <parameter key="graviton.document.listener.fieldnamesearchlistener.class">Graviton\DocumentBundle\Listener\FieldNameSearchListener</parameter>
         <parameter key="graviton.document.serializer.handler.hash.class">Graviton\DocumentBundle\Serializer\Handler\HashHandler</parameter>
@@ -17,6 +18,12 @@
         <service id="graviton.document.service.extrefconverter" class="%graviton.document.service.extrefconverter.class%">
             <argument type="service" id="router"/>
             <argument>%graviton.document.type.extref.mapping%</argument>
+        </service>
+
+        <!-- Collection Cache Service -->
+        <service id="graviton.document.service.collectioncache" class="%graviton.document.service.collectioncache.class%">
+            <argument type="service" id="doctrine_cache.providers.local"/>
+            <argument>%graviton.cache.collections%</argument>
         </service>
 
         <!-- empty extref serializing listener -->

--- a/src/Graviton/DocumentBundle/Service/CollectionCache.php
+++ b/src/Graviton/DocumentBundle/Service/CollectionCache.php
@@ -127,7 +127,7 @@ class CollectionCache
         $key = self::BASE_UPDATE_KEY.'-'.$this->buildCacheKey($collection, $id);
 
         while ($this->cache->fetch($key)) {
-            sleep(0.25);
+            usleep(250000);
         }
     }
 

--- a/src/Graviton/DocumentBundle/Service/CollectionCache.php
+++ b/src/Graviton/DocumentBundle/Service/CollectionCache.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * ExtReferenceConverter class file
+ */
+
+namespace Graviton\DocumentBundle\Service;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\ODM\MongoDB\DocumentRepository as Repository;
+
+/**
+ * graviton.cache.collections
+
+ * Collection Cache Service
+ *
+ *
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class CollectionCache
+{
+    /** Prefix cache key */
+    const BASE_KEY = 'CollectionCache';
+
+    /** @var array  */
+    private $config = [];
+
+    /** @var CacheProvider */
+    private $cache;
+
+    /**
+     * CollectionCache constructor.
+     * @param CacheProvider $cache         Cache provider
+     * @param array         $configuration Collections to be saved
+     */
+    public function __construct(
+        CacheProvider $cache,
+        $configuration
+    ) {
+        $this->cache = $cache;
+        $this->config = $configuration;
+    }
+
+    /**
+     * Makes an id
+     *
+     * @param string $collection DB collection name
+     * @param string $id         Object Identifier
+     * @return string
+     */
+    private function buildCacheKey($collection, $id)
+    {
+        return self::BASE_KEY.'-'.preg_replace("/[^a-zA-Z0-9_-]+/", "-", $collection.'-'.$id);
+    }
+
+    /**
+     * Time it should be in cache and if so should happen
+     *
+     * @param string $collection DB collection name
+     * @return int
+     */
+    private function getCollectionCacheTime($collection)
+    {
+        if (array_key_exists($collection, $this->config)) {
+            return (int) $this->config[$collection];
+        }
+        return 0;
+    }
+
+    /**
+     * Return un cached object.
+     *
+     * @param Repository $repository DB Repository
+     * @param string     $id         Queried is
+     * @return object|false if no cache found
+     */
+    public function getByRepository(Repository $repository, $id)
+    {
+        $collection = $repository->getClassMetadata()->collection;
+        if (!$this->getCollectionCacheTime($collection)) {
+            return false;
+        }
+        $key = $this->buildCacheKey($collection, $id);
+
+        if ($result = $this->cache->fetch($key)) {
+            return unserialize($result);
+        }
+        return false;
+    }
+
+    /**
+     * @param Repository $repository DB Repository
+     * @param object     $document   Object document
+     * @return bool
+     */
+    public function setByRepository(Repository $repository, $document)
+    {
+        if (empty($document)) {
+            return false;
+        }
+        $collection = $repository->getClassMetadata()->collection;
+        if (!$time = $this->getCollectionCacheTime($collection)) {
+            return false;
+        }
+        $key = $this->buildCacheKey($collection, $document->getId());
+
+        return $this->cache->save($key, serialize($document), $time);
+    }
+}

--- a/src/Graviton/DocumentBundle/Service/CollectionCache.php
+++ b/src/Graviton/DocumentBundle/Service/CollectionCache.php
@@ -88,28 +88,26 @@ class CollectionCache
         $key = $this->buildCacheKey($collection, $id);
 
         if ($result = $this->cache->fetch($key)) {
-            return unserialize($result);
+            return $result;
         }
         return false;
     }
 
     /**
      * @param Repository $repository DB Repository
-     * @param object     $document   Object document
+     * @param string     $serialized Serialised Object document
+     * @param string     $id         Object document identifier
      * @return bool
      */
-    public function setByRepository(Repository $repository, $document)
+    public function setByRepository(Repository $repository, $serialized, $id)
     {
-        if (empty($document)) {
-            return false;
-        }
         $collection = $repository->getClassMetadata()->collection;
         if (!$time = $this->getCollectionCacheTime($collection)) {
             return false;
         }
-        $key = $this->buildCacheKey($collection, $document->getId());
+        $key = $this->buildCacheKey($collection, $id);
 
-        return $this->cache->save($key, serialize($document), $time);
+        return $this->cache->save($key, $serialized, $time);
     }
 
     /**
@@ -161,7 +159,11 @@ class CollectionCache
         $collection = $repository->getClassMetadata()->collection;
         $baseKey = $this->buildCacheKey($collection, $id);
         $key = self::BASE_UPDATE_KEY.'-'.$baseKey;
-        if ($this->cache->delete($key)) {
+
+        $this->cache->delete($key);
+
+        $collection = $repository->getClassMetadata()->collection;
+        if ($this->getCollectionCacheTime($collection)) {
             $this->cache->delete($baseKey);
         }
     }

--- a/src/Graviton/DocumentBundle/Service/CollectionCache.php
+++ b/src/Graviton/DocumentBundle/Service/CollectionCache.php
@@ -162,7 +162,6 @@ class CollectionCache
 
         $this->cache->delete($key);
 
-        $collection = $repository->getClassMetadata()->collection;
         if ($this->getCollectionCacheTime($collection)) {
             $this->cache->delete($baseKey);
         }

--- a/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
@@ -83,9 +83,10 @@ class CollectionCacheTest extends RestTestCase
         $document = new EventStatus();
         $document->setId('testing-cache');
         $document->setCreatedate(new \DateTime());
-        $this->cache->setByRepository($repository, $document);
+        $this->cache->setByRepository($repository, serialize($document), 'testing-cache');
 
-        $object = $this->cache->getByRepository($repository, 'testing-cache');
+        $stringCache = $this->cache->getByRepository($repository, 'testing-cache');
+        $object = unserialize($stringCache);
         $this->assertEquals($document->getId(), $object->getId());
         $this->assertEquals($document->getCreatedate(), $object->getCreatedate());
     }
@@ -101,7 +102,7 @@ class CollectionCacheTest extends RestTestCase
         $repository = $this->getContainer()->get('gravitondyn.eventstatus.repository.eventstatusstatus');
         $document = new EventStatusStatus();
         $document->setId('testing-cache-2');
-        $shouldNotBeSet = $this->cache->setByRepository($repository, $document);
+        $shouldNotBeSet = $this->cache->setByRepository($repository, serialize($document), $document->getId());
 
         $this->assertFalse($shouldNotBeSet, '');
     }

--- a/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
@@ -117,11 +117,13 @@ class CollectionCacheTest extends RestTestCase
         $repository = $this->getContainer()->get('gravitondyn.eventstatus.repository.eventstatus');
 
         $id = 'ocack-test';
-        $this->cache->addUpdateLock($repository, $id, 0.4);
+        $this->cache->addUpdateLock($repository, $id, 1);
         $start = microtime(true);
-        $shouldHaveBeenReleased = $start + 500;
+        $shouldHaveBeenReleased = $start + 2;
         $this->cache->updateOperationCheck($repository, $id);
         $end = microtime(true);
-        $this->assertTrue(($start < $end) && ($end < $shouldHaveBeenReleased));
+        $this->assertTrue(($start+0.15) < $end);
+
+        $this->assertTrue($end < $shouldHaveBeenReleased);
     }
 }

--- a/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
@@ -120,7 +120,7 @@ class CollectionCacheTest extends RestTestCase
         $id = 'ocack-test';
         $this->cache->addUpdateLock($repository, $id, 1);
         $start = microtime(true);
-        $shouldHaveBeenReleased = $start + 2;
+        $shouldHaveBeenReleased = $start + 3;
         $this->cache->updateOperationCheck($repository, $id);
         $end = microtime(true);
         $this->assertTrue(($start+0.15) < $end);

--- a/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
@@ -106,6 +106,11 @@ class CollectionCacheTest extends RestTestCase
         $this->assertFalse($shouldNotBeSet, '');
     }
 
+    /**
+     * Update lock tests
+     *
+     * @return void
+     */
     public function testLocks()
     {
         /** @var AppRepository $repository */

--- a/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/CollectionCacheTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * CollectionCache class file
+ */
+
+namespace Graviton\DocumentBundle\Tests\Service;
+
+use Graviton\CoreBundle\Repository\AppRepository;
+use Graviton\DocumentBundle\Service\CollectionCache;
+use Graviton\TestBundle\Test\RestTestCase;
+use GravitonDyn\EventStatusBundle\Document\EventStatus;
+use GravitonDyn\EventStatusBundle\Document\EventStatusStatus;
+
+/**
+ * ExtReferenceConverter test
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/GPL GPL
+ * @link     http://swisscom.ch
+ */
+class CollectionCacheTest extends RestTestCase
+{
+    /** @var  CollectionCache */
+    private $cache;
+
+    /**
+     * setup type we want to test
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->cache = $this->getContainer()->get('graviton.document.service.collectioncache');
+        $config = $this->getContainer()->getParameter('graviton.cache.collections');
+        if (!array_key_exists('EventStatus', $config)) {
+            $config['EventStatus'] = 10;
+            $this->cache->setConfiguration($config);
+        }
+    }
+
+    /**
+     * private build key test Makes an id
+     *
+     * @return void
+     */
+    public function testbuildCacheKey()
+    {
+        $collection = 'App';
+        $id = 'kjeGd-213-csd';
+        $key = CollectionCache::BASE_KEY.'-'.preg_replace("/[^a-zA-Z0-9_-]+/", "-", $collection.'-'.$id);
+
+        $method = $this->getPrivateClassMethod(get_class($this->cache), 'buildCacheKey');
+        $result = $method->invokeArgs($this->cache, [$collection, $id]);
+
+        $this->assertEquals($key, $result);
+    }
+
+    /**
+     * Time it should be in cache and if so should happen
+     *
+     * @return void
+     */
+    public function testgetCollectionCacheTime()
+    {
+        $collection = 'EventStatus';
+
+        $config = $this->getContainer()->getParameter('graviton.cache.collections');
+        $method = $this->getPrivateClassMethod(get_class($this->cache), 'getCollectionCacheTime');
+        $result = $method->invokeArgs($this->cache, [$collection]);
+
+        $this->assertEquals($config['EventStatus'], $result);
+    }
+
+    /**
+     * Cache testing
+     *
+     * @return void
+     */
+    public function testsetAndgetByRepository()
+    {
+        /** @var AppRepository $repository */
+        $repository = $this->getContainer()->get('gravitondyn.eventstatus.repository.eventstatus');
+        $document = new EventStatus();
+        $document->setId('testing-cache');
+        $document->setCreatedate(new \DateTime());
+        $this->cache->setByRepository($repository, $document);
+
+        $object = $this->cache->getByRepository($repository, 'testing-cache');
+        $this->assertEquals($document->getId(), $object->getId());
+        $this->assertEquals($document->getCreatedate(), $object->getCreatedate());
+    }
+
+    /**
+     * Cache testing
+     *
+     * @return void
+     */
+    public function testsetAndgetByRepositoryFalse()
+    {
+        /** @var AppRepository $repository */
+        $repository = $this->getContainer()->get('gravitondyn.eventstatus.repository.eventstatusstatus');
+        $document = new EventStatusStatus();
+        $document->setId('testing-cache-2');
+        $shouldNotBeSet = $this->cache->setByRepository($repository, $document);
+
+        $this->assertFalse($shouldNotBeSet, '');
+    }
+
+    public function testLocks()
+    {
+        /** @var AppRepository $repository */
+        $repository = $this->getContainer()->get('gravitondyn.eventstatus.repository.eventstatus');
+
+        $id = 'ocack-test';
+        $this->cache->addUpdateLock($repository, $id, 0.4);
+        $start = microtime(true);
+        $shouldHaveBeenReleased = $start + 500;
+        $this->cache->updateOperationCheck($repository, $id);
+        $end = microtime(true);
+        $this->assertTrue(($start < $end) && ($end < $shouldHaveBeenReleased));
+    }
+}

--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -23,6 +23,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Filesystem\Filesystem as SfFileSystem;
 use GravitonDyn\FileBundle\Model\File as DocumentModel;
+use Graviton\ExceptionBundle\Exception\NotFoundException;
 
 /**
  * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
@@ -153,7 +154,12 @@ class FileManager
             $document->setId($requestId);
         }
 
-        $original = $model->find($requestId);
+        try {
+            $original = $model->find($requestId);
+        } catch (NotFoundException $e) {
+            $original = false;
+        }
+
         $isNew = $requestId ? !$original : true;
 
         // If posted  file document not equal the one to be created or updated, then error

--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -175,20 +175,10 @@ class RestController
      * @param mixed   $id      Record id
      * @param Request $request request
      *
-     * @throws \Graviton\ExceptionBundle\Exception\NotFoundException
-     *
      * @return object $record Document object
      */
     protected function findRecord($id, Request $request = null)
     {
-        $response = $this->getResponse();
-
-        if (!($this->getModel()->recordExists($id))) {
-            $e = new NotFoundException("Entry with id " . $id . " not found!");
-            $e->setResponse($response);
-            throw $e;
-        }
-
         return $this->getModel()->find($id, $request);
     }
 

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -80,6 +80,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="graviton.schema.utils"/>
+            <argument type="service" id="graviton.document.service.collectioncache" />
             <call method="setJsonPatchValidator">
                 <argument type="service" id="graviton.rest.service.jsonpatchvalidator"/>
             </call>

--- a/src/Graviton/RestBundle/Resources/config/services.xml
+++ b/src/Graviton/RestBundle/Resources/config/services.xml
@@ -92,6 +92,7 @@
         <service id="graviton.rest.model" abstract="true" class="%graviton.rest.model.documentmodel.class%" parent="graviton.schema.model.schemamodel">
             <argument type="service" id="graviton.rql.visitor.mongodb" />
             <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="graviton.document.service.collectioncache" />
             <argument>%graviton.rest.not_modifiable.origin.records%</argument>
             <argument>%graviton.rest.pagination.limit%</argument>
         </service>


### PR DESCRIPTION
Configurable cache handling for Documents.
Due to update document is deleted before inserted as updated document we need a temporary cache. Also, added the option so other collections can be saved for Get requests.

There is 2 implementations in this PR.

A) On update using RestController, any call to GET by ID will be paused if there is an update in progress on that element.  Implementing full cache was not an option here, yet.

B) Configurable cached Document. Only available for GET by ID, no option to use select rql, it's being used for EventStatus mainly as this service is pulled by many workers at the same time.