### PR TITLE
Feature/evo 6305 subnetuser serialiser

### DIFF
--- a/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
+++ b/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
@@ -21,6 +21,9 @@ class SameSubnetStrategy extends AbstractHttpStrategy
     /** @var String */
     protected $subnet;
 
+    /** @var bool pass through by default */
+    protected $stopPropagation = false;
+
     /**
      * @param String $subnet      Subnet to be checked (e.g. 10.2.0.0/24)
      * @param String $headerField Http header field to be searched for the 'username'
@@ -40,9 +43,10 @@ class SameSubnetStrategy extends AbstractHttpStrategy
      */
     public function apply(Request $request)
     {
-        if (IpUtils::checkIp($request->getClientIp(), $this->subnet)) {
+       // if (IpUtils::checkIp($request->getClientIp(), $this->subnet)) {
+            $this->stopPropagation = true;
             return $this->determineName($request);
-        }
+       // }
 
         throw new \InvalidArgumentException('Provided request information are not valid.');
     }
@@ -54,7 +58,7 @@ class SameSubnetStrategy extends AbstractHttpStrategy
      */
     public function stopPropagation()
     {
-        return false;
+        return $this->stopPropagation;
     }
 
     /**

--- a/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
+++ b/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
@@ -21,6 +21,9 @@ class SameSubnetStrategy extends AbstractHttpStrategy
     /** @var String */
     protected $subnet;
 
+    /** @var String */
+    protected $headerField;
+
     /** @var bool pass through by default */
     protected $stopPropagation = false;
 
@@ -43,10 +46,9 @@ class SameSubnetStrategy extends AbstractHttpStrategy
      */
     public function apply(Request $request)
     {
-       // if (IpUtils::checkIp($request->getClientIp(), $this->subnet)) {
-            $this->stopPropagation = true;
+        if (IpUtils::checkIp($request->getClientIp(), $this->subnet)) {
             return $this->determineName($request);
-       // }
+        }
 
         throw new \InvalidArgumentException('Provided request information are not valid.');
     }
@@ -81,6 +83,7 @@ class SameSubnetStrategy extends AbstractHttpStrategy
     private function determineName(Request $request)
     {
         if ($request->headers->has($this->headerField)) {
+            $this->stopPropagation = true;
             return $request->headers->get($this->headerField);
         }
 

--- a/src/Graviton/SecurityBundle/Resources/config/serializer/Entities.SubnetUser.xml
+++ b/src/Graviton/SecurityBundle/Resources/config/serializer/Entities.SubnetUser.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+  <class name="Graviton\SecurityBundle\Entities\SubnetUser" exclusion-policy="ALL">
+    <property name="id" type="int" accessor-getter="getId" expose="false"/>
+    <property name="username" type="string" accessor-getter="getUsername" accessor-setter="setUsername" exclude="false" expose="true"/>
+  </class>
+</serializer>


### PR DESCRIPTION
Added missing stop when username is sent via header and from same subnet. 
The implementation done for Multi strategy only contemplates the use of header-subnet and cookie authentication. There is no option to use header, subnet and cookie together with current implementation. 