### PR TITLE
File upload with POST multipart/mixed is not accepted straight by sf2

### DIFF
--- a/src/Graviton/FileBundle/Controller/FileController.php
+++ b/src/Graviton/FileBundle/Controller/FileController.php
@@ -66,11 +66,11 @@ class FileController extends RestController
     public function postAction(Request $request)
     {
         $file = new File();
+        $request = $this->requestManager->updateFileRequest($request);
+
         if ($formData = $request->get('metadata')) {
             $file = $this->restUtils->validateRequest($formData, $this->getModel());
         }
-
-        $request = $this->requestManager->updateFileRequest($request);
 
         /** @var FileModel $model */
         $model = $this->getModel();


### PR DESCRIPTION
request->get(metadata) was empty on multipart/mixed requests, moved the handler to be executed before to set the request 