### PR TITLE
Revert serialiser to v1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sensio/generator-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.1",
         "jms/serializer-bundle": ">=1.1,<2",
-        "jms/serializer": "~1.4",
+        "jms/serializer": "1.1.0",
         "jms/di-extra-bundle": "~1.7",
         "doctrine/mongodb-odm": "~1.0",
         "doctrine/mongodb-odm-bundle": "~3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e2aeae871bd9f43ef29ee24c1dc692f7",
-    "content-hash": "ca8818d7d5089d65dcd90aff6f541249",
+    "hash": "b99b0fb4a48890a15046d31f78cf1ff2",
+    "content-hash": "19e33eab6a90fccd253be8ae1986b311",
     "packages": [
         {
             "name": "antimattr/mongodb-migrations",
@@ -2394,42 +2394,40 @@
         },
         {
             "name": "jms/serializer",
-            "version": "1.4.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "f39d8b4660d5cef43b0c3265ce642173d9b2c58b"
+                "reference": "fe13a1f993ea3456e195b7820692f2eb2b6bbb48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/f39d8b4660d5cef43b0c3265ce642173d9b2c58b",
-                "reference": "f39d8b4660d5cef43b0c3265ce642173d9b2c58b",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/fe13a1f993ea3456e195b7820692f2eb2b6bbb48",
+                "reference": "fe13a1f993ea3456e195b7820692f2eb2b6bbb48",
                 "shasum": ""
             },
             "require": {
-                "doctrine/annotations": "^1.0",
-                "doctrine/instantiator": "^1.0.3",
+                "doctrine/annotations": "1.*",
+                "doctrine/instantiator": "~1.0.3",
                 "jms/metadata": "~1.1",
                 "jms/parser-lib": "1.*",
-                "php": ">=5.5.0",
-                "phpcollection/phpcollection": "~0.1",
-                "phpoption/phpoption": "^1.1"
+                "php": ">=5.4.0",
+                "phpcollection/phpcollection": "~0.1"
             },
             "conflict": {
                 "twig/twig": "<1.12"
             },
             "require-dev": {
                 "doctrine/orm": "~2.1",
-                "doctrine/phpcr-odm": "^1.3|^2.0",
-                "ext-pdo_sqlite": "*",
-                "jackalope/jackalope-doctrine-dbal": "^1.1.5",
-                "phpunit/phpunit": "^4.8|^5.0",
+                "doctrine/phpcr-odm": "~1.0.1",
+                "jackalope/jackalope-doctrine-dbal": "1.0.*",
+                "phpunit/phpunit": "~4.0",
                 "propel/propel1": "~1.7",
-                "symfony/filesystem": "^2.1",
+                "symfony/filesystem": "2.*",
                 "symfony/form": "~2.1",
-                "symfony/translation": "^2.1",
-                "symfony/validator": "^2.2",
-                "symfony/yaml": "^2.1",
+                "symfony/translation": "~2.0",
+                "symfony/validator": "~2.0",
+                "symfony/yaml": "2.*",
                 "twig/twig": "~1.12|~2.0"
             },
             "suggest": {
@@ -2438,7 +2436,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -2465,7 +2463,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2016-11-13 10:20:11"
+            "time": "2015-10-27 09:24:41"
         },
         {
             "name": "jms/serializer-bundle",

--- a/src/Graviton/I18nBundle/Listener/I18nSerializationListener.php
+++ b/src/Graviton/I18nBundle/Listener/I18nSerializationListener.php
@@ -157,9 +157,11 @@ class I18nSerializationListener
                 $translated = $this->utils->getTranslatedField($value);
             }
 
-            if (!$visitor->hasData($field)) {
-                $visitor->setData($field, $translated);
-            }
+            try {
+                $visitor->addData($field, $translated);
+            } catch (\Exception $e) {
+                // JMS serializer do in newer version have a simple "hasData" check.
+            };
         }
     }
 }


### PR DESCRIPTION
Changes of Serialiser gave issues in checklist serialisation: EVO-9238
"modules": {
  "common": { ... },
  "financing": { ... },
  ...
}
was rendered as
"modules": [
  { ... },
  { ... },
  ...
]