### PR TITLE
Auth headers should not have empty username.

### DIFF
--- a/src/Graviton/SecurityBundle/Authentication/SecurityAuthenticator.php
+++ b/src/Graviton/SecurityBundle/Authentication/SecurityAuthenticator.php
@@ -138,11 +138,13 @@ final class SecurityAuthenticator implements
             throw new AuthenticationException('Authentication key is required.');
         }
 
-        if (in_array(SecurityUser::ROLE_SUBNET, $roles)) {
-            $this->logger->info('Authentication, loaded subnet user IP address: '. $token->getAttribute('ipAddress'));
-            $user = new SubnetUser($username);
-        } elseif ($username && $user = $this->userProvider->loadUserByUsername($username)) {
-            $roles[] = SecurityUser::ROLE_CONSULTANT;
+        if ($username) {
+            if (in_array(SecurityUser::ROLE_SUBNET, $roles)) {
+                $this->logger->info('Authentication, subnet user IP address: ' . $token->getAttribute('ipAddress'));
+                $user = new SubnetUser($username);
+            } elseif ($user = $this->userProvider->loadUserByUsername($username)) {
+                $roles[] = SecurityUser::ROLE_CONSULTANT;
+            }
         }
 
         // If no user, try to fetch the test user, else check if anonymous is enabled

--- a/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
+++ b/src/Graviton/SecurityBundle/Authentication/Strategies/SameSubnetStrategy.php
@@ -83,8 +83,11 @@ class SameSubnetStrategy extends AbstractHttpStrategy
     private function determineName(Request $request)
     {
         if ($request->headers->has($this->headerField)) {
-            $this->stopPropagation = true;
-            return $request->headers->get($this->headerField);
+            $name = $request->headers->get($this->headerField);
+            if (!empty($name)) {
+                $this->stopPropagation = true;
+            }
+            return $name;
         }
 
         return 'graviton_subnet_user';


### PR DESCRIPTION
Our firewall is sending x-auth but is not matching our field and still it stop checking for the cookie information. Here we continue to check cookie field data.