### PR TITLE
Hotfix/evo 9870 put request control fix

### DIFF
--- a/src/Graviton/RestBundle/Controller/RestController.php
+++ b/src/Graviton/RestBundle/Controller/RestController.php
@@ -270,8 +270,8 @@ class RestController
         $this->collectionCache->updateOperationCheck($repository, $id);
         $this->collectionCache->addUpdateLock($repository, $id);
 
+        // Validate received data. On failure release the lock.
         try {
-            // Any of the following can throw a not valid json or data. So we release the lock.
             $this->restUtils->checkJsonRequest($request, $response, $this->getModel());
             $record = $this->restUtils->validateRequest($request->getContent(), $model);
         } catch (\Exception $e) {


### PR DESCRIPTION
On put requests the update lock was not removed on failure and made the second request wait. 
Fixed and updated use of variable.