### PR TITLE
update to symfony 3.2

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -6,6 +6,7 @@ parameters:
     graviton.log.path: "%kernel.logs_dir%/%kernel.environment%.log"
 
     # if set to a path, documentbundle will search this also for generated bundles
+    # important: this should best be a path relative to the graviton root dir! (./app/../)
     graviton.generator.dynamicbundle.dir: null
 
     # Dependency injection in Security Bundle

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -5,6 +5,9 @@ parameters:
 
     graviton.log.path: "%kernel.logs_dir%/%kernel.environment%.log"
 
+    # if set to a path, documentbundle will search this also for generated bundles
+    graviton.generator.dynamicbundle.dir: null
+
     # Dependency injection in Security Bundle
     graviton.security.authentication.header_required: false
     graviton.security.authentication.test_username: false

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6",
         "ext-fileinfo": "*",
-        "symfony/symfony": "^2.8.0",
+        "symfony/symfony": "^3.2.0",
         "doctrine/orm": "~2.5",
         "twig/extensions": "^1.4.0",
         "symfony/monolog-bundle": "~3.0",
@@ -35,7 +35,7 @@
         "graviton/rql-parser-bundle": "^0.12.0",
         "graviton/json-schema": "^1.7.0",
         "php-jsonpatch/php-jsonpatch": "~3.0",
-        "antimattr/mongodb-migrations": "^1.0.0",
+        "doesntmattr/mongodb-migrations": "^1.1.3",
         "jenssegers/proxy": ">=3.0.0-beta2",
         "thefrozenfire/swagger": "=2.0.7",
         "symfony/psr-http-message-bridge": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
                     "graviton.mongodb.default.server.db": "MONGODB_DB",
                     "graviton.mongodb.default.server.uri": "MONGODB_URI",
                     "graviton.rest.pagination.limit": "PAGINATION_LIMIT",
+                    "graviton.generator.dynamicbundle.dir": "DYNAMICBUNDLE_DIR",
                     "graviton.composer.cmd": "COMPOSER_CMD",
                     "graviton.rabbitmq.host": "RABBITMQ_HOST",
                     "graviton.rabbitmq.port": "RABBITMQ_PORT",

--- a/composer.lock
+++ b/composer.lock
@@ -2121,17 +2121,17 @@
         },
         {
             "name": "jms/serializer-bundle",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "target-dir": "JMS/SerializerBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/JMSSerializerBundle.git",
-                "reference": "95c0258b74a71ed40981998a8aa8b3bc13f9760d"
+                "reference": "4c6af116ff93d071c6086963798ca1ff8c1384df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSSerializerBundle/zipball/95c0258b74a71ed40981998a8aa8b3bc13f9760d",
-                "reference": "95c0258b74a71ed40981998a8aa8b3bc13f9760d",
+                "url": "https://api.github.com/repos/schmittjoh/JMSSerializerBundle/zipball/4c6af116ff93d071c6086963798ca1ff8c1384df",
+                "reference": "4c6af116ff93d071c6086963798ca1ff8c1384df",
                 "shasum": ""
             },
             "require": {
@@ -2189,7 +2189,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-02-22T16:15:59+00:00"
+            "time": "2017-03-13T17:02:39+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2503,16 +2503,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.9",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "6968531206671f94377b01dc7888d5d1b858a01b"
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/6968531206671f94377b01dc7888d5d1b858a01b",
-                "reference": "6968531206671f94377b01dc7888d5d1b858a01b",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
                 "shasum": ""
             },
             "require": {
@@ -2547,7 +2547,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-03T20:43:42+00:00"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "php-amqplib/php-amqplib",
@@ -3245,16 +3245,16 @@
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb"
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/37f9f4e165b033fb76cc2320838321cc57140e65",
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65",
                 "shasum": ""
             },
             "require": {
@@ -3266,7 +3266,9 @@
             },
             "require-dev": {
                 "doctrine/orm": "~2.4",
-                "symfony/doctrine-bridge": "~2.7|~3.0"
+                "symfony/doctrine-bridge": "~2.7|~3.0",
+                "symfony/filesystem": "~2.7|~3.0",
+                "symfony/phpunit-bridge": "^3.3"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -3293,7 +3295,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2017-03-03T15:22:50+00:00"
+            "time": "2017-03-15T01:02:10+00:00"
         },
         {
             "name": "sensiolabs/security-checker",

--- a/composer.lock
+++ b/composer.lock
@@ -2259,16 +2259,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.35",
+            "version": "1.0.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "dda7f3ab94158a002d9846a97dc18ebfb7acc062"
+                "reference": "d9c1698582dfbfbd092ec9c5c3325f862cdb3297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/dda7f3ab94158a002d9846a97dc18ebfb7acc062",
-                "reference": "dda7f3ab94158a002d9846a97dc18ebfb7acc062",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/d9c1698582dfbfbd092ec9c5c3325f862cdb3297",
+                "reference": "d9c1698582dfbfbd092ec9c5c3325f862cdb3297",
                 "shasum": ""
             },
             "require": {
@@ -2338,7 +2338,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-02-09T11:33:58+00:00"
+            "time": "2017-03-18T16:02:30+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4990,16 +4990,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.15",
+            "version": "5.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b99112aecc01f62acf3d81a3f59646700a1849e5"
+                "reference": "68752b665d3875f9a38a357e3ecb35c79f8673bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b99112aecc01f62acf3d81a3f59646700a1849e5",
-                "reference": "b99112aecc01f62acf3d81a3f59646700a1849e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68752b665d3875f9a38a357e3ecb35c79f8673bf",
+                "reference": "68752b665d3875f9a38a357e3ecb35c79f8673bf",
                 "shasum": ""
             },
             "require": {
@@ -5068,7 +5068,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-02T15:22:43+00:00"
+            "time": "2017-03-19T16:52:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c223216ee0e5b38b33d7936228c6f644",
+    "content-hash": "c6253c33048104f74202ac8b26bae836",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2342,16 +2342,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.22.0",
+            "version": "1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
+                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558",
-                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
                 "shasum": ""
             },
             "require": {
@@ -2416,7 +2416,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-11-26T00:15:39+00:00"
+            "time": "2017-03-13T07:08:03+00:00"
         },
         {
             "name": "oneup/flysystem-bundle",
@@ -3297,16 +3297,16 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v4.0.1",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "f2ce0035fc512287978510ca1740cd111d60f89f"
+                "reference": "56bded66985e22f6eac2cf86735fd21c625bff2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/f2ce0035fc512287978510ca1740cd111d60f89f",
-                "reference": "f2ce0035fc512287978510ca1740cd111d60f89f",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/56bded66985e22f6eac2cf86735fd21c625bff2f",
+                "reference": "56bded66985e22f6eac2cf86735fd21c625bff2f",
                 "shasum": ""
             },
             "require": {
@@ -3337,7 +3337,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2017-02-18T17:53:25+00:00"
+            "time": "2017-03-09T17:33:20+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",
@@ -3801,16 +3801,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47"
+                "reference": "b0f8a7fa4b8baadf9db299cb6ac87c96a8977dbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/141569be5b33a7cf0d141fb88422649fe11b0c47",
-                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/b0f8a7fa4b8baadf9db299cb6ac87c96a8977dbe",
+                "reference": "b0f8a7fa4b8baadf9db299cb6ac87c96a8977dbe",
                 "shasum": ""
             },
             "require": {
@@ -3827,7 +3827,8 @@
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0",
-                "phpdocumentor/type-resolver": "<0.2.0"
+                "phpdocumentor/type-resolver": "<0.2.0",
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "provide": {
                 "psr/cache-implementation": "1.0"
@@ -3940,7 +3941,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-02-17T00:00:43+00:00"
+            "time": "2017-03-10T18:35:48+00:00"
         },
         {
             "name": "thefrozenfire/swagger",
@@ -5719,20 +5720,23 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "996374975357b569ea319ec1c98c5ca0f7dda610"
+                "reference": "9103d17dd57c512a3a027bb5628f6701464d6fef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/996374975357b569ea319ec1c98c5ca0f7dda610",
-                "reference": "996374975357b569ea319ec1c98c5ca0f7dda610",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/9103d17dd57c512a3a027bb5628f6701464d6fef",
+                "reference": "9103d17dd57c512a3a027bb5628f6701464d6fef",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": ">=6.0"
             },
             "suggest": {
                 "ext-zip": "Zip support is required when using bin/simple-phpunit",
@@ -5774,7 +5778,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2017-03-09T12:58:16+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,74 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfe2c231014d397600a7f78d0a35dc3c",
+    "content-hash": "c223216ee0e5b38b33d7936228c6f644",
     "packages": [
-        {
-            "name": "antimattr/mongodb-migrations",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/antimattr/mongodb-migrations.git",
-                "reference": "d553f96ec588ed929ffc75c88f039b26da0d705a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/antimattr/mongodb-migrations/zipball/d553f96ec588ed929ffc75c88f039b26da0d705a",
-                "reference": "d553f96ec588ed929ffc75c88f039b26da0d705a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/mongodb": "1.*",
-                "php": ">=5.3.2",
-                "symfony/console": "~2",
-                "symfony/yaml": "~2"
-            },
-            "require-dev": {
-                "antimattr/test-case": "~1.0@stable",
-                "friendsofphp/php-cs-fixer": "~1",
-                "mikey179/vfsstream": "1.*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "AntiMattr\\MongoDB\\Migrations\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matthew Fitzgerald",
-                    "email": "matthewfitz@gmail.com"
-                },
-                {
-                    "name": "Ryan Catlin",
-                    "email": "ryan.catlin@gmail.com"
-                },
-                {
-                    "name": "Jonathon Suggs",
-                    "email": "jsuggs@gmail.com"
-                }
-            ],
-            "description": "Managed Database Migrations for MongoDB",
-            "homepage": "http://github.com/antimattr/mongodb-migrations",
-            "keywords": [
-                "antimattr",
-                "database",
-                "doctrine",
-                "migration",
-                "mongodb"
-            ],
-            "time": "2016-09-16T17:14:51+00:00"
-        },
         {
             "name": "behat/transliterator",
             "version": "v1.1.0",
@@ -1232,6 +1166,71 @@
             "time": "2016-12-18T15:42:34+00:00"
         },
         {
+            "name": "doesntmattr/mongodb-migrations",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doesntmattr/mongodb-migrations.git",
+                "reference": "4b0a7ff353c3f711be1680e99c88fc40cbe8cd83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doesntmattr/mongodb-migrations/zipball/4b0a7ff353c3f711be1680e99c88fc40cbe8cd83",
+                "reference": "4b0a7ff353c3f711be1680e99c88fc40cbe8cd83",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/mongodb": "1.*",
+                "php": ">=5.3.2",
+                "symfony/console": "^2.5|^3.0",
+                "symfony/yaml": "^2.5|^3.0"
+            },
+            "conflict": {
+                "antimattr/mongodb-migrations": "*"
+            },
+            "require-dev": {
+                "antimattr/test-case": "~1.0@stable",
+                "friendsofphp/php-cs-fixer": "^1.0",
+                "mikey179/vfsstream": "1.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "AntiMattr\\MongoDB\\Migrations\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Fitzgerald",
+                    "email": "matthewfitz@gmail.com"
+                },
+                {
+                    "name": "Ryan Catlin",
+                    "email": "ryan.catlin@gmail.com"
+                }
+            ],
+            "description": "Managed Database Migrations for MongoDB",
+            "homepage": "http://github.com/doesntmattr/mongodb-migrations",
+            "keywords": [
+                "antimattr",
+                "database",
+                "doctrine",
+                "migration",
+                "mongodb"
+            ],
+            "time": "2017-01-16T09:38:17+00:00"
+        },
+        {
             "name": "gedmo/doctrine-extensions",
             "version": "v2.4.26",
             "source": {
@@ -1687,48 +1686,6 @@
                 "parameters management"
             ],
             "time": "2015-11-10T17:04:01+00:00"
-        },
-        {
-            "name": "ircmaxell/password-compat",
-            "version": "v1.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ircmaxell/password_compat.git",
-                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
-                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/password.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Anthony Ferrara",
-                    "email": "ircmaxell@php.net",
-                    "homepage": "http://blog.ircmaxell.com"
-                }
-            ],
-            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
-            "homepage": "https://github.com/ircmaxell/password_compat",
-            "keywords": [
-                "hashing",
-                "password"
-            ],
-            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -2932,6 +2889,52 @@
             "time": "2015-07-25T16:39:46+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -3458,59 +3461,6 @@
             "time": "2017-01-10T20:01:51+00:00"
         },
         {
-            "name": "symfony/polyfill-apcu",
-            "version": "v1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "5d4474f447403c3348e37b70acc2b95475b7befa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/5d4474f447403c3348e37b70acc2b95475b7befa",
-                "reference": "5d4474f447403c3348e37b70acc2b95475b7befa",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "apcu",
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-11-14T01:06:16+00:00"
-        },
-        {
             "name": "symfony/polyfill-intl-icu",
             "version": "v1.3.0",
             "source": {
@@ -3621,120 +3571,6 @@
             "keywords": [
                 "compatibility",
                 "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-11-14T01:06:16+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php54",
-            "version": "v1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php54.git",
-                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
-                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php54\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 5.4+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-11-14T01:06:16+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php55",
-            "version": "v1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php55.git",
-                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/03e3f0350bca2220e3623a0e340eef194405fc67",
-                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67",
-                "shasum": ""
-            },
-            "require": {
-                "ircmaxell/password-compat": "~1.0",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php55\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 5.5+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
                 "polyfill",
                 "portable",
                 "shim"
@@ -3964,102 +3800,42 @@
             "time": "2016-08-18T14:44:25+00:00"
         },
         {
-            "name": "symfony/security-acl",
-            "version": "v3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/security-acl.git",
-                "reference": "053b49bf4aa333a392c83296855989bcf88ddad1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-acl/zipball/053b49bf4aa333a392c83296855989bcf88ddad1",
-                "reference": "053b49bf4aa333a392c83296855989bcf88ddad1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "symfony/security-core": "~2.8|~3.0"
-            },
-            "require-dev": {
-                "doctrine/common": "~2.2",
-                "doctrine/dbal": "~2.2",
-                "psr/log": "~1.0",
-                "symfony/phpunit-bridge": "~2.8|~3.0"
-            },
-            "suggest": {
-                "doctrine/dbal": "For using the built-in ACL implementation",
-                "symfony/class-loader": "For using the ACL generateSql script",
-                "symfony/finder": "For using the ACL generateSql script"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Security\\Acl\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Security Component - ACL (Access Control List)",
-            "homepage": "https://symfony.com",
-            "time": "2015-12-28T09:39:46+00:00"
-        },
-        {
             "name": "symfony/symfony",
-            "version": "v2.8.18",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "8c28bf706b3bf4250d18535ee46a8a5d7a5825e1"
+                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/8c28bf706b3bf4250d18535ee46a8a5d7a5825e1",
-                "reference": "8c28bf706b3bf4250d18535ee46a8a5d7a5825e1",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/141569be5b33a7cf0d141fb88422649fe11b0c47",
+                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.4",
-                "php": ">=5.3.9",
+                "php": ">=5.5.9",
+                "psr/cache": "~1.0",
                 "psr/log": "~1.0",
-                "symfony/polyfill-apcu": "~1.1",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php54": "~1.0",
-                "symfony/polyfill-php55": "~1.0",
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
                 "symfony/polyfill-util": "~1.0",
-                "symfony/security-acl": "~2.7|~3.0.0",
                 "twig/twig": "~1.28|~2.0"
             },
             "conflict": {
-                "phpdocumentor/reflection": "<1.0.7",
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpdocumentor/reflection-docblock": "<3.0",
+                "phpdocumentor/type-resolver": "<0.2.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0"
             },
             "replace": {
                 "symfony/asset": "self.version",
                 "symfony/browser-kit": "self.version",
+                "symfony/cache": "self.version",
                 "symfony/class-loader": "self.version",
                 "symfony/config": "self.version",
                 "symfony/console": "self.version",
@@ -4077,9 +3853,9 @@
                 "symfony/framework-bundle": "self.version",
                 "symfony/http-foundation": "self.version",
                 "symfony/http-kernel": "self.version",
+                "symfony/inflector": "self.version",
                 "symfony/intl": "self.version",
                 "symfony/ldap": "self.version",
-                "symfony/locale": "self.version",
                 "symfony/monolog-bridge": "self.version",
                 "symfony/options-resolver": "self.version",
                 "symfony/process": "self.version",
@@ -4095,7 +3871,6 @@
                 "symfony/security-http": "self.version",
                 "symfony/serializer": "self.version",
                 "symfony/stopwatch": "self.version",
-                "symfony/swiftmailer-bridge": "self.version",
                 "symfony/templating": "self.version",
                 "symfony/translation": "self.version",
                 "symfony/twig-bridge": "self.version",
@@ -4103,24 +3878,30 @@
                 "symfony/validator": "self.version",
                 "symfony/var-dumper": "self.version",
                 "symfony/web-profiler-bundle": "self.version",
+                "symfony/workflow": "self.version",
                 "symfony/yaml": "self.version"
             },
             "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
-                "doctrine/doctrine-bundle": "~1.2",
+                "doctrine/doctrine-bundle": "~1.4",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2,>=1.2.1",
+                "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-                "phpdocumentor/reflection": "^1.0.7",
+                "phpdocumentor/reflection-docblock": "^3.0",
+                "predis/predis": "~1.0",
                 "sensio/framework-extra-bundle": "^3.0.2",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "~3.2",
+                "symfony/polyfill-apcu": "~1.1",
+                "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -4159,7 +3940,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-03-06T03:54:50+00:00"
+            "time": "2017-02-17T00:00:43+00:00"
         },
         {
             "name": "thefrozenfire/swagger",

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFieldNamesCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentFieldNamesCompilerPass.php
@@ -23,16 +23,6 @@ class DocumentFieldNamesCompilerPass implements CompilerPassInterface
     private $documentMap;
 
     /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
-
-    /**
      * load services
      *
      * @param ContainerBuilder $container container builder
@@ -41,6 +31,8 @@ class DocumentFieldNamesCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
         foreach ($this->documentMap->getDocuments() as $document) {
             $map[$document->getClass()] = $this->getFieldNames($document);

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * build a collection_name to routerId mapping for ExtReference Types
+ *
+ * This is all done the cheap way by just inferring collection names from
+ * the available serviecs that are tagged as rest service. This also means
+ * we need to stick to the naming conventions already there even more.
+ */
+
+namespace Graviton\DocumentBundle\DependencyInjection\Compiler;
+
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\DocumentMap;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class DocumentMapCompilerPass implements CompilerPassInterface
+{
+    /**
+     * create mapping from services
+     *
+     * @param ContainerBuilder $container container builder
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // If it's inside vendor library or running as graviton base.
+        $rootDir = $container->getParameter('kernel.root_dir');
+
+        if (strpos($rootDir, 'vendor/graviton')) {
+            $dirs = [
+                $rootDir.'/../..'
+            ];
+        } else {
+            $dirs = [
+                __DIR__ . '/../../../..',
+                $rootDir.'/../vendor/graviton'
+            ];
+        }
+
+        $dynamicBundleDir = $container->getParameter('graviton.generator.dynamicbundle.dir');
+        if (!empty($dynamicBundleDir)) {
+            $dirs[] = $dynamicBundleDir;
+        }
+
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in($dirs)
+                ->path('Resources/config/doctrine')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in($dirs)
+                ->path('Resources/config/serializer')
+                ->name('*.xml'),
+            (new Finder())
+                ->in($dirs)
+                ->path('Resources/config')
+                ->name('validation.xml'),
+            (new Finder())
+                ->in($dirs)
+                ->path('Resources/config/schema')
+                ->name('*.json')
+        );
+
+        $container->set('graviton.document.map', $documentMap);
+    }
+}

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
@@ -51,6 +51,9 @@ class DocumentMapCompilerPass implements CompilerPassInterface
             }
 
             $dirs[] = $dynamicBundleDir;
+        } else {
+            // default dynamic bundle dir is withing our ./src
+            $dynamicBundleDir = __DIR__.'/../../../../GravitonDyn';
         }
 
         $documentMap = new DocumentMap(
@@ -73,5 +76,6 @@ class DocumentMapCompilerPass implements CompilerPassInterface
         );
 
         $container->set('graviton.document.map', $documentMap);
+        $container->setParameter('graviton.generator.dynamicbundle.dir', $dynamicBundleDir);
     }
 }

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
@@ -54,6 +54,9 @@ class DocumentMapCompilerPass implements CompilerPassInterface
         } else {
             // default dynamic bundle dir is withing our ./src
             $dynamicBundleDir = __DIR__.'/../../../../GravitonDyn';
+            if (!is_dir($dynamicBundleDir)) {
+                $dynamicBundleDir = null;
+            }
         }
 
         $documentMap = new DocumentMap(

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/DocumentMapCompilerPass.php
@@ -45,6 +45,11 @@ class DocumentMapCompilerPass implements CompilerPassInterface
 
         $dynamicBundleDir = $container->getParameter('graviton.generator.dynamicbundle.dir');
         if (!empty($dynamicBundleDir)) {
+            // if this is not an absolute dir, make it relative to the base dir
+            if (substr($dynamicBundleDir, 0, 1) !== '/') {
+                $dynamicBundleDir = $container->getParameter('kernel.root_dir').'/../'.$dynamicBundleDir;
+            }
+
             $dirs[] = $dynamicBundleDir;
         }
 

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ExtRefFieldsCompilerPass.php
@@ -26,20 +26,11 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class ExtRefFieldsCompilerPass implements CompilerPassInterface
 {
+
     /**
      * @var DocumentMap
      */
     private $documentMap;
-
-    /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
 
     /**
      * Make extref fields map and set it to parameter
@@ -49,6 +40,8 @@ class ExtRefFieldsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
 
         $services = array_keys($container->findTaggedServiceIds('graviton.rest'));

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ReadOnlyFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/ReadOnlyFieldsCompilerPass.php
@@ -22,16 +22,6 @@ class ReadOnlyFieldsCompilerPass implements CompilerPassInterface
     private $documentMap;
 
     /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
-
-    /**
      * Make readOnly fields map and set it to parameter
      *
      * @param ContainerBuilder $container container builder
@@ -40,6 +30,8 @@ class ReadOnlyFieldsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
         foreach ($this->documentMap->getDocuments() as $document) {
             $readOnlyFields = $this->documentMap->getFieldNamesFlat(

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RecordOriginExceptionFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RecordOriginExceptionFieldsCompilerPass.php
@@ -22,16 +22,6 @@ class RecordOriginExceptionFieldsCompilerPass implements CompilerPassInterface
     private $documentMap;
 
     /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
-
-    /**
      * Make recordOriginException fields map and set it to parameter
      *
      * @param ContainerBuilder $container container builder
@@ -40,6 +30,8 @@ class RecordOriginExceptionFieldsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
         foreach ($this->documentMap->getDocuments() as $document) {
             $recordOriginExceptionFields = $this->documentMap->getFieldNamesFlat(

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RqlFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/RqlFieldsCompilerPass.php
@@ -23,16 +23,6 @@ class RqlFieldsCompilerPass implements CompilerPassInterface
     private $documentMap;
 
     /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
-
-    /**
      * Make extref fields map and set it to parameter
      *
      * @param ContainerBuilder $container container builder
@@ -40,6 +30,8 @@ class RqlFieldsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
 
         $services = array_keys($container->findTaggedServiceIds('graviton.rest'));

--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/TranslatableFieldsCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/TranslatableFieldsCompilerPass.php
@@ -28,16 +28,6 @@ class TranslatableFieldsCompilerPass implements CompilerPassInterface
     private $documentMap;
 
     /**
-     * Constructor
-     *
-     * @param DocumentMap $documentMap Document map
-     */
-    public function __construct(DocumentMap $documentMap)
-    {
-        $this->documentMap = $documentMap;
-    }
-
-    /**
      * Make translatable fields map and set it to parameter
      *
      * @param ContainerBuilder $container container builder
@@ -45,6 +35,8 @@ class TranslatableFieldsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $this->documentMap = $container->get('graviton.document.map');
+
         $map = [];
         foreach ($this->documentMap->getDocuments() as $document) {
             $map[$document->getClass()] = $this->getTranslatableFields($document);

--- a/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
+++ b/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
@@ -72,7 +72,7 @@ class GravitonDocumentBundle extends Bundle implements GravitonBundleInterface
         $container->addCompilerPass(
             new DocumentMapCompilerPass(),
             PassConfig::TYPE_BEFORE_OPTIMIZATION,
-            10
+            100
         );
         $container->addCompilerPass(
             new ExtRefMappingCompilerPass(),

--- a/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
+++ b/src/Graviton/DocumentBundle/GravitonDocumentBundle.php
@@ -5,10 +5,10 @@
 
 namespace Graviton\DocumentBundle;
 
+use Graviton\DocumentBundle\DependencyInjection\Compiler\DocumentMapCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\ReadOnlyFieldsCompilerPass;
 use Graviton\DocumentBundle\DependencyInjection\Compiler\RecordOriginExceptionFieldsCompilerPass;
-use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\DocumentMap;
-use Symfony\Component\Finder\Finder;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Graviton\BundleBundle\GravitonBundleInterface;
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
@@ -69,45 +69,46 @@ class GravitonDocumentBundle extends Bundle implements GravitonBundleInterface
     {
         parent::build($container);
 
-        // If it's inside vendor library or running as graviton base.
-        $rootDir = $container->getParameter('kernel.root_dir');
-        if (strpos($rootDir, 'vendor/graviton')) {
-            $dirs = [
-                $rootDir.'/../..'
-            ];
-        } else {
-            $dirs = [
-                __DIR__ . '/../..',
-                $rootDir.'/../vendor/graviton'
-            ];
-        }
-
-        $documentMap = new DocumentMap(
-            (new Finder())
-                ->in($dirs)
-                ->path('Resources/config/doctrine')
-                ->name('*.mongodb.xml'),
-            (new Finder())
-                ->in($dirs)
-                ->path('Resources/config/serializer')
-                ->name('*.xml'),
-            (new Finder())
-                ->in($dirs)
-                ->path('Resources/config')
-                ->name('validation.xml'),
-            (new Finder())
-                ->in($dirs)
-                ->path('Resources/config/schema')
-                ->name('*.json')
+        $container->addCompilerPass(
+            new DocumentMapCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            10
         );
-
-        $container->addCompilerPass(new ExtRefMappingCompilerPass());
-        $container->addCompilerPass(new ExtRefFieldsCompilerPass($documentMap));
-        $container->addCompilerPass(new RqlFieldsCompilerPass($documentMap));
-        $container->addCompilerPass(new TranslatableFieldsCompilerPass($documentMap));
-        $container->addCompilerPass(new DocumentFieldNamesCompilerPass($documentMap));
-        $container->addCompilerPass(new ReadOnlyFieldsCompilerPass($documentMap));
-        $container->addCompilerPass(new RecordOriginExceptionFieldsCompilerPass($documentMap));
+        $container->addCompilerPass(
+            new ExtRefMappingCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new ExtRefFieldsCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new RqlFieldsCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new TranslatableFieldsCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new DocumentFieldNamesCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new ReadOnlyFieldsCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
+        $container->addCompilerPass(
+            new RecordOriginExceptionFieldsCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            5
+        );
     }
 
     /**

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFieldNamesCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/DocumentFieldNamesCompilerPassTest.php
@@ -23,9 +23,29 @@ class DocumentFieldNamesCompilerPassTest extends \PHPUnit_Framework_TestCase
     {
         $baseNamespace = 'Graviton\DocumentBundle\Tests\DependencyInjection\CompilerPass\Resources\Document';
 
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/form')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/form')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/validation/form')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/schema')
+                ->name('*.json')
+        );
+
         $containerDouble = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
             ->disableOriginalConstructor()
             ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('graviton.document.map'))
+            ->willReturn($documentMap);
         $containerDouble
             ->expects($this->once())
             ->method('setParameter')
@@ -57,22 +77,7 @@ class DocumentFieldNamesCompilerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $documentMap = new DocumentMap(
-            (new Finder())
-                ->in(__DIR__.'/Resources/doctrine/form')
-                ->name('*.mongodb.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/serializer/form')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/validation/form')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/schema')
-                ->name('*.json')
-        );
-
-        $compilerPass = new DocumentFieldNamesCompilerPass($documentMap);
+        $compilerPass = new DocumentFieldNamesCompilerPass();
         $compilerPass->process($containerDouble);
     }
 }

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/ExtRefFieldsCompilerPassTest.php
@@ -32,10 +32,30 @@ class ExtRefFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->with('graviton.rest')
             ->willReturn([]);
 
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/extref')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/validation/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/schema')
+                ->name('*.json')
+        );
+
         $containerDouble = $this
             ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')
             ->disableOriginalConstructor()
             ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('graviton.document.map'))
+            ->willReturn($documentMap);
         $containerDouble
             ->expects($this->once())
             ->method('findTaggedServiceIds')
@@ -77,22 +97,7 @@ class ExtRefFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $documentMap = new DocumentMap(
-            (new Finder())
-                ->in(__DIR__.'/Resources/doctrine/extref')
-                ->name('*.mongodb.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/serializer/extref')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/validation/extref')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/schema')
-                ->name('*.json')
-        );
-
-        $compilerPass = new ExtRefFieldsCompilerPass($documentMap);
+        $compilerPass = new ExtRefFieldsCompilerPass();
         $compilerPass->process($containerDouble);
     }
 }

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/RqlFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/RqlFieldsCompilerPassTest.php
@@ -67,10 +67,30 @@ class RqlFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->with('graviton.rest')
             ->willReturn([]);
 
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/extref')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/validation/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/schema')
+                ->name('*.json')
+        );
+
         $containerDouble = $this
             ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')
             ->disableOriginalConstructor()
             ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('graviton.document.map'))
+            ->willReturn($documentMap);
         $containerDouble
             ->expects($this->once())
             ->method('findTaggedServiceIds')
@@ -92,22 +112,7 @@ class RqlFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $documentMap = new DocumentMap(
-            (new Finder())
-                ->in(__DIR__.'/Resources/doctrine/extref')
-                ->name('*.mongodb.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/serializer/extref')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/validation/extref')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/schema')
-                ->name('*.json')
-        );
-
-        $compilerPass = new RqlFieldsCompilerPass($documentMap);
+        $compilerPass = new RqlFieldsCompilerPass();
         $compilerPass->process($containerDouble);
     }
 }

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/TranslatableFieldsCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/TranslatableFieldsCompilerPassTest.php
@@ -21,10 +21,30 @@ class TranslatableFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess()
     {
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/translatable')
+                ->name('*.mongodb.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/translatable')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/validation/translatable')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/schema')
+                ->name('*.json')
+        );
+
         $containerDouble = $this
             ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')
             ->disableOriginalConstructor()
             ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('graviton.document.map'))
+            ->willReturn($documentMap);
 
         $containerDouble
             ->expects($this->once())
@@ -52,22 +72,7 @@ class TranslatableFieldsCompilerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $documentMap = new DocumentMap(
-            (new Finder())
-                ->in(__DIR__.'/Resources/doctrine/translatable')
-                ->name('*.mongodb.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/serializer/translatable')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/validation/translatable')
-                ->name('*.xml'),
-            (new Finder())
-                ->in(__DIR__.'/Resources/schema')
-                ->name('*.json')
-        );
-
-        $compilerPass = new TranslatableFieldsCompilerPass($documentMap);
+        $compilerPass = new TranslatableFieldsCompilerPass();
         $compilerPass->process($containerDouble);
     }
 }

--- a/src/Graviton/DocumentBundle/Tests/Service/ExtReferenceConverterTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/ExtReferenceConverterTest.php
@@ -57,8 +57,13 @@ class ExtReferenceConverterTest extends \PHPUnit_Framework_TestCase
                     '_format' => '~'
                 ],
                 [
-                    '_method' => 'GET',
                     'id' => '[a-zA-Z0-9\-_\/]+',
+                ],
+                [],
+                '',
+                [],
+                [
+                    'GET'
                 ]
             ),
             new Route(
@@ -67,8 +72,12 @@ class ExtReferenceConverterTest extends \PHPUnit_Framework_TestCase
                     '_controller' => 'graviton.core.controller.app.appAction',
                     '_format' => '~'
                 ],
+                [],
+                [],
+                '',
+                [],
                 [
-                    '_method' => 'GET',
+                    'GET'
                 ]
             ),
             new Route(
@@ -78,8 +87,13 @@ class ExtReferenceConverterTest extends \PHPUnit_Framework_TestCase
                     '_format' => '~'
                 ],
                 [
-                    '_method' => 'GET',
                     'id' => '[a-zA-Z0-9\-_\/]+',
+                ],
+                [],
+                '',
+                [],
+                [
+                    'GET'
                 ]
             ),
             new Route(
@@ -89,8 +103,13 @@ class ExtReferenceConverterTest extends \PHPUnit_Framework_TestCase
                     '_format' => '~'
                 ],
                 [
-                    '_method' => 'GET',
                     'id' => '[a-zA-Z0-9\-_\/]+',
+                ],
+                [],
+                '',
+                [],
+                [
+                    'GET'
                 ]
             ),
         ];

--- a/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
+++ b/src/Graviton/GeneratorBundle/Command/GenerateDynamicBundleCommand.php
@@ -395,7 +395,7 @@ class GenerateDynamicBundleCommand extends Command
         $resourceFinder->in($templateDir)->files()->sortByName();
         $templateTimes = '';
         foreach ($resourceFinder as $file) {
-            $templateTimes .= PATH_SEPARATOR . $file->getMTime();
+            $templateTimes .= PATH_SEPARATOR . sha1_file($file->getPathname());
         }
         return sha1($templateTimes);
     }

--- a/src/Graviton/GeneratorBundle/DependencyInjection/Compiler/GeneratorHashCompilerPass.php
+++ b/src/Graviton/GeneratorBundle/DependencyInjection/Compiler/GeneratorHashCompilerPass.php
@@ -29,32 +29,36 @@ class GeneratorHashCompilerPass implements CompilerPassInterface
         // first type of hash: the genhash'es of all GravitonDyn bundles
         $dir = $container->getParameter('graviton.generator.dynamicbundle.dir');
 
-        $finder = (new Finder())
-            ->in($dir)
-            ->files()
-            ->sortByName()
-            ->name('genhash');
-
         $dynHash = '';
-        foreach ($finder as $file) {
-            $dynHash .= DIRECTORY_SEPARATOR . $file->getContents();
+        if (is_dir($dir)) {
+            $finder = (new Finder())
+                ->in($dir)
+                ->files()
+                ->sortByName()
+                ->name('genhash');
+
+            foreach ($finder as $file) {
+                $dynHash .= DIRECTORY_SEPARATOR . $file->getContents();
+            }
         }
 
         // 2nd hash: configuration of our own graviton things (static stuff)
-        $finder = (new Finder())
-            ->in(__DIR__.'/../../../')
-            ->path('/serializer/')
-            ->path('/doctrine/')
-            ->path('/schema/')
-            ->notPath('/Tests/')
-            ->files()
-            ->sortByName()
-            ->name('*.xml')
-            ->name('*.json');
-
         $staticHash = '';
-        foreach ($finder as $file) {
-            $staticHash .= DIRECTORY_SEPARATOR . sha1_file($file->getPathname());
+        if (is_dir(__DIR__.'/../../../')) {
+            $finder = (new Finder())
+                ->in(__DIR__ . '/../../../')
+                ->path('/serializer/')
+                ->path('/doctrine/')
+                ->path('/schema/')
+                ->notPath('/Tests/')
+                ->files()
+                ->sortByName()
+                ->name('*.xml')
+                ->name('*.json');
+
+            foreach ($finder as $file) {
+                $staticHash .= DIRECTORY_SEPARATOR . sha1_file($file->getPathname());
+            }
         }
 
         $dynHash = sha1($dynHash);

--- a/src/Graviton/GeneratorBundle/DependencyInjection/Compiler/GeneratorHashCompilerPass.php
+++ b/src/Graviton/GeneratorBundle/DependencyInjection/Compiler/GeneratorHashCompilerPass.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * a compilerpass that computes a single hash of the current generated bundles
+ */
+
+namespace Graviton\GeneratorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class GeneratorHashCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * generate the hashes
+     *
+     * @param ContainerBuilder $container container builder
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // first type of hash: the genhash'es of all GravitonDyn bundles
+        $dir = $container->getParameter('graviton.generator.dynamicbundle.dir');
+
+        $finder = (new Finder())
+            ->in($dir)
+            ->files()
+            ->sortByName()
+            ->name('genhash');
+
+        $dynHash = '';
+        foreach ($finder as $file) {
+            $dynHash .= DIRECTORY_SEPARATOR . $file->getContents();
+        }
+
+        // 2nd hash: configuration of our own graviton things (static stuff)
+        $finder = (new Finder())
+            ->in(__DIR__.'/../../../')
+            ->path('/serializer/')
+            ->path('/doctrine/')
+            ->path('/schema/')
+            ->notPath('/Tests/')
+            ->files()
+            ->sortByName()
+            ->name('*.xml')
+            ->name('*.json');
+
+        $staticHash = '';
+        foreach ($finder as $file) {
+            $staticHash .= DIRECTORY_SEPARATOR . sha1_file($file->getPathname());
+        }
+
+        $dynHash = sha1($dynHash);
+        $staticHash = sha1($staticHash);
+        $allHash = sha1($dynHash . DIRECTORY_SEPARATOR . $staticHash);
+
+        $container->setParameter('graviton.generator.hash.dyn', $dynHash);
+        $container->setParameter('graviton.generator.hash.static', $staticHash);
+        $container->setParameter('graviton.generator.hash.all', $allHash);
+    }
+}

--- a/src/Graviton/GeneratorBundle/GravitonGeneratorBundle.php
+++ b/src/Graviton/GeneratorBundle/GravitonGeneratorBundle.php
@@ -6,6 +6,9 @@
 namespace Graviton\GeneratorBundle;
 
 use Graviton\BundleBundle\GravitonBundleInterface;
+use Graviton\GeneratorBundle\DependencyInjection\Compiler\GeneratorHashCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -24,6 +27,24 @@ class GravitonGeneratorBundle extends Bundle implements GravitonBundleInterface
      */
     public function getBundles()
     {
-        return array();
+        return [];
+    }
+
+    /**
+     * load compiler pass
+     *
+     * @param ContainerBuilder $container container builder
+     *
+     * @return void
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(
+            new GeneratorHashCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            50
+        );
     }
 }

--- a/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Command/GenerateBundleCommandTest.php
@@ -39,12 +39,11 @@ class GenerateBundleCommandTest extends BaseTest
      * get command
      *
      * @param \Graviton\GeneratorBundle\Generator\BundleGenerator $generator generator
-     * @param object                                              $input     input mock
      * @param object                                              $container Container
      *
      * @return \Graviton\GeneratorBundle\Command\GenerateBundleCommand
      */
-    protected function getCommand($generator, $input, $container)
+    protected function getCommand($generator, $container)
     {
         $command = $this
             ->getMockBuilder('Graviton\GeneratorBundle\Command\GenerateBundleCommand')
@@ -52,7 +51,7 @@ class GenerateBundleCommandTest extends BaseTest
             ->getMock();
 
         $command->setContainer($container);
-        $command->setHelperSet($this->getHelperSet($input));
+        $command->setHelperSet($this->getHelperSet());
         $command->setGenerator($generator);
 
         return $command;

--- a/src/Graviton/I18nBundle/DependencyInjection/Compiler/ReplaceTranslatorCompilerPass.php
+++ b/src/Graviton/I18nBundle/DependencyInjection/Compiler/ReplaceTranslatorCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * overrides the default translator with ours..
+ */
+
+namespace Graviton\I18nBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class ReplaceTranslatorCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * create mapping from services
+     *
+     * @param ContainerBuilder $container container builder
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $def = $container->findDefinition('translator.default');
+        $def->setClass('Graviton\I18nBundle\Translator\Translator');
+        $container->setDefinition('translator.default', $def);
+    }
+}

--- a/src/Graviton/I18nBundle/GravitonI18nBundle.php
+++ b/src/Graviton/I18nBundle/GravitonI18nBundle.php
@@ -5,6 +5,8 @@
 
 namespace Graviton\I18nBundle;
 
+use Graviton\I18nBundle\DependencyInjection\Compiler\ReplaceTranslatorCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Graviton\BundleBundle\GravitonBundleInterface;
 
@@ -27,5 +29,19 @@ class GravitonI18nBundle extends Bundle implements GravitonBundleInterface
     public function getBundles()
     {
         return array();
+    }
+
+    /**
+     * add our compiler pass
+     *
+     * @param ContainerBuilder $container container
+     *
+     * @return void
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ReplaceTranslatorCompilerPass());
     }
 }

--- a/src/Graviton/I18nBundle/Tests/Controller/ExternalTranslationDomainControllerTest.php
+++ b/src/Graviton/I18nBundle/Tests/Controller/ExternalTranslationDomainControllerTest.php
@@ -42,6 +42,26 @@ class ExternalTranslationDomainControllerTest extends RestTestCase
         );
 
         // make sure we have no resource files for domain 'external'
+        $this->cleanFiles();
+    }
+
+    /**
+     * cleanup actions
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->cleanFiles();
+    }
+
+    /**
+     * clean up our mess
+     *
+     * @return void
+     */
+    private function cleanFiles()
+    {
         $fs = new Filesystem();
         $finder = new Finder();
         $finder

--- a/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
+++ b/src/Graviton/RabbitMqBundle/Listener/EventStatusLinkResponseListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Graviton\SecurityBundle\Service\SecurityUtils;
 use GravitonDyn\EventStatusBundle\Document\EventStatus;
@@ -290,7 +291,7 @@ class EventStatusLinkResponseListener
             [
                 'id' => $eventStatus->getId()
             ],
-            true
+            UrlGeneratorInterface::ABSOLUTE_URL
         );
 
         return $url;

--- a/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
+++ b/src/Graviton/RestBundle/Listener/PagingLinkResponseListener.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * FilterResponseListener for adding a rel=self Link header to a response.
@@ -142,7 +143,8 @@ class PagingLinkResponseListener
 
         $url = $this->getRqlUrl(
             $request,
-            $this->router->generate($routeName, [], true) . '?' . strtr($rql, [',' => '%2C'])
+            $this->router->generate($routeName, [], UrlGeneratorInterface::ABSOLUTE_URL) .
+                '?' . strtr($rql, [',' => '%2C'])
         );
 
         $this->linkHeader->add(new LinkHeaderItem($url, array('rel' => $type)));

--- a/web/app.php
+++ b/web/app.php
@@ -37,9 +37,7 @@ if ($activateDebug) {
     Debug::enable();
 }
 $kernel = new AppKernel($env, $activateDebug);
-
 $kernel->setBundleLoader(new BundleLoader(new GravitonBundleBundle()));
-$kernel->loadClassCache();
 
 if (!$activateDebug) {
     $kernel = new AppCache($kernel);


### PR DESCRIPTION
here we try to update to symfony 3.2 - looks quite good

What this PR changes
* Update all symfony deps to 3.2.* series
* Makes changes where necessary caused by the Symfony update
* Add ability to configure the "GravitonDyn" location via parameters.yml.. if it is not configured, it will behave as before
* swagger.json generation is smarter - it will hash all generated artifacts and decide if it needs to be regenerated or not.