### PR TITLE
higher retry connect for problems under php7.1 with the newest mongodb driver

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -69,7 +69,7 @@ doctrine_mongodb:
             options: { connect: true }
     document_managers:
         default:
-            retry_connect: 3
+            retry_connect: 10
             retry_query: 1
             mappings:
                 GravitonCoreBundle: ~


### PR DESCRIPTION
this seems to largely mitigate the problems we have (again) with disconnecting mongo connections 