### PR TITLE
Feature/base url options id patern

### DIFF
--- a/src/Graviton/CoreBundle/Controller/MainController.php
+++ b/src/Graviton/CoreBundle/Controller/MainController.php
@@ -10,6 +10,7 @@ use Graviton\RestBundle\HttpFoundation\LinkHeader;
 use Graviton\RestBundle\HttpFoundation\LinkHeaderItem;
 use Graviton\RestBundle\Service\RestUtilsInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -282,5 +283,21 @@ class MainController
         }
 
         return [];
+    }
+
+    /**
+     * Return OPTIONS results.
+     *
+     * @param Request $request Current http request
+     *
+     * @return Response $response Result of the action
+     */
+    public function optionsAction(Request $request)
+    {
+        $response = $this->response;
+        $response->setStatusCode(Response::HTTP_NO_CONTENT);
+        $request->attributes->set('corsMethods', 'GET, OPTIONS');
+
+        return $response;
     }
 }

--- a/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ShowcaseControllerTest.php
@@ -278,7 +278,7 @@ class ShowcaseControllerTest extends RestTestCase
             (object) [
                 'propertyPath' => "nestedApps[1].\$ref",
                 'message' =>
-                    'Does not match the regex pattern (\/core\/app\/)([a-zA-Z0-9\-_\/\+\040\'\.]+)$'
+                    'Does not match the regex pattern (\/core\/app\/)([a-zA-Z0-9\-_\+\040\'\.]+)$'
             ]
         ];
 

--- a/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
+++ b/src/Graviton/RestBundle/Routing/Loader/ActionUtils.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Route;
  */
 class ActionUtils
 {
-    const ID_PATTERN = '[a-zA-Z0-9\-_\/\+\040\'\.]+';
+    const ID_PATTERN = '[a-zA-Z0-9\-_\+\040\'\.]+';
 
     /**
      * Get route for GET requests


### PR DESCRIPTION
Some of our services have same base name.
/servicename/{id}
/servicename/persistance/{id}
Sometimes it works out of the box but as this depends on how the router cache is loaded it is very random if it works.

Another issue, doing a OPTIONS request to base route / return a error 500.