### PR TITLE
[WIP] Api Concept to use Json Schema as service rest build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ app/config/parameters_local.xml
 app/files/
 app/config/deploy.yml
 versions.yml
+app/services

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -74,7 +74,9 @@ class AppKernel extends Kernel
             new \Graviton\RqlParserBundle\GravitonRqlParserBundle(),
             new \Oneup\FlysystemBundle\OneupFlysystemBundle(),
             new \Graviton\JsonSchemaBundle\GravitonJsonSchemaBundle(),
-            new \OldSound\RabbitMqBundle\OldSoundRabbitMqBundle()
+            new \OldSound\RabbitMqBundle\OldSoundRabbitMqBundle(),
+            new \Graviton\GeneratorV2Bundle\GravitonGeneratorV2Bundle(),
+            new \Graviton\ApiBundle\GravitonApiBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test', 'oauth_dev'))) {

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,5 +1,7 @@
 # This file is a "template" of what your parameters.yml file should look like
 parameters:
+    graviton.api.generated_service_directory: '%kernel.root_dir%/services'
+
     graviton.mongodb.default.server.db: db
     graviton.mongodb.default.server.uri: ~
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,7 @@
+graviton_api:
+    resource: "@GravitonApiBundle/Resources/config/routing.yml"
+    prefix:   /v2
+
 graviton_rest_routing:
     resource: "@GravitonRestBundle/Resources/config/routing.xml"
     prefix: /

--- a/src/Graviton/ApiBundle/Controller/RestController.php
+++ b/src/Graviton/ApiBundle/Controller/RestController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Graviton\ApiBundle\Controller;
+
+use Graviton\ApiBundle\Service\ApiService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RestController
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var ApiService
+     */
+    protected $apiService;
+
+    public function __construct(ApiService $apiService)
+    {
+        $this->apiService = $apiService;
+    }
+
+
+    public function indexAction()
+    {
+        $response = new JsonResponse();
+        $data = $this->apiService->getRoutes();
+        $response->setData($data);
+
+        return $response;
+    }
+
+
+    public function schemaAction()
+    {
+        $response = new JsonResponse();
+        $data = $this->apiService->getSchema();
+        $response->setData($data);
+
+        return $response;
+    }
+
+
+    public function getAction()
+    {
+        $response = new JsonResponse();
+        $data = $this->apiService->getData();
+        $response->setData($data);
+
+        return $response;
+    }
+
+    public function optionsAction()
+    {
+        $response = new JsonResponse();
+        $response->setData(['something in options']);
+
+        return $response;
+    }
+
+
+    public function putAction()
+    {
+        $response = new JsonResponse();
+        $response->setData(['something in put']);
+
+        return $response;
+    }
+
+
+    public function patchAction()
+    {
+        $response = new JsonResponse();
+        $response->setContent(['something in patch']);
+
+        return $response;
+    }
+}

--- a/src/Graviton/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Graviton/ApiBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Graviton\ApiBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files.
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('graviton_api');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Graviton/ApiBundle/DependencyInjection/GravitonApiExtension.php
+++ b/src/Graviton/ApiBundle/DependencyInjection/GravitonApiExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Graviton\ApiBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ */
+class GravitonApiExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+        //$loader->load('parameters.yml');
+
+        $uri = $container->getParameter('graviton.mongodb.default.server.uri');
+        $dbc = $container->getParameter('graviton.mongodb.default.server.db');
+
+        if ($services = getenv('VCAP_SERVICES')) {
+            $services = json_decode($services, true);
+            $mongo = $services['mongodb'][0]['credentials'];
+            $uri = $mongo['uri'];
+            $dbc = $mongo['database'];
+        }
+
+        $container->setParameter('graviton.api.mongodb.server.uri', $uri);
+        $container->setParameter('graviton.api.mongodb.server.db', $dbc);
+    }
+}

--- a/src/Graviton/ApiBundle/GravitonApiBundle.php
+++ b/src/Graviton/ApiBundle/GravitonApiBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Graviton\ApiBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class GravitonApiBundle extends Bundle
+{
+}

--- a/src/Graviton/ApiBundle/Manager/DatabaseManager.php
+++ b/src/Graviton/ApiBundle/Manager/DatabaseManager.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Graviton\ApiBundle\Manager;
+
+
+class DatabaseManager
+{
+    /** @var string */
+    protected $databseUri;
+
+    /** @var string */
+    protected $databaseName;
+
+    /** @var \MongoClient */
+    protected $dbClient;
+
+    public function __construct(
+        $dbUrl,
+        $dbName
+    ) {
+        $this->databseUri = $dbUrl;
+        $this->databaseName = $dbName;
+    }
+
+    /**
+     * Connect to DB
+     *
+     * @throws \MongoConnectionException
+     * @return \MongoClient
+     */
+    private function getClient()
+    {
+        if (!$this->dbClient) {
+            $this->dbClient = new \MongoClient($this->databseUri, ['connect' => false]);
+            $this->dbClient->connect();
+        }
+        return $this->dbClient;
+    }
+
+    private function find($collection, $filter = [], $sort = [], $limit = 1, $offset = 0)
+    {
+        /** @var \MongoCollection $collection */
+        $collection = $this->getClient()->{$this->databaseName}->{$collection};
+
+        $options = [];//['sort' => ['catid' => 1], 'limit' => 10];
+        /** @var \MongoCursor $cursor */
+        $cursor = $collection->find($filter, $options);
+        return iterator_to_array($cursor, false);
+    }
+
+    public function findOne($collection, $id)
+    {
+        $filter = ['_id' => (string) $id];
+        $data = $this->find($collection, $filter);
+        if ($data) {
+            return $data[0];
+        }
+        return [];
+    }
+
+    public function findAll($collection)
+    {
+        $data = $this->find($collection, [], [], 10);
+        return $data;
+    }
+}

--- a/src/Graviton/ApiBundle/Resources/config/routing.yml
+++ b/src/Graviton/ApiBundle/Resources/config/routing.yml
@@ -1,0 +1,46 @@
+graviton_api_rest_home:
+    path:     /
+    defaults: { _controller: graviton_api.rest_controller:indexAction }
+    methods:  [GET,OPTIONS]
+
+graviton_api_rest_options:
+    path:     /{service}
+    methods:  [OPTIONS]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:getAction }
+
+graviton_api_rest_schema:
+    path:     /schema/{service}/collection
+    methods:  [GET,OPTIONS]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:schemaAction }
+
+graviton_api_rest_get:
+    path:     /{service}
+    methods:  [GET]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:getAction }
+
+graviton_api_rest_post:
+    path:     /{service}
+    methods:  [POST]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:postAction }
+
+graviton_api_rest_put:
+    path:     /{service}
+    methods:  [PUT]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:putAction }
+
+graviton_api_rest_patch:
+    path:     /{service}
+    methods:  [PATCH]
+    requirements:
+        service: .+
+    defaults: { _controller: graviton_api.rest_controller:patchAction }

--- a/src/Graviton/ApiBundle/Resources/config/services.yml
+++ b/src/Graviton/ApiBundle/Resources/config/services.yml
@@ -1,0 +1,36 @@
+services:
+
+    graviton_api.rest_controller:
+        class: Graviton\ApiBundle\Controller\RestController
+        arguments:
+            apiService: "@graviton_api.api_service"
+
+    graviton_api.api_service:
+        class: Graviton\ApiBundle\Service\ApiService
+        arguments:
+            requestStack: "@request_stack"
+            configService: "@graviton.api.config_service"
+            schemaService: "@graviton.api.schema_service"
+            mappingService: "@graviton.api.mapping_service"
+            dbManager: "@graviton.api.database_manager"
+
+    graviton.api.database_manager:
+        class: Graviton\ApiBundle\Manager\DatabaseManager
+        arguments:
+            dbUrl: "%graviton.api.mongodb.server.uri%"
+            dbName: "%graviton.api.mongodb.server.db%"
+
+    graviton.api.schema_service:
+        class: Graviton\ApiBundle\Service\SchemaService
+        arguments:
+            configService: "@graviton.api.config_service"
+
+    graviton.api.mapping_service:
+        class: Graviton\ApiBundle\Service\MappingService
+
+    graviton.api.config_service:
+        class: Graviton\ApiBundle\Service\ConfigService
+        arguments:
+            serviceDir: "%graviton.api.generated_service_directory%"
+            cacheDir: "%kernel.cache_dir%"
+

--- a/src/Graviton/ApiBundle/Service/ApiService.php
+++ b/src/Graviton/ApiBundle/Service/ApiService.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: taachja1
+ * Date: 04.04.17
+ * Time: 09:50
+ */
+
+namespace Graviton\ApiBundle\Service;
+
+
+use Graviton\ApiBundle\Manager\DatabaseManager;
+use Graviton\ExceptionBundle\Exception\NotFoundException;
+use Graviton\JsonSchemaBundle\Validator\InvalidJsonException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ApiService
+{
+    /** @var string Where services are located */
+    protected $dirService;
+
+    /** @var string Where we will cache definitions trees */
+    protected $dirCache;
+
+    /** @var DatabaseManager */
+    protected $dbManager;
+
+    /** @var SchemaService Schema Definition */
+    private $schemaService;
+
+    /** @var ConfigService Config Definition */
+    private $configService;
+
+    /** @var MappingService Config Definition */
+    private $mappingService;
+
+    /** @var RequestStack */
+    protected $requestStack;
+
+    /** @var string Host and Schema */
+    private $baseUri;
+
+    /** @var string Service Definition */
+    private $requestedService;
+
+    /** @var string Requested class id */
+    private $classId;
+
+    /** @var string Requested collection id */
+    private $collectionId;
+
+
+    public function __construct(
+        RequestStack $requestStack,
+        ConfigService $configService,
+        SchemaService $schemaService,
+        MappingService $mappingService,
+        DatabaseManager $dbManager
+    )
+    {
+        $this->requestStack = $requestStack;
+        $this->schemaService = $schemaService;
+        $this->configService = $configService;
+        $this->mappingService = $mappingService;
+        $this->dbManager = $dbManager;
+        $this->init();
+    }
+
+    /**
+     * Staring the needed params.
+     */
+    private function init()
+    {
+        $request = $this->requestStack->getMasterRequest();
+        $this->baseUri = $request->getSchemeAndHttpHost() . $request->getPathInfo();
+        $this->requestedService = $request->get('service');
+
+        $this->extractServiceRequest();
+    }
+
+    public function getRoutes()
+    {
+        $routes = $this->configService->getJsonFromFile('routes.json');
+
+        // Remove trailing slash
+        $baseUri = rtrim($this->baseUri, '/');
+        $services = [];
+
+        foreach ($routes as $route) {
+            $services[] = [
+                '$ref' => $baseUri . '/' . $route,
+                'profile' => $baseUri . '/schema/' . $route . '/collection'
+            ];
+        }
+
+
+        return ['services' => $services];
+    }
+
+    public function getSchema()
+    {
+        return $this->schemaService->getSchema($this->classId);
+    }
+
+    public function getData()
+    {
+        $schema = $this->getSchema();
+        if ($this->collectionId) {
+            $data = $this->dbManager->findOne($schema->{'x-documentClass'}, $this->collectionId);
+            if (!$data) {
+                throw new NotFoundException('Entry with id not found!');
+            }
+        } else {
+            $data = $this->dbManager->findAll($schema->{'x-documentClass'});
+        }
+        return $this->mappingService->mapData($data, $schema);
+    }
+
+    /**
+     * Will extract and set variables for
+     *
+     * @param string $requestService Requested service call
+     */
+    private function extractServiceRequest()
+    {
+        if (!$this->requestedService) {
+            return;
+        }
+        $requestService = trim($this->requestedService, "/");
+        $routes = $this->configService->getJsonFromFile('routes.json');
+        $matchedRoute = $this->findMatchedService($requestService, $routes);
+
+        $serviceRoute = reset($matchedRoute);
+        $serviceId = (array_keys($matchedRoute));
+
+        if ($id = substr($requestService, strlen($serviceRoute))) {
+            $this->collectionId = trim($id, '/');
+        }
+
+        $this->classId = $serviceId[0];
+    }
+
+    /**
+     * Will return the must accurate requested Service match.
+     * request service may be:
+     * foo
+     * foo/bar
+     * foo/bar/one
+     * for/bar/two
+     * for/{id}
+     * for/bar/{id}
+     * for/bar/one/{id}
+     *
+     * @param $requestService
+     * @param $routes
+     * @return array
+     */
+    private function findMatchedService($requestService, $routes)
+    {
+        $matched = [];
+        $routes = (array) $routes;
+        $match = array_search($requestService, $routes);
+
+        // Fast matching return
+        if ($match && strlen($routes[$match]) === strlen($requestService)) {
+            $matched[$match] = $requestService;
+            return $matched;
+        }
+
+        // When id is given in request
+        foreach ($routes as $serviceId => $route) {
+            if ($this->startsWith($route, $requestService)) {
+                $matched[$serviceId] = $route;
+            } elseif ($this->startsWith($requestService, $route)) {
+                $matched[$serviceId] = $route;
+            }
+        }
+
+        // Some routes have same start, but we do not control definition load
+        if (count($matched) > 1) {
+            $score = [];
+            foreach ($matched as $serviceId => $route) {
+                if (strpos($requestService, $route) !== false) {
+                    $sbResult = substr($requestService, strlen($route));
+                    $score[strlen($sbResult)] = $serviceId;
+                }
+            }
+            if (!empty($score)) {
+                ksort($score);
+                $score = reset($score);
+                $matched = [$score => $matched[$score]];
+            } else {
+                throw new NotFoundException(
+                    sprintf('Sorry, no route matched. Did you mean: %s', implode(', ', $matched))
+                );
+            }
+        }
+
+        // Can happen we match a route that's incomplete
+        $matchedUrl = reset($matched);
+        if (strlen($matchedUrl) > strlen($requestService)) {
+            throw new NotFoundException(
+                sprintf('Sorry, no route matched. Did you mean: %s', $matchedUrl)
+            );
+        }
+
+        if (empty($matched)) {
+            throw new NotFoundException('Service not found with given url');
+        }
+        return $matched;
+    }
+
+    /**
+     * @param $haystack
+     * @param $needle
+     * @return bool
+     */
+    private function startsWith($haystack, $needle)
+    {
+        $length = strlen($needle);
+        return (substr($haystack, 0, $length) === $needle);
+    }
+
+}

--- a/src/Graviton/ApiBundle/Service/ConfigService.php
+++ b/src/Graviton/ApiBundle/Service/ConfigService.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: taachja1
+ * Date: 04.04.17
+ * Time: 09:50
+ */
+namespace Graviton\ApiBundle\Service;
+
+use Graviton\JsonSchemaBundle\Validator\InvalidJsonException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class ConfigService
+ * To provide a unique entry for Configuration data and caching
+ *
+ * @package Graviton\ApiBundle\Service
+ */
+class ConfigService
+{
+    /** @var string Where services are located */
+    protected $dirService;
+
+    /**
+     * TODO Build save to cache for schema trees and so.
+     * @var string Where we will cache definitions trees */
+    protected $dirCache;
+
+    public function __construct(
+        $serviceDir,
+        $cacheDir
+    ) {
+        $this->dirService = $serviceDir;
+        if (strpos($this->dirService, 'vendor/graviton/graviton') ) {
+            $this->dirService = str_replace('vendor/graviton/graviton/', '', $this->dirService);
+        }
+        $this->dirCache = $cacheDir;
+    }
+
+    public function getJsonFromFile($fileName)
+    {
+        $string = file_get_contents($this->dirService . DIRECTORY_SEPARATOR . $fileName);
+        if (!$string) {
+            throw new ServiceNotFoundException('Service not found');
+        }
+        $json = json_decode($string);
+        if (json_last_error()) {
+            throw new InvalidJsonException('Service error, '.json_last_error_msg());
+        }
+        return $json;
+    }
+
+}

--- a/src/Graviton/ApiBundle/Service/MappingService.php
+++ b/src/Graviton/ApiBundle/Service/MappingService.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: taachja1
+ * Date: 04.04.17
+ * Time: 09:50
+ */
+namespace Graviton\ApiBundle\Service;
+
+
+use Graviton\ApiBundle\Manager\DatabaseManager;
+use Graviton\ExceptionBundle\Exception\NotFoundException;
+use Graviton\JsonSchemaBundle\Validator\InvalidJsonException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MappingService
+{
+    /**
+     * Meant to map the Service data with the output
+     * TODO move this to a real mapper class
+     * @param $data
+     * @param $schema
+     * @return array
+     */
+    public function mapData($data, $schema)
+    {
+        if (empty($data)) {
+            return $data;
+        }
+        if (array_key_exists('_id', $data)) {
+            return $this->fieldMapper($data);
+        } else {
+            foreach ($data as &$item) {
+                $item = $this->fieldMapper($item);
+            }
+        }
+        return $data;
+    }
+    private function fieldMapper($data)
+    {
+        // Use some how $this->schema to map output
+        $rtn = [];
+        foreach ($data as $field => $value) {
+            if ('_id' == $field) {
+                $rtn['id'] = $value;
+            } else {
+                $rtn[$field] = $value;
+            }
+        }
+
+        return $rtn;
+    }
+}

--- a/src/Graviton/ApiBundle/Service/SchemaService.php
+++ b/src/Graviton/ApiBundle/Service/SchemaService.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: taachja1
+ * Date: 04.04.17
+ * Time: 09:50
+ */
+namespace Graviton\ApiBundle\Service;
+
+
+use Graviton\ApiBundle\Manager\DatabaseManager;
+use Graviton\ExceptionBundle\Exception\NotFoundException;
+use Graviton\JsonSchemaBundle\Validator\InvalidJsonException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SchemaService
+{
+    /** @var ConfigService */
+    protected $configService;
+
+    public function __construct(
+        $configService
+    ) {
+        $this->configService = $configService;
+    }
+
+    /**
+     * Should return the full schema tree from cached location, build and save.
+     *
+     * @param $classId
+     * @return mixed
+     */
+    public function getSchema($classId)
+    {
+        $mainSchema = $this->configService->getJsonFromFile('schema/' . $classId .'.json');
+            // we should load several levels ...
+        return $mainSchema;
+    }
+
+    /**
+     * Should build a full schema tree
+     * @param $classId
+     */
+    private function buildSchemaTree($classId)
+    {
+
+    }
+
+}

--- a/src/Graviton/ApiBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Graviton/ApiBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Graviton\ApiBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/');
+
+        $this->assertContains('Hello World', $client->getResponse()->getContent());
+    }
+}

--- a/src/Graviton/ExceptionBundle/Exception/NotFoundException.php
+++ b/src/Graviton/ExceptionBundle/Exception/NotFoundException.php
@@ -27,6 +27,6 @@ final class NotFoundException extends NotFoundHttpException implements RestExcep
      */
     public function __construct($message = "Not Found", $prev = null)
     {
-        parent::__construct($message, $prev);
+        parent::__construct($message, $prev, 404);
     }
 }

--- a/src/Graviton/GeneratorV2Bundle/Command/GenerateCommand.php
+++ b/src/Graviton/GeneratorV2Bundle/Command/GenerateCommand.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * cleans dynamic bundle directory
+ */
+
+namespace Graviton\GeneratorV2Bundle\Command;
+
+use Graviton\GeneratorBundle\Definition\JsonDefinition;
+use Graviton\GeneratorBundle\Definition\Loader\Loader;
+use Graviton\GeneratorBundle\Definition\Schema\Definition;
+use Graviton\GeneratorBundle\Generator\ResourceGenerator\FieldMapper;
+use Graviton\GeneratorV2Bundle\Service\SchemaMapper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * php -d memory_limit=-1 vendor/graviton/graviton/app/console graviton:generate-v2:service-files
+ *
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class GenerateCommand extends Command
+{
+
+    /* @var \Graviton\AppKernel */
+    private $kernel;
+
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var FieldMapper */
+    private $mapper;
+
+    /** @var Loader */
+    private $loader;
+
+    /** @var OutputInterface */
+    private $output;
+
+    /** @var string */
+    private $contextMode;
+
+    /** @var string */
+    private $destinationDir;
+
+    /** @var Definition */
+    private $currentDefinition;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('graviton:generate-v2:service-files')
+            ->setDescription(
+                'Will create the requires services definition files and routing'
+            );
+    }
+
+    /**
+     * set kernel
+     *
+     * @param mixed $kernel kernel
+     *
+     * @return void
+     */
+    public function setKernel($kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * set filesystem
+     *
+     * @param mixed $filesystem filesystem
+     *
+     * @return void
+     */
+    public function setFilesystem($filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param InputInterface $input input
+     * @param OutputInterface $output output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->output->writeln('<info>');
+        $this->output->writeln('Welcome to Service Generator v2.');
+        $this->output->writeln('Hold on for a second while we fetch the definition files.');
+        $this->output->writeln('</info>');
+
+        /** @var Application $application */
+        $application = $this->getApplication();
+        /** @var ContainerInterface $container */
+        $container = $application->getKernel()->getContainer();
+
+        $this->loader = $container->get('graviton_generator.definition.loader');
+        $this->mapper = $container->get('graviton_generator.resourcegenerator.field_mapper');
+
+        // Get the base dir of the project to know if it's installed as vendor or stand alone app.
+        $this->destinationDir = $container->getParameter('graviton.api.generated_service_directory');
+        $this->contextMode = strpos($this->destinationDir, 'vendor/graviton/graviton') ? 'WRAPPER' : 'CORE';
+        if ('WRAPPER' == $this->contextMode) {
+            $this->destinationDir = str_replace('vendor/graviton/graviton/', '', $this->destinationDir);
+        }
+
+        $this->output->writeln(sprintf('Starting generation in %s context mode.', $this->contextMode));
+
+        $this->generateServices($container->getParameter('kernel.root_dir'));
+
+        $this->output->writeln('<info>');
+        $this->output->writeln('Thanks you for using the service.');
+        $this->output->writeln('Generated files are located in: ' . $this->destinationDir);
+        $this->output->writeln('</info>');
+
+    }
+
+    /**
+     * @param $rootDir
+     */
+    private function generateServices($rootDir)
+    {
+        $this->output->writeln('<info>Generating folder structure for services.</info>');
+        $fileSystem = new Filesystem();
+        if ($fileSystem->exists($this->destinationDir)) {
+            $this->output->writeln('<comment> - > Removing old services.</comment>');
+            $fileSystem->remove($this->destinationDir);
+        }
+        $fileSystem->mkdir($this->destinationDir);
+        $fileSystem->mkdir($this->destinationDir . '/definition/');
+        $fileSystem->mkdir($this->destinationDir . '/schema/');
+
+        // Let get all definition files
+        if ('CORE' == $this->contextMode) {
+            $rootDir = realpath( $rootDir . '/../');
+            $directories = [
+                $rootDir . '/src/Graviton',
+                $rootDir . '/vendor/libgraviton'
+            ];
+        } else {
+            $rootDir = realpath($rootDir . '/../../../../vendor/');
+            $directories = [
+                $rootDir . '/graviton',
+                $rootDir . '/grv',
+            ];
+        }
+        $this->output->writeln('<info>Scanning for services in.</info>');
+        foreach ($directories as $dir) {
+            $this->output->writeln('<comment> - > '. $dir . '</comment>');
+        }
+
+        $finder = new Finder();
+        $finder->files()->in($directories)
+            ->name('*.json')
+            ->notName('_*')
+            ->path('/(^|\/)resources\/definition($|\/)/i');
+        if ('WRAPPER' == $this->contextMode) {
+            $finder->notPath('/(^|\/)Tests($|\/)/i');
+        }
+
+        $routes = [];
+
+        $progress = new ProgressBar($this->output, $finder->count());
+
+        foreach ($finder as $file) {
+            $progress->advance();
+            $path = $file->getRealPath();
+
+            $json = json_decode($file->getContents());
+            if (!$json || json_last_error()) {
+                throw new InvalidConfigurationException('Failure: ' . $path . ': ' . json_last_error_msg());
+            } elseif (!property_exists($json, 'id')) {
+                throw new InvalidConfigurationException('Failure: ' . $path . ': id field is required');
+            }
+
+            // Routes
+            if (property_exists($json, 'service' ) && property_exists($json->service, 'routerBase' )) {
+                $routes[$json->id] = trim( $json->service->routerBase, "/" );
+            }
+
+            // Copy definition
+            if (property_exists($json, 'service') && property_exists($json->service, 'fixtures')) {
+                unset($json->service->fixtures);
+            }
+            $fileSystem->dumpFile($this->destinationDir . '/definition/' . $file->getFilename(), json_encode($json, JSON_PRETTY_PRINT));
+
+            // Generate Schema
+            $schema = $this->generateSchema($file);
+            $fileSystem->dumpFile($this->destinationDir . '/schema/' . $file->getFilename(), $schema);
+        }
+
+        // Save routing
+        $fileSystem->dumpFile($this->destinationDir . '/routes.json', json_encode($routes, JSON_PRETTY_PRINT));
+
+    }
+
+
+    /**
+     * @param SplFileInfo $file
+     * @return string
+     */
+    private function generateSchema($file)
+    {
+        $path = $file->getRealPath();
+
+        /** @var JsonDefinition[] $definition */
+        $definition = $this->loader->load($path);
+        if (!array_key_exists(0, $definition) || !($definition[0] instanceof JsonDefinition)) {
+            throw new InvalidConfigurationException('Failure: ' . $path . ': Incorrect JsonDefinition load.');
+        }
+
+        $this->currentDefinition = $definition[0];
+
+        $mp = new SchemaMapper();
+        $schema = $mp->convert($definition[0]);
+
+        return json_encode($schema, JSON_PRETTY_PRINT);
+    }
+}

--- a/src/Graviton/GeneratorV2Bundle/DependencyInjection/Configuration.php
+++ b/src/Graviton/GeneratorV2Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Graviton\GeneratorV2Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files.
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('graviton_generator_v2');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Graviton/GeneratorV2Bundle/DependencyInjection/GravitonGeneratorV2Extension.php
+++ b/src/Graviton/GeneratorV2Bundle/DependencyInjection/GravitonGeneratorV2Extension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Graviton\GeneratorV2Bundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ */
+class GravitonGeneratorV2Extension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/Graviton/GeneratorV2Bundle/GravitonGeneratorV2Bundle.php
+++ b/src/Graviton/GeneratorV2Bundle/GravitonGeneratorV2Bundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Graviton\GeneratorV2Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class GravitonGeneratorV2Bundle extends Bundle
+{
+}

--- a/src/Graviton/GeneratorV2Bundle/Resources/config/services.yml
+++ b/src/Graviton/GeneratorV2Bundle/Resources/config/services.yml
@@ -1,0 +1,4 @@
+services:
+#    graviton_generator_v2.example:
+#        class: Graviton\GeneratorV2Bundle\Example
+#        arguments: ["@service_id", "plain_value", "%parameter%"]

--- a/src/Graviton/GeneratorV2Bundle/Service/SchemaMapper.php
+++ b/src/Graviton/GeneratorV2Bundle/Service/SchemaMapper.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: taachja1
+ * Date: 03.04.17
+ * Time: 11:15
+ */
+
+namespace Graviton\GeneratorV2Bundle\Service;
+
+
+use Graviton\GeneratorBundle\Definition\JsonDefinition;
+use Graviton\GeneratorBundle\Definition\JsonDefinitionField;
+use Graviton\GeneratorBundle\Definition\Schema\XDynamicKey;
+
+class SchemaMapper
+{
+
+
+    public function convert(JsonDefinition $definition)
+    {
+        $schema = [
+            "x-documentClass" => $definition->getId()
+        ];
+
+        if (!$definition->getDef()->getTarget()) {
+           // return $schema;
+        }
+
+        $requiredFields = [];
+        $searchableFields = [];
+        $readOnlyFields = [];
+
+
+        $schema = [
+            "x-documentClass" => $definition->getId(),
+            "title" => $definition->getTitle(),
+            "description" => $definition->getDescription(),
+            "x-recordOriginModifiable" => $definition->isRecordOriginModifiable(),
+            "properties" => []
+        ];
+        if (method_exists($definition, 'isVersionedService')) {
+            $schema["x-versioning"] = $definition->isVersionedService();
+        }
+
+        $exposeFieldNames = array_flip(['title', 'type', 'readOnly', 'description', 'recordOriginException']);
+
+        if (!$definition->getDef()->getTarget()) {
+            return $schema;
+        }
+
+        /** @var JsonDefinitionField $field */
+        foreach ($definition->getFields() as $field) {
+            $def = $field->getDefAsArray();
+            $key = $field->getName();
+            if (isset($def['required']) && $def['required']) {
+                $requiredFields[] = $field->getName();
+            }
+            if (isset($def['searchable']) && $def['searchable']) {
+                $searchableFields[] = $field->getName();
+            }
+            if (isset($def['readOnly']) && $def['readOnly']) {
+                $readOnlyFields[] = $field->getName();
+            }
+
+            $data = array_intersect_key($def,$exposeFieldNames);
+            $schema["properties"][$key] = $data;
+
+            /** @var XDynamicKey $xkex */
+            if (method_exists($field, 'getXDynamicKey') && $xkex = $field->getXDynamicKey()) {
+                $schema["properties"][$key]["x-dynamic-key"] = [
+                    "document-id" => $xkex->getDocumentId(),
+                    "repository-method" => $xkex->getRepositoryMethod(),
+                    "ref-field" => $xkex->getRefField()
+                ];
+            }
+        }
+
+        $schema["required"] = $requiredFields;
+        $schema["searchable"] = $searchableFields;
+        $schema["readOnlyFields"] = $readOnlyFields;
+
+        return $schema;
+
+
+    }
+
+
+    /*
+     *
+
+    {
+
+  "x-documentClass": {{ (base ~ 'Document\\' ~ document) | json_encode() }},
+
+{% if json is defined %}
+  "description": {{ json.getDescription()|json_encode() }},
+{% else %}
+  "description": "@todo replace me",
+{% endif %}
+
+  "x-versioning": {{ isVersioning|json_encode() }},
+
+{% if noIdField is not defined %}
+  "x-id-in-post-allowed": false,
+{% else %}
+  "x-id-in-post-allowed": true,
+{% endif %}
+
+{% if json is defined %}
+    "title": "{{ json.getTitle() }}",
+{% endif %}
+
+  "properties": {
+{% set requiredFields = [] %}
+{% set searchableFields = [] %}
+{% set readOnlyFields = [] %}
+
+{% if idField is defined %}
+      {% if idField.required is defined and idField.required == true %}
+      {% set requiredFields = requiredFields|merge(['id']) %}
+      {% endif %}
+{% endif %}
+
+
+
+{% for field in fields %}
+    "{{ field.fieldName }}": {
+        "title": {{ field.title|json_encode() }},
+
+{% if field.collection is defined and field.type == 'extref' %}
+      "collection": {{ field.collection|json_encode() }},
+{% endif %}
+
+{% if field.readOnly is defined and field.readOnly == true %}
+      "readOnly": {{ field.readOnly|json_encode() }},
+{% endif %}
+
+{% if field.recordOriginException is defined and field.recordOriginException == true %}
+      "recordOriginException": {{ field.recordOriginException|json_encode() }},
+{% endif %}
+
+{% if field.xDynamicKey is defined and field.xDynamicKey != null %}
+      "x-dynamic-key": {
+          "document-id": "{{ field.xDynamicKey.documentId }}",
+          "repository-method": "{{ field.xDynamicKey.repositoryMethod }}",
+          "ref-field": "{{ field.xDynamicKey.refField }}"
+      },
+{% endif %}
+
+{% if field.constraints is defined and field.constraints != null %}
+      "x-constraints": {{ field.constraints|json_encode() }},
+{% endif %}
+
+{% if field.description is defined and field.description != '' %}
+      "description": {{ field.description|json_encode() }}
+{% else %}
+      "description": "@todo replace me"
+{% endif %}
+
+{% if field.required is defined and field.required == true %}
+    {% set requiredFields = requiredFields|merge([field.fieldName]) %}
+{% endif %}
+
+{% if field.searchable is defined and field.searchable > 0 %}
+    {% set searchableFields = searchableFields|merge([field.fieldName]) %}
+{% endif %}
+
+{% if field.readOnly is defined and field.readOnly == true %}
+    {% set readOnlyFields = readOnlyFields|merge([field.fieldName]) %}
+{% endif %}
+
+    },
+{% endfor %}
+
+
+
+    "id": {
+      "title": "ID",
+      "description": "Unique identifier"
+{% if isrecordOriginFlagSet %}
+    },
+    "recordOrigin": {
+      "title": "record origin",
+      "description": "A small string like 'core' to determine the record origin. Documents from some sources must not be modified. The 'core' value is defined as readonly by default."
+{% endif %}
+    }
+  },
+
+{#
+the whole recordOrigin thing is kinda messed up as you need 2 vars to correctly detect what should be done.
+for schema, we condense it so recordOriginModifiable holds the whole truth in one..
+ #}
+{% if (recordOriginModifiable is defined and recordOriginModifiable == "false") and
+  (isrecordOriginFlagSet is defined and isrecordOriginFlagSet == true) %}
+  "recordOriginModifiable": false,
+{% else %}
+  "recordOriginModifiable": true,
+{% endif %}
+  "required": {{ requiredFields|json_encode() }},
+  "searchable": {{ searchableFields|json_encode() }},
+  "readOnlyFields": {{ readOnlyFields|json_encode() }}
+}
+
+
+     *
+     *
+     *
+     *
+     */
+}

--- a/src/Graviton/GeneratorV2Bundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Graviton/GeneratorV2Bundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Graviton\GeneratorV2Bundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/');
+
+        $this->assertContains('Hello World', $client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
## PoC

This is a Proof of Concept, another way of running an Api based on Json definition and schema. 
- Schema files will be used to render and validate api request. SchemaForms
- No more Dynamic bundles

The code done in this first commit is just to have a demo available. 
- ApiBundle, /v2/ api is plain db output of the stored mongoDB data, yet no mapping.
- GeneratorV2Bbundle, will create "schema" files using the first generator implementation. But it is incomplete. 

How to try it:
- composer install, stop the post script where it generate the Dynamic bundles. if it starts. 
- php app/console graviton:generate-v2:service-files
- if no server, use sf build-in server: php app/console server:start 0.0.0.0:8000
- go to your browser and type: https://localhost:8000/v2 

There is no data fixtures, you should have from previous installation. Otherwise /schema files will be all good ( as mentioned before, the schema is not complete ).  

There is still a lot to do, just "concepting". Aiming for Hexagonal development. Optional Doctrine usage for DB querying making it DB independent. Possible Jms/Serialiser for output handling. 