### PR TITLE
File hash should not allow longer than 64 chars string, hash 256

### DIFF
--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -225,8 +225,10 @@ class FileManager
 
         // File related, if no file uploaded we keep original file info.
         if ($file) {
-            $hash = $metadata->getHash() ? substr($metadata->getHash(), 0, 64) :
-                hash('sha256', file_get_contents($file->getRealPath()));
+            $hash = $metadata->getHash();
+            if (!$hash || strlen($hash)>64) {
+                $hash = hash('sha256', file_get_contents($file->getRealPath()));
+            }
             $metadata->setHash($hash);
             $metadata->setMime($file->getMimeType());
             $metadata->setSize($file->getSize());

--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -225,7 +225,7 @@ class FileManager
 
         // File related, if no file uploaded we keep original file info.
         if ($file) {
-            $hash = $metadata->getHash() ? $metadata->getHash() :
+            $hash = $metadata->getHash() ? substr($metadata->getHash(), 0, 64) :
                 hash('sha256', file_get_contents($file->getRealPath()));
             $metadata->setHash($hash);
             $metadata->setMime($file->getMimeType());

--- a/src/Graviton/FileBundle/Manager/FileManager.php
+++ b/src/Graviton/FileBundle/Manager/FileManager.php
@@ -228,6 +228,8 @@ class FileManager
             $hash = $metadata->getHash();
             if (!$hash || strlen($hash)>64) {
                 $hash = hash('sha256', file_get_contents($file->getRealPath()));
+            } else {
+                $hash = preg_replace('/[^a-z0-9_-]/i', '-', $hash);
             }
             $metadata->setHash($hash);
             $metadata->setMime($file->getMimeType());

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -576,8 +576,10 @@ class FileControllerTest extends RestTestCase
         $file = sys_get_temp_dir() . '/test.txt';
         $uploadedFile = new UploadedFile($file, 'test.txt', 'text/plain', 15);
 
-        // Max 64 length, should not contain the extra bits
-        $correctHash = hash('sha256', 'somestring');
+        $fixtureData = file_get_contents(__DIR__.'/fixtures/test.txt');
+        $correctHash = hash('sha256', $fixtureData);
+
+        // Max 64 length, should not contain the extra bitsasd
         $toLongHashExtra = $correctHash . '-some-extra-bits ';
 
         $jsonData = '{

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -508,7 +508,7 @@ class FileControllerTest extends RestTestCase
             }
           ],
           "metadata": {
-            "hash": "demo-test-hash",
+            "hash": "fix,Not,allowEd,%&ç*2$a-here-demo-test-hash",
             "action":[{"command":"print"},{"command":"archive"}],
             "additionalInformation": "someInfo",
             "additionalProperties": [
@@ -555,7 +555,7 @@ class FileControllerTest extends RestTestCase
         );
         $this->assertCount(2, $returnData['metadata']['additionalProperties']);
         $this->assertEquals($metaData['metadata']['filename'], $returnData['metadata']['filename']);
-        $this->assertEquals($metaData['metadata']['hash'], $returnData['metadata']['hash']);
+        $this->assertEquals('fix-Not-allowEd------2-a-here-demo-test-hash', $returnData['metadata']['hash']);
 
         // clean up
         $client = $this->createClient();

--- a/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
+++ b/src/Graviton/FileBundle/Tests/Controller/FileControllerTest.php
@@ -565,8 +565,72 @@ class FileControllerTest extends RestTestCase
         );
     }
 
+    /**
+     * test behavior when data sent was multipart/form-data
+     *
+     * @return void
+     */
+    public function testPutNewFileViaFormHashToLong()
+    {
+        copy(__DIR__ . '/fixtures/test.txt', sys_get_temp_dir() . '/test.txt');
+        $file = sys_get_temp_dir() . '/test.txt';
+        $uploadedFile = new UploadedFile($file, 'test.txt', 'text/plain', 15);
+
+        // Max 64 length, should not contain the extra bits
+        $correctHash = hash('sha256', 'somestring');
+        $toLongHashExtra = $correctHash . '-some-extra-bits ';
+
+        $jsonData = '{
+          "id": "myPersonalFile2",
+          "metadata": {
+            "hash": "'.$toLongHashExtra.'",
+            "action":[{"command":"archive"}],
+            "filename": "customFileName"
+          }
+        }';
+
+        $client = static::createRestClient();
+        $client->put(
+            '/file/myPersonalFile2',
+            [],
+            [
+                'metadata' => $jsonData,
+            ],
+            [
+                'upload' => $uploadedFile,
+            ],
+            [],
+            false
+        );
+
+        $response = $client->getResponse();
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertNotContains('location', $response->headers->all());
+
+        $response = $this->updateFileContent('myPersonalFile2', "This is a new text!!!");
+
+        $metaData = json_decode($jsonData, true);
+        $returnData = json_decode($response->getContent(), true);
+
+        $this->assertEquals($metaData['metadata']['filename'], $returnData['metadata']['filename']);
+
+        // Should NOT be equal as hash was to long and was chopped.
+        $this->assertNotEquals($metaData['metadata']['hash'], $returnData['metadata']['hash']);
+        // But it should be equal to to first part of the hash
+        $this->assertEquals($correctHash, $returnData['metadata']['hash']);
+
+        // clean up
+        $client = $this->createClient();
+        $client->request(
+            'DELETE',
+            '/file/myPersonalFile2'
+        );
+    }
 
 
+
+    /**
     /**
      * test behavior when data sent was multipart/form-data
      *


### PR DESCRIPTION
Some clients when reading longer than 64 char hash strings they failed. So we do now limit this silently. 
EVO-10275