### PR TITLE
MongoDB 3.4 have slightly different index requirements versus 3.2

### DIFF
--- a/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
+++ b/src/Graviton/GeneratorBundle/Resources/skeleton/document/Document.mongodb.xml.twig
@@ -88,10 +88,9 @@
     {# TODO This is a fix for a missing feature in XMLDriver that can not build wieght indexes, redo this when so. #}
     {# TODO The command that build the indexes is : GenerateBuildIndexes: graviton:generate:build-indexes. #}
     {% if textIndexes is defined and textIndexes is not empty %}
-            <index>
-                <key name="search{{ document }}Index"/>
+            <index background="true" name="search_{{ document }}_index">
                 {% for index, value in textIndexes %}
-                    <option name="search{{ index }}" value="{{ value }}"/>
+                    <key name="search_{{ index }}-{{ value }}"/>
                 {% endfor %}
             </index>
     {% endif %}

--- a/src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php
+++ b/src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php
@@ -57,6 +57,6 @@ class GenerateBuildIndexesCommandTest extends GravitonTestCase
             ->getDocumentCollection("GravitonDyn\ModuleBundle\Document\Module")
             ->getIndexInfo();
 
-        $this->assertEquals('searchModuleIndex', $indexInfo[1]['name']);
+        $this->assertEquals('searchModuleindex', $indexInfo[1]['name']);
     }
 }

--- a/src/Graviton/RestBundle/Model/DocumentModel.php
+++ b/src/Graviton/RestBundle/Model/DocumentModel.php
@@ -303,7 +303,7 @@ class DocumentModel extends SchemaModel implements ModelInterface
      * @param string $prefix the prefix for custom text search indexes
      * @return bool
      */
-    private function hasCustomSearchIndex($prefix = 'search')
+    private function hasCustomSearchIndex($prefix = 'search_')
     {
         $metadata = $this->repository->getClassMetadata();
         $indexes = $metadata->getIndexes();
@@ -311,10 +311,13 @@ class DocumentModel extends SchemaModel implements ModelInterface
             return false;
         }
         $collectionsName = substr($metadata->getName(), strrpos($metadata->getName(), '\\') + 1);
-        $searchIndexName = $prefix.$collectionsName.'Index';
+        $searchIndexName = $prefix.$collectionsName.'_index';
         // We reverse as normally the search index is the last.
         foreach (array_reverse($indexes) as $index) {
-            if (array_key_exists('keys', $index) && array_key_exists($searchIndexName, $index['keys'])) {
+            if (array_key_exists('options', $index) &&
+                array_key_exists('name', $index['options']) &&
+                $searchIndexName == $index['options']['name']
+            ) {
                 return true;
             }
         }


### PR DESCRIPTION
We use this approach in order to create a temporary index so that the weighted index can be created later via: graviton:generate:build-indexes
