### PR TITLE
Set CoreConfig service fields to un-required.

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Config.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Config.json
@@ -39,9 +39,7 @@
     },
     "target": {
         "indexes": [
-          "key",
-          "default",
-          "value"    
+            "key"
         ],
         "relations": [],
         "fields": [
@@ -57,7 +55,7 @@
                 "type": "varchar",
                 "title": "Key",
                 "description": "A fixed string identifying this configuration value.",
-                "required": true
+                "required": false
             },
             {
                 "name": "app.ref",
@@ -73,7 +71,7 @@
                 "type": "varchar",
                 "title": "Default",
                 "description": "Default value of configuration value.",
-                "required": true
+                "required": false
             },
             {
                 "name": "value",


### PR DESCRIPTION
As part of a clean up in EVO-7820 we remove some fields from the service.
As fields with empty values are not displayed we just set those to not required and update initial data. 
We keep KEY index if field should be used for group query to make it back-compatible 