### PR TITLE
Elements of a Empty free object if empty should not be returned.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,6 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+    "hash": "23ba61dc490aebdd2b256e560a7061c8",
     "content-hash": "c6253c33048104f74202ac8b26bae836",
     "packages": [
         {
@@ -4254,20 +4255,20 @@
                 }
             ],
             "description": "low level deploy helpers",
-            "time": "2016-08-16T11:37:23+00:00"
+            "time": "2016-08-16 11:37:23"
         },
         {
             "name": "graviton/test-services-bundle",
-            "version": "v0.26.0",
+            "version": "v0.26.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git",
-                "reference": "7e216a46e3784954097abdc8f7b9bbc0a440c3ea"
+                "reference": "9a5fba212f5c5c76e8687e233e224f4e102aedd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/7e216a46e3784954097abdc8f7b9bbc0a440c3ea",
-                "reference": "7e216a46e3784954097abdc8f7b9bbc0a440c3ea",
+                "url": "https://api.github.com/repos/libgraviton/GravitonTestServicesBundle/zipball/9a5fba212f5c5c76e8687e233e224f4e102aedd2",
+                "reference": "9a5fba212f5c5c76e8687e233e224f4e102aedd2",
                 "shasum": ""
             },
             "type": "library",
@@ -4287,7 +4288,7 @@
                 }
             ],
             "description": "Graviton service bundle containing some service definitions useful for testing.",
-            "time": "2017-02-28T12:20:54+00:00"
+            "time": "2017-05-02T06:47:25+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
@@ -130,6 +130,11 @@ class PrimitiveArrayControllerTest extends RestTestCase
                     'datearray' => ['2015-09-30T23:59:59+0000', '2015-10-01T00:00:01+0300'],
                 ]
             ],
+
+            'rawData'      => (object) [
+                'hasharray' => [(object) ['x' => 'y'], (object) []],
+                'emptyhash' => (object) []
+            ],
         ];
 
         $client = static::createRestClient();
@@ -146,6 +151,8 @@ class PrimitiveArrayControllerTest extends RestTestCase
         $result = $client->getResults();
         $this->assertNotNull($result->id);
         unset($result->id);
+        unset($data->rawData->hasharray[1]);
+        unset($data->rawData->emptyhash);
         $this->assertEquals($this->fixDateTimezone($data), $result);
     }
 

--- a/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
@@ -189,6 +189,8 @@ class PrimitiveArrayControllerTest extends RestTestCase
                     'datearray' => ['2015-09-30T23:59:59+0000', '2015-10-01T00:00:01+0300'],
                 ]
             ],
+
+            'rawData'      => (object) [],
         ];
 
         $client = static::createRestClient();

--- a/src/Graviton/DocumentBundle/Entity/Hash.php
+++ b/src/Graviton/DocumentBundle/Entity/Hash.php
@@ -21,6 +21,25 @@ class Hash extends \ArrayObject implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        return (object) $this->getArrayCopy();
+        return (object) $this->arrayFilterRecursive($this->getArrayCopy());
+    }
+
+    /**
+     * Clean up, remove empty positions of second level and above
+     *
+     * @param array $input to be cleaned up
+     * @return array
+     */
+    private function arrayFilterRecursive($input)
+    {
+        if (empty($input)) {
+            return [];
+        }
+        foreach ($input as &$value) {
+            if (is_array($value) || is_object($value)) {
+                $value = $this->arrayFilterRecursive($value);
+            }
+        }
+        return array_filter($input);
     }
 }

--- a/src/Graviton/DocumentBundle/Serializer/Handler/HashHandler.php
+++ b/src/Graviton/DocumentBundle/Serializer/Handler/HashHandler.php
@@ -26,7 +26,7 @@ class HashHandler
      * @param Hash                     $data    Data
      * @param array                    $type    Type
      * @param Context                  $context Context
-     * @return array
+     * @return Hash
      */
     public function serializeHashToJson(
         JsonSerializationVisitor $visitor,
@@ -34,7 +34,7 @@ class HashHandler
         array $type,
         Context $context
     ) {
-        return $data;
+        return new Hash($data);
     }
 
     /**


### PR DESCRIPTION
We have in a few places fields that are allowed to store any kind of object data. 
If we accept a {} as empty this should then be returned as {}, but the serielizer will render this element as [] causing an error. Therefor we clean up the empty elements.