### PR TITLE
Revert "Set CoreConfig service fields to un-required."

### DIFF
--- a/src/Graviton/CoreBundle/Resources/definition/Config.json
+++ b/src/Graviton/CoreBundle/Resources/definition/Config.json
@@ -39,7 +39,9 @@
     },
     "target": {
         "indexes": [
-            "key"
+          "key",
+          "default",
+          "value"    
         ],
         "relations": [],
         "fields": [
@@ -55,7 +57,7 @@
                 "type": "varchar",
                 "title": "Key",
                 "description": "A fixed string identifying this configuration value.",
-                "required": false
+                "required": true
             },
             {
                 "name": "app.ref",
@@ -71,7 +73,7 @@
                 "type": "varchar",
                 "title": "Default",
                 "description": "Default value of configuration value.",
-                "required": false
+                "required": true
             },
             {
                 "name": "value",


### PR DESCRIPTION
This reverts commit 9a1d85a91fc258b10aa5d78a9e4b4d65d27fce6c.