### PR TITLE
Feature/evo 7836 schema hide embedded ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - mongodb-org-server
 before_script:
 - free -m
-- ulimit -c unlimited -S
 - >
     if [ "$PHPUNIT_SUITE" != "integration" ]; then
         export MONGODB_URI=mongodb://does.not.exist.example.org:443
@@ -23,6 +22,7 @@ before_script:
 - >
     if [ $(phpenv version-name) = "5.6" ]; then
         echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+        echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
     fi
 - >
     if [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - mongodb-org-server
 before_script:
 - free -m
+- ulimit -c unlimited -S
 - >
     if [ "$PHPUNIT_SUITE" != "integration" ]; then
         export MONGODB_URI=mongodb://does.not.exist.example.org:443

--- a/src/Graviton/GeneratorBundle/Generator/DynamicBundleBundleGenerator.php
+++ b/src/Graviton/GeneratorBundle/Generator/DynamicBundleBundleGenerator.php
@@ -65,10 +65,18 @@ class DynamicBundleBundleGenerator extends AbstractGenerator
             $absoluteList = array_merge($absoluteList, $this->additions);
         }
 
+        // Sort bundle names, done here to include the additional
+        $bundleList = [];
+        foreach ($absoluteList as $bundle) {
+            $key = str_replace('\\', '', $bundle);
+            $bundleList[$key] = $bundle;
+        }
+        ksort($bundleList);
+
         $parameters = array(
             'namespace' => str_replace('/', '\\', $bundleBundleNamespace),
             'bundleName' => $bundleName,
-            'bundleClassList' => $absoluteList
+            'bundleClassList' => $bundleList
         );
 
         $this->renderFile('bundle/DynamicBundleBundle.php.twig', $targetFilename, $parameters);

--- a/src/Graviton/SchemaBundle/Document/Schema.php
+++ b/src/Graviton/SchemaBundle/Document/Schema.php
@@ -620,8 +620,8 @@ class Schema
      */
     public function removeProperty($name)
     {
-        if (!$this->properties->containsKey($name)) {
-            $this->properties->remove($this->properties->get($name));
+        if ($this->properties->containsKey($name)) {
+            $this->properties->remove($name);
         }
     }
 


### PR DESCRIPTION
This is part of clean-up process for cleaner response.
Schema response update.

Embedded object do not need the ID field unless it's required by definition. 
Our /schema/ {route} /collection was returning ID field due to serialised object Schema class so we do now hide this but allow it still in validation if post/put ( Back-compatibility needed yet due to some Admins/Clients are still sending this value )

Added KEY sort bundle names to have same output in GravitonDyn load bundles array.
