### PR TITLE
Set indexes for Event Status api

### DIFF
--- a/src/Graviton/RabbitMqBundle/Resources/definition/EventStatus.json
+++ b/src/Graviton/RabbitMqBundle/Resources/definition/EventStatus.json
@@ -6,7 +6,10 @@
     "routerBase": "/event/status/"
   },
   "target": {
-    "indexes": [],
+    "indexes": [
+      "createDate",
+      "eventName"
+    ],
     "relations": [],
     "fields": [
       {


### PR DESCRIPTION
Due to pooling status updates via admin we need to index the minimal fields to speed up response.