### PR TITLE
Feature/evo 10954 false not serialised

### DIFF
--- a/src/Graviton/DocumentBundle/Entity/Hash.php
+++ b/src/Graviton/DocumentBundle/Entity/Hash.php
@@ -48,7 +48,8 @@ class Hash extends \ArrayObject implements \JsonSerializable
      * @param mixed $var object field value
      * @return bool
      */
-    private function cleanUpArray($var) {
+    private function cleanUpArray($var)
+    {
         if ($var !== false) {
             return !empty($var);
         }

--- a/src/Graviton/DocumentBundle/Entity/Hash.php
+++ b/src/Graviton/DocumentBundle/Entity/Hash.php
@@ -50,9 +50,15 @@ class Hash extends \ArrayObject implements \JsonSerializable
      */
     private function cleanUpArray($var)
     {
-        if ($var !== false) {
-            return !empty($var);
+        $empty = empty($var);
+        if ($empty && (
+                is_int($var) ||
+                is_bool($var) ||
+                is_float($var) ||
+                is_integer($var))
+        ) {
+            return true;
         }
-        return true;
+        return !$empty;
     }
 }

--- a/src/Graviton/DocumentBundle/Entity/Hash.php
+++ b/src/Graviton/DocumentBundle/Entity/Hash.php
@@ -40,6 +40,18 @@ class Hash extends \ArrayObject implements \JsonSerializable
                 $value = $this->arrayFilterRecursive($value);
             }
         }
-        return array_filter($input);
+        return array_filter($input, [$this, 'cleanUpArray']);
+    }
+
+    /**
+     * Remove NULL values or Empty array object
+     * @param mixed $var object field value
+     * @return bool
+     */
+    private function cleanUpArray($var) {
+        if ($var !== false) {
+            return !empty($var);
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Our HASH class was removing empty key that had empty values, like false. 
It should only remove EMPTY arrays, objects, and so. but not 0, false