### PR TITLE
EVO-10759: fix sq routing

### DIFF
--- a/src/Graviton/ProxyBundle/Resources/config/routing.yml
+++ b/src/Graviton/ProxyBundle/Resources/config/routing.yml
@@ -2,12 +2,12 @@ graviton.proxy.static.proxy.canonicalIdSchema:
     path: /schema/3rdparty/{api}/item
     defaults:
         _controller: graviton.proxy.controller.proxy:schemaAction
-        requirement:
-            api: .{1,}
+    requirements:
+        api: '.+'
 
 graviton.proxy.static.proxy.all:
     path: /3rdparty/{api}
     defaults:
         _controller: graviton.proxy.controller.proxy:proxyAction
-        requirements:
-            api: .{1,}
+    requirements:
+        api: '.+'

--- a/src/Graviton/ProxyBundle/Resources/config/services.yml
+++ b/src/Graviton/ProxyBundle/Resources/config/services.yml
@@ -23,7 +23,7 @@ services:
               - "%graviton.proxy.httploader.curloptions%"
 
     graviton.proxy:
-        class: "Proxy\Proxy"
+        class: Proxy\Proxy
         arguments:
             - "@graviton.proxy.adapter.guzzle"
 
@@ -65,7 +65,7 @@ services:
             method: setCache
             arguments:
               - "@=service(parameter('graviton.doctrine.cache.provider.service_id'))"
-              - ProxyBundle<
+              - ProxyBundle
               - 86400
 
     # api loaders -->


### PR DESCRIPTION
there were some errors for the sq routing after the YAML migration, this fixes the SQ routing as well as the 

```
"message": "Attempted to load class \"Proxy roxy\" from the global namespace.\nDid you forget a \"use\" statement?"
```
error