### PR TITLE
In testing environment we use BasicAuth

### DIFF
--- a/src/Graviton/RestBundle/Resources/config/services.yml
+++ b/src/Graviton/RestBundle/Resources/config/services.yml
@@ -257,6 +257,11 @@ services:
             arguments:
               - Pragma
           -
+            #we need to allow this header for basic auth environments -->
+            method: addAllowHeader
+            arguments:
+              - Authorization
+          -
             #static headers -->
             method: addStaticHeader
             arguments:


### PR DESCRIPTION
This header needs to be there to allow PreFlight.
