### PR TITLE
Feature/evo 11246 rql string url parsing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1920029061d1c2d18cfd15a0ca0a6305",
+    "content-hash": "f410b977170077069cb121c6973602c3",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -1480,16 +1480,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "v2.3.1",
+            "version": "dev-feature/EVO-11245-string-rql-url-parsing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "add017f5564af4f28cb0e4f25fc3ad81042d92e5"
+                "reference": "4aeff9c37ef2e07a6f0e7dbca9c03ce59aa603d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/add017f5564af4f28cb0e4f25fc3ad81042d92e5",
-                "reference": "add017f5564af4f28cb0e4f25fc3ad81042d92e5",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/4aeff9c37ef2e07a6f0e7dbca9c03ce59aa603d2",
+                "reference": "4aeff9c37ef2e07a6f0e7dbca9c03ce59aa603d2",
                 "shasum": ""
             },
             "require": {
@@ -1533,7 +1533,7 @@
                 "rest",
                 "rql"
             ],
-            "time": "2017-05-22T07:49:00+00:00"
+            "time": "2017-08-09 10:48:09"
         },
         {
             "name": "graviton/rql-parser-bundle",
@@ -5997,9 +5997,17 @@
             "time": "2016-11-23T20:04:58+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.3.2-alpha",
+            "alias_normalized": "2.3.2.0-alpha",
+            "version": "dev-feature/EVO-11245-string-rql-url-parsing",
+            "package": "graviton/php-rql-parser"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "graviton/php-rql-parser": 20,
         "lapistano/proxy-object": 20
     },
     "prefer-stable": true,

--- a/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -94,4 +94,22 @@ class ConfigControllerTest extends RestTestCase
             rawurlencode($value)
         );
     }
+    /**
+     * ensure we have nice parse error output in rql parse failure
+     *
+     * @return void
+     */
+    public function testRqlSyntaxForUrlError()
+    {
+        $client = static::createRestClient();
+
+        $client->request('GET', '/core/config/?eq(app.$ref,string:http://localhost:8000/core/app/admin)');
+
+        $response = $client->getResponse();
+        $results = $client->getResults();
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEquals(2, count($results));
+    }
 }


### PR DESCRIPTION
Sometimes we need to be able to search or do RQL's with urls. String should be possible.
like:
/core/config/?eq(app.$ref,string:http://localhost:8000/core/app/admin)

Original pr: https://github.com/libgraviton/php-rql-parser/pull/66