### PR TITLE
Feature/evo 11673 return empty string

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,9 +20,9 @@
       <file>src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyServiceTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/JsonExceptionListerTest.php</file>
-      <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</file>
       <file>src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php</file>
       <file>src/Graviton/AnalyticsBundle/Tests/Model/AnalyticModelTest.php</file>
+      <exclude>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</exclude>
     </testsuite>
     <testsuite name="unit">
       <directory>src/*/*Bundle/Tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,9 +20,9 @@
       <file>src/Graviton/CoreBundle/Tests/Services/CoreVersionUtilsTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyServiceTest.php</file>
       <file>src/Graviton/CoreBundle/Tests/Services/JsonExceptionListerTest.php</file>
+      <file>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</file>
       <file>src/Graviton/GeneratorBundle/Tests/Command/GenerateBuildIndexesCommandTest.php</file>
       <file>src/Graviton/AnalyticsBundle/Tests/Model/AnalyticModelTest.php</file>
-      <exclude>src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php</exclude>
     </testsuite>
     <testsuite name="unit">
       <directory>src/*/*Bundle/Tests</directory>

--- a/src/Graviton/CoreBundle/Listener/JsonExceptionListener.php
+++ b/src/Graviton/CoreBundle/Listener/JsonExceptionListener.php
@@ -83,7 +83,8 @@ class JsonExceptionListener
             strpos($exception->getMessage(), 'Cannot serialize content class') !== false
         ) {
             $error = $exception->getMessage();
-            $message = substr($error, 0, strpos($error, 'not be found.')).'not be found.';
+            $message =  strpos($error, 'not be found.') !== false ?
+                substr($error, 0, strpos($error, 'not be found.')).'not be found.' : $error;
             preg_match('/\bwith id: (.*);.*?\bdocument\\\(.*)".*?\bidentifier "(.*)"/is', $message, $matches);
             if (array_key_exists(3, $matches)) {
                 $sentence = 'Internal Database reference error as been discovered. '.

--- a/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
+++ b/src/Graviton/CoreBundle/Tests/Controller/PrimitiveArrayControllerTest.php
@@ -133,7 +133,8 @@ class PrimitiveArrayControllerTest extends RestTestCase
 
             'rawData'      => (object) [
                 'hasharray' => [(object) ['x' => 'y'], (object) []],
-                'emptyhash' => (object) []
+                'emptyhash' => (object) [],
+                'emptystring' => ""
             ],
         ];
 

--- a/src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php
+++ b/src/Graviton/CoreBundle/Tests/Services/ReadOnlyFieldTest.php
@@ -53,7 +53,8 @@ class ReadOnlyFieldTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->put('/testcase/readonlyfield/101', $data);
-        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), $response->getContent());
 
         $this->assertEquals(
             $client->getResults(),
@@ -90,7 +91,8 @@ class ReadOnlyFieldTest extends RestTestCase
 
         $client = static::createRestClient();
         $client->put('/testcase/readonlyfield/101', $data);
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
     }
 
     /**
@@ -106,13 +108,15 @@ class ReadOnlyFieldTest extends RestTestCase
         $data->allowed = 'can be edited';
 
         $client->put('/testcase/readonlyfield/101_2', $data);
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
 
         // But should be able to add it, as it was never there.
         $data->denied = 'can not be edited';
 
         $client->put('/testcase/readonlyfield/101_2', $data);
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
 
         $client->request('GET', '/testcase/readonlyfield/101_2');
         $savedData = $client->getResults();

--- a/src/Graviton/DocumentBundle/Entity/Hash.php
+++ b/src/Graviton/DocumentBundle/Entity/Hash.php
@@ -55,7 +55,8 @@ class Hash extends \ArrayObject implements \JsonSerializable
                 is_int($var) ||
                 is_bool($var) ||
                 is_float($var) ||
-                is_integer($var))
+                is_integer($var) ||
+                is_string($var))
         ) {
             return true;
         }

--- a/src/Graviton/RabbitMqBundle/Tests/Controller/EventStatusControllerTest.php
+++ b/src/Graviton/RabbitMqBundle/Tests/Controller/EventStatusControllerTest.php
@@ -200,7 +200,7 @@ class EventStatusControllerTest extends RestTestCase
         $client = static::createRestClient();
         $client->put('/event/worker/' . $worker->id, $worker);
         $response = $client->getResponse();
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
 
         $testApp = new \stdClass();
         $testApp->id = "test-event-app";
@@ -216,7 +216,7 @@ class EventStatusControllerTest extends RestTestCase
 
         $client->put('/core/app/' . $testApp->id, $testApp);
         $response = $client->getResponse();
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
 
         /** @var Dummy $dbProducer */
         $events = $dbProducer->getEventList();
@@ -241,7 +241,7 @@ class EventStatusControllerTest extends RestTestCase
         );
         $client->request('PATCH', '/core/app/' . $testApp->id, [], [], [], $patchObject);
         $response = $client->getResponse();
-        $this->assertEquals(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_MODIFIED, $response->getStatusCode(), $response->getContent());
 
         /** @var Dummy $dbProducer */
         $events = $dbProducer->getEventList();
@@ -251,7 +251,7 @@ class EventStatusControllerTest extends RestTestCase
         $testApp->showInMenuS = false;
         $client->put('/core/app/' . $testApp->id, $testApp);
         $response = $client->getResponse();
-        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), $response->getContent());
 
         /** @var Dummy $dbProducer */
         $events = $dbProducer->getEventList();

--- a/src/Graviton/SecurityBundle/Tests/Authentication/Strategies/SameSubnetStrategyTest.php
+++ b/src/Graviton/SecurityBundle/Tests/Authentication/Strategies/SameSubnetStrategyTest.php
@@ -58,7 +58,7 @@ class SameSubnetStrategyTest extends WebTestCase
             array() //server
         );
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $this->strategy->apply($this->client->getRequest());
     }
 
@@ -97,7 +97,7 @@ class SameSubnetStrategyTest extends WebTestCase
 
         $strategy = new SameSubnetStrategy('10.2.0.2');
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $strategy->apply($this->client->getRequest());
     }
 }


### PR DESCRIPTION
Clients are not able to handle a field not returned if empty string is expected.