### PR TITLE
change solr operators

### DIFF
--- a/src/Graviton/DocumentBundle/DependencyInjection/Compiler/SolrDefinitionCompilerPass.php
+++ b/src/Graviton/DocumentBundle/DependencyInjection/Compiler/SolrDefinitionCompilerPass.php
@@ -53,7 +53,9 @@ class SolrDefinitionCompilerPass implements CompilerPassInterface
     {
         $weights = [];
         foreach ($solrFields as $field) {
-            $weights[] = $field['name'].'^'.$field['weight'];
+            if (is_numeric($field['weight']) && $field['weight'] != 0) {
+                $weights[] = $field['name'].'^'.$field['weight'];
+            }
         }
 
         return implode(' ', $weights);

--- a/src/Graviton/DocumentBundle/Service/SolrQuery.php
+++ b/src/Graviton/DocumentBundle/Service/SolrQuery.php
@@ -91,7 +91,8 @@ class SolrQuery
         'OR',
         '&&',
         '||',
-        '!'
+        '!',
+        '-'
     ];
 
     /**
@@ -217,7 +218,7 @@ class SolrQuery
         }
 
         if ($this->andifyTerms) {
-            $glue = 'AND';
+            $glue = '&&';
         } else {
             $glue = '';
         }
@@ -347,7 +348,7 @@ class SolrQuery
         }
 
         return sprintf(
-            '(%s OR %s%s)',
+            '(%s || %s%s)',
             $term,
             $term,
             $modifier

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/Resources/schema/A.json
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/Resources/schema/A.json
@@ -1,1 +1,31 @@
-{}
+{
+  "x-documentClass": "GravitonTest\\DocumentBundle\\Document\\A",
+  "required": [],
+  "searchable": [],
+  "readOnlyFields": [],
+  "properties": [],
+  "solr": {
+    "fields": [
+      {
+        "name": "fieldA",
+        "type": "text_general",
+        "weight": 1
+      },
+      {
+        "name": "fieldB",
+        "type": "text_general",
+        "weight": 15
+      },
+      {
+        "name": "fieldC",
+        "type": "text_general",
+        "weight": 0
+      },
+      {
+        "name": "fieldD",
+        "type": "text_general",
+        "weight": 0.3
+      }
+    ]
+  }
+}

--- a/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/SolrDefinitionCompilerPassTest.php
+++ b/src/Graviton/DocumentBundle/Tests/DependencyInjection/CompilerPass/SolrDefinitionCompilerPassTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * SolrDefinitionCompilerPassTest class file
+ */
+
+namespace Graviton\DocumentBundle\Tests\DependencyInjection\CompilerPass;
+
+use Graviton\DocumentBundle\DependencyInjection\Compiler\SolrDefinitionCompilerPass;
+use Graviton\DocumentBundle\DependencyInjection\Compiler\Utils\DocumentMap;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/graviton/graphs/contributors>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     http://swisscom.ch
+ */
+class SolrDefinitionCompilerPassTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * test the processing
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $expectedResult = [
+            'GravitonTest\DocumentBundle\Document\A' => 'fieldA^1 fieldB^15 fieldD^0.3'
+        ];
+
+        $documentMap = new DocumentMap(
+            (new Finder())
+                ->in(__DIR__.'/Resources/doctrine/extref')
+                ->name('*.mongodb.yml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/serializer/extref')
+                ->name('*.xml'),
+            (new Finder())
+                ->in(__DIR__.'/Resources/schema')
+                ->name('*.json')
+        );
+
+        $containerDouble = $this
+            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $containerDouble
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('graviton.document.map'))
+            ->willReturn($documentMap);
+
+        $containerDouble
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                'graviton.document.solr.map',
+                $expectedResult
+            );
+
+        $sut = new SolrDefinitionCompilerPass();
+        $sut->process($containerDouble);
+    }
+}

--- a/src/Graviton/DocumentBundle/Tests/Listener/RqlSearchNodeListenerTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Listener/RqlSearchNodeListenerTest.php
@@ -178,7 +178,7 @@ class RqlSearchNodeListenerTest extends \PHPUnit\Framework\TestCase
         $this->solrClientQuery
             ->expects($this->once())
             ->method('setQuery')
-            ->with('(fred OR fred*) AND (test OR test*)');
+            ->with('(fred || fred*) && (test || test*)');
         $this->solrClientQuery
             ->expects($this->once())
             ->method('setStart')

--- a/src/Graviton/DocumentBundle/Tests/Service/SolrQueryTest.php
+++ b/src/Graviton/DocumentBundle/Tests/Service/SolrQueryTest.php
@@ -146,42 +146,42 @@ class SolrQueryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple-search-andified' => [
                 'han ha2',
-                'han AND ha2',
+                'han && ha2',
                 true
             ],
             'simple-search-wildcard' => [
                 'hans',
-                '(hans OR hans*)',
+                '(hans || hans*)',
                 true
             ],
             'simple-search-fuzzy' => [
                 'hanso',
-                '(hanso OR hanso~)',
+                '(hanso || hanso~)',
                 true
             ],
             'forced-wildcard-from-client' => [
                 'hanso*', // this *should* be fuzzy as from config, but client wants wildcard
-                '(hanso OR hanso*)',
+                '(hanso || hanso*)',
                 true
             ],
             'forced-fuzzy-from-client' => [
                 'hans~', // this *should* be fuzzy as from config, but client wants wildcard
-                '(hans OR hans~)',
+                '(hans || hans~)',
                 true
             ],
             'forced-mixed-from-client' => [
                 'hansomat* han~',
-                '(hansomat OR hansomat*) AND (han OR han~)',
+                '(hansomat || hansomat*) && (han || han~)',
                 true
             ],
             'simple-combined-no-andify' => [
                 'han hans hanso',
-                'han (hans OR hans*) (hanso OR hanso~)',
+                'han (hans || hans*) (hanso || hanso~)',
                 false
             ],
             'simple-combined-with-andify' => [
                 'han hans hanso',
-                'han AND (hans OR hans*) AND (hanso OR hanso~)',
+                'han && (hans || hans*) && (hanso || hanso~)',
                 true
             ],
             'alphanumeric-iban' => [
@@ -205,23 +205,33 @@ class SolrQueryTest extends \PHPUnit\Framework\TestCase
                 true
             ],
             'own-operator-2-NOT' => [
-                'peter AND year:>40 AND month:<10 NOT segment:15 NOT segment:90',
-                '(peter OR peter~) AND year:[40 TO *] AND month:[* TO 10] NOT segment:"15" NOT segment:"90"',
+                'peter && year:>40 && month:<10 -segment:15 -segment:90',
+                '(peter || peter~) && year:[40 TO *] && month:[* TO 10] && -segment:"15" && -segment:"90"',
                 true
             ],
             'own-operator-1-NOT' => [
                 'peter NOT segment:15',
-                '(peter OR peter~) NOT segment:"15"',
+                '(peter || peter~) NOT segment:"15"',
                 true
             ],
             'own-operator-1-NOT-BOOL' => [
                 'peter ! segment:15',
-                '(peter OR peter~) ! segment:"15"',
+                '(peter || peter~) ! segment:"15"',
                 true
             ],
-            'own-operator-1-OR-BOOL' => [
+            'own-operator-1-NOT-OP' => [
+                'peter -segment:15',
+                '(peter || peter~) && -segment:"15"',
+                true
+            ],
+            'own-operator-1-||-BOOL' => [
                 'peter || segment:15',
-                '(peter OR peter~) || segment:"15"',
+                '(peter || peter~) || segment:"15"',
+                true
+            ],
+            'own-operator-1-||-BOOL-OP' => [
+                'peter || segment:15 -segment:16',
+                '(peter || peter~) || segment:"15" && -segment:"16"',
                 true
             ]
         ];


### PR DESCRIPTION
there is strange behavior how edismax parses our query sometimes, using AND/NOT keywords as text strings in the generated search